### PR TITLE
Fix lint error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the components related to the OpenTelemetry Ecosystem Explorer, a web application that helps
 users discover and explore the various projects available in the OpenTelemetry ecosystem.
 
-See project proposal [here](https://github.com/open-telemetry/community/blob/main/projects/ecosystem-explorer.md).
+See [project proposal](https://github.com/open-telemetry/community/blob/main/projects/ecosystem-explorer.md).
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,7 +514,6 @@
       "integrity": "sha512-esPk+8Qvx/f0bzI7YelUeZp+jCtFOk3KjZ7s9iBQZ6HlymSXoTtWGiIRZP05/9Oy2ehIoIjenVwndxGtxOIJYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "15.0.0",
         "js-yaml": "4.1.1",


### PR DESCRIPTION
#14 introduced a new rule that wasn't failing before but is now, so this fixes that

`README.md:6:23 error MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]`