### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,4 @@
 # Learn about CODEOWNERS file format:
 # https://help.github.com/en/articles/about-code-owners
 
-* @open-telemetry/ecosystem-explorer-approvers
-* @open-telemetry/docs-approvers
+* @open-telemetry/ecosystem-explorer-approvers @open-telemetry/docs-approvers


### PR DESCRIPTION
Since they are on separate lines it's overwriting the ecosystem-explorer-approvers and only adding docs-approvers by default