### PR TITLE
Group all renovate updates into a single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,12 +6,8 @@
   ],
   "packageRules": [
     {
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
-      "schedule": ["before 8am every weekday"]
-    },
-    {
-      "matchUpdateTypes": ["minor", "major"],
+      "groupName": "all dependencies",
+      "matchUpdateTypes": ["patch", "minor", "major"],
       "schedule": ["before 8am on Monday"]
     }
   ],


### PR DESCRIPTION
Instead of having patches handled differently let's just group them all into a single weekly update for now. We can re-assess down the line when we have more dependencies to worry about with the explorer