### PR TITLE
Start documentation sync module

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'ecosystem-automation/collector-watcher/**'
+      - 'ecosystem-automation/**'
       - 'ecosystem-explorer/**'
       - 'build-and-test.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'ecosystem-automation/collector-watcher/**'
+      - 'ecosystem-automation/**'
       - 'ecosystem-explorer/**'
       - 'build-and-test.yml'
 
 jobs:
-  test-collector-watcher:
+  test-ecosystem-automation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -31,10 +31,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Run tests with coverage
+      - name: Run collector-watcher tests
         run: |
           cd ecosystem-automation/collector-watcher
           uv run pytest tests/ --cov=collector_watcher --cov-report=term-missing --cov-report=json
+
+      - name: Run documentation-sync tests
+        run: |
+          cd ecosystem-automation/documentation-sync
+          uv run pytest tests/ --cov=documentation_sync --cov-report=term-missing --cov-report=json
 
   test-ecosystem-explorer:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,56 +11,28 @@ There are three components in this repository:
 
 ### ecosystem-registry
 
-This will act as our raw data registry of the metadata from various projects. See the
-`collector-metadata` directory in the [collector-watcher](https://github.com/jaydeluca/collector-watcher/tree/main/collector-metadata)
-as a POC/reference.
-
-Scope:
-
-* Stores versioned history of metadata for each project
+This will act as our raw data registry of the metadata from various projects. It is updated nightly by the
+automation tools in ecosystem-automation (`collector-watcher`, `documentation-sync`).
 
 ### ecosystem-automation
 
-This will act as our data pipeline and tools for synchronizing documentation, the v1 registry, and anything else.
-
-See the [collector-watcher](https://github.com/jaydeluca/collector-watcher/tree/main/src/collector_watcher) for the
-POC/reference.
-
-Scope:
-
-* Pipelines and automation that runs on a schedule and collects and aggregates metadata from various projects to
-populate and update the registry
-* Automatically synchronizes documentation and other targets with registry data opentelemetry.io integration
-  * Collector components
-  * Java Agent instrumentations
-  * Java Agent configuration options
+Automation pipelines and tools to populate and maintain the ecosystem-registry, and to synchronize documentation and other
+targets with the registry data.
 
 ### ecosystem-explorer
 
 React/Vite web application for exploring the data. See [instrumentation-explorer](https://github.com/jaydeluca/instrumentation-explorer)
 for a POC/reference.
 
-See the [ecosystem-explorer README](./ecosystem-explorer/README.md) for setup and development instructions.
-
-## Getting Started
-
-Install dependencies and sync the workspace:
-
-```bash
-uv sync
-```
-
-Run the collector-watcher from the root directory:
-
-```bash
-uv run collector-watcher
-```
-
 ## Contributing
 
 This project welcomes contributions from the community.
 
 Please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute to this project.
+
+See the [ecosystem-explorer README](./ecosystem-explorer/README.md) for setup and development instructions.
+
+See the [ecosystem-automation README](./ecosystem-automation/README.md) for setup and development instructions.
 
 ## Maintainers
 

--- a/ecosystem-automation/README.md
+++ b/ecosystem-automation/README.md
@@ -1,0 +1,56 @@
+# Ecosystem Automation
+
+Automation tools for the OpenTelemetry Ecosystem Explorer project.
+
+**Note: This directory is part of a uv workspace. All package management should be done from the repository root using
+`uv` commands.**
+
+## Components
+
+- **collector-watcher**: Collects and aggregates metadata from OpenTelemetry Collector components
+- **documentation-sync**: Synchronizes documentation with the ecosystem registry
+
+## Setup
+
+This project uses [uv](https://github.com/astral-sh/uv) for dependency management.
+
+### Prerequisites
+
+- Python 3.11+
+- uv package manager
+
+Install uv if you don't have it:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### Installation
+
+From the repository root:
+
+```bash
+# Install all dependencies
+uv sync
+
+# Run tests
+uv run pytest
+
+# Run linting
+uv run ruff check .
+uv run ruff format .
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+uv run pytest ecosystem-automation/
+
+# Run tests for a specific package
+uv run pytest ecosystem-automation/collector-watcher/tests/
+uv run pytest ecosystem-automation/documentation-sync/tests/
+
+# Run tests with coverage
+uv run pytest --cov=collector_watcher --cov=documentation_sync
+```

--- a/ecosystem-automation/collector-watcher/README.md
+++ b/ecosystem-automation/collector-watcher/README.md
@@ -39,24 +39,11 @@ uv run collector-watcher
 
 ## Development
 
-From the repository root:
+See the parent [ecosystem-automation README](../README.md) for setup and testing instructions.
+
+### Running Tests
 
 ```bash
-# Install dependencies
-uv sync
-
-# Run tests
-uv run pytest ecosystem-automation/collector-watcher/tests
-
-# Run tests with coverage
+# From repository root
 uv run pytest ecosystem-automation/collector-watcher/tests --cov=collector_watcher
-
-# Run the module
-uv run python -m collector_watcher
-```
-
-## Adding Dependencies
-
-```bash
-uv add --package collector-watcher <package-name>
 ```

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/__init__.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/__init__.py
@@ -1,5 +1,7 @@
 """Collector Watcher - OpenTelemetry Collector component metadata automation."""
 
+import importlib.metadata
+
 from .collector_sync import CollectorSync
 from .component_scanner import ComponentScanner
 from .inventory_manager import InventoryManager
@@ -9,7 +11,7 @@ from .type_defs import DistributionName
 from .version import Version
 from .version_detector import VersionDetector
 
-__version__ = "0.1.0"
+__version__ = importlib.metadata.version("collector-watcher")
 
 __all__ = [
     "CollectorSync",

--- a/ecosystem-automation/documentation-sync/README.md
+++ b/ecosystem-automation/documentation-sync/README.md
@@ -1,0 +1,27 @@
+# Documentation Sync
+
+Automation tool for synchronizing documentation with the OpenTelemetry ecosystem registry.
+
+## Overview
+
+This tool updates documentation files by replacing content between marker comments with generated content from the
+ecosystem registry.
+
+## Usage
+
+From the repository root:
+
+```bash
+uv run documentation-sync
+```
+
+## Development
+
+See the parent [ecosystem-automation README](../README.md) for setup and testing instructions.
+
+### Running Tests
+
+```bash
+# From repository root
+uv run pytest ecosystem-automation/documentation-sync/tests
+```

--- a/ecosystem-automation/documentation-sync/pyproject.toml
+++ b/ecosystem-automation/documentation-sync/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "documentation-sync"
+version = "0.1.0"
+description = "Automation tool for synchronizing documentation with the OpenTelemetry ecosystem registry"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+documentation-sync = "documentation_sync.main:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/documentation_sync"]

--- a/ecosystem-automation/documentation-sync/src/documentation_sync/__init__.py
+++ b/ecosystem-automation/documentation-sync/src/documentation_sync/__init__.py
@@ -1,0 +1,9 @@
+"""Documentation Sync - Automatically update documentation using the registry."""
+
+import importlib.metadata
+
+from .doc_marker_updater import DocMarkerUpdater
+
+__version__ = importlib.metadata.version("documentation-sync")
+
+__all__ = ["DocMarkerUpdater"]

--- a/ecosystem-automation/documentation-sync/src/documentation_sync/doc_marker_updater.py
+++ b/ecosystem-automation/documentation-sync/src/documentation_sync/doc_marker_updater.py
@@ -1,0 +1,119 @@
+"""Update existing documentation files with generated content using markers."""
+
+import re
+from pathlib import Path
+
+
+class DocMarkerUpdater:
+    def __init__(
+        self, marker_prefix: str = "GENERATED", source: str = "open-telemetry/opentelemetry-ecosystem-explorer"
+    ):
+        """
+        Args:
+            marker_prefix: Prefix for marker comments (default: "GENERATED")
+            source: Source identifier for the markers (default: "open-telemetry/opentelemetry-ecosystem-explorer")
+        """
+        self.marker_prefix = marker_prefix
+        self.source = source
+
+    def get_marker_pattern(self, marker_id: str) -> tuple[str, str]:
+        """
+        Get the begin and end marker strings for a given marker ID.
+
+        Args:
+            marker_id: Unique identifier for the marker (e.g., "receiver-table")
+
+        Returns:
+            Tuple of (begin_marker, end_marker)
+        """
+        begin = f"<!-- BEGIN {self.marker_prefix}: {marker_id} SOURCE: {self.source} -->"
+        end = f"<!-- END {self.marker_prefix}: {marker_id} SOURCE: {self.source} -->"
+        return begin, end
+
+    def update_section(self, content: str, marker_id: str, new_content: str) -> tuple[str, bool]:
+        """
+        Update a section of content between markers.
+
+        Args:
+            content: Original markdown content
+            marker_id: Marker identifier
+            new_content: New content to insert between markers
+
+        Returns:
+            Tuple of (updated_content, was_updated)
+            was_updated is False if markers weren't found
+        """
+        begin_marker, end_marker = self.get_marker_pattern(marker_id)
+
+        # Ex: <!-- BEGIN GENERATED: marker-id SOURCE: open-telemetry/opentelemetry-ecosystem-explorer -->
+        begin_pattern = (
+            re.escape(f"<!-- BEGIN {self.marker_prefix}: {marker_id}")
+            + r"(?:\s+SOURCE:\s+[\w\-/.]+)?"
+            + re.escape(" -->")
+        )
+        end_pattern = (
+            re.escape(f"<!-- END {self.marker_prefix}: {marker_id}")
+            + r"(?:\s+SOURCE:\s+[\w\-/.]+)?"
+            + re.escape(" -->")
+        )
+
+        pattern = begin_pattern + r".*?" + end_pattern
+        regex = re.compile(pattern, re.DOTALL)
+
+        if not regex.search(content):
+            return content, False
+
+        replacement = f"{begin_marker}\n{new_content}\n{end_marker}"
+        updated_content = regex.sub(replacement, content)
+
+        return updated_content, True
+
+    def update_multiple_sections(self, content: str, updates: dict[str, str]) -> tuple[str, dict[str, bool]]:
+        """
+        Update multiple sections in content.
+
+        Args:
+            content: Original Markdown content
+            updates: Dictionary mapping marker_id to new_content
+
+        Returns:
+            Tuple of (updated_content, results_dict)
+            results_dict maps marker_id to whether it was updated
+        """
+        results = {}
+        current_content = content
+
+        for marker_id, new_content in updates.items():
+            current_content, was_updated = self.update_section(current_content, marker_id, new_content)
+            results[marker_id] = was_updated
+
+        return current_content, results
+
+    def update_file(self, file_path: Path | str, marker_id: str, new_content: str) -> bool:
+        """
+        Update a file by replacing content between markers.
+
+        Args:
+            file_path: Path to the Markdown file
+            marker_id: Marker identifier
+            new_content: New content to insert
+
+        Returns:
+            True if update was successful, False if markers not found
+
+        Raises:
+            FileNotFoundError: If file doesn't exist
+        """
+        file_path = Path(file_path)
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        original_content = file_path.read_text(encoding="utf-8")
+        updated_content, was_updated = self.update_section(original_content, marker_id, new_content)
+
+        if not was_updated:
+            return False
+
+        file_path.write_text(updated_content, encoding="utf-8")
+        return True

--- a/ecosystem-automation/documentation-sync/tests/test_doc_marker_updater.py
+++ b/ecosystem-automation/documentation-sync/tests/test_doc_marker_updater.py
@@ -1,0 +1,173 @@
+"""Tests for marker based documentation updates."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from documentation_sync.doc_marker_updater import DocMarkerUpdater
+
+
+@pytest.fixture
+def doc_updater():
+    return DocMarkerUpdater()
+
+
+@pytest.fixture
+def sample_content():
+    """Sample markdown content with markers."""
+    return """# Test Page
+
+This is some manual content.
+
+<!-- BEGIN GENERATED: test-section -->
+Old generated content here
+<!-- END GENERATED: test-section -->
+
+More manual content below.
+"""
+
+
+class TestUpdateSection:
+    def test_update_section_basic(self, doc_updater, sample_content):
+        new_content = "New generated content"
+        updated, was_updated = doc_updater.update_section(sample_content, "test-section", new_content)
+
+        assert was_updated
+        assert (
+            "<!-- BEGIN GENERATED: test-section SOURCE: open-telemetry/opentelemetry-ecosystem-explorer -->" in updated
+        )
+        assert "New generated content" in updated
+        assert "Old generated content here" not in updated
+        assert "This is some manual content." in updated
+        assert "More manual content below." in updated
+
+    def test_update_section_already_has_source_metadata(self, doc_updater):
+        """Test updating content that already has SOURCE metadata."""
+        content = """# Test Page
+
+<!-- BEGIN GENERATED: test-section SOURCE: open-telemetry/opentelemetry-ecosystem-explorer -->
+Old content with source
+<!-- END GENERATED: test-section SOURCE: open-telemetry/opentelemetry-ecosystem-explorer -->
+
+More content.
+"""
+        new_content = "New content"
+        updated, was_updated = doc_updater.update_section(content, "test-section", new_content)
+
+        assert was_updated
+        assert (
+            "<!-- BEGIN GENERATED: test-section SOURCE: open-telemetry/opentelemetry-ecosystem-explorer -->" in updated
+        )
+        assert "New content" in updated
+        assert "Old content with source" not in updated
+
+    def test_update_section_markers_not_found(self, doc_updater):
+        content = "# Simple Page\n\nNo markers here."
+        updated, was_updated = doc_updater.update_section(content, "nonexistent", "New content")
+
+        assert not was_updated
+        assert updated == content
+
+    def test_update_section_multiline_content(self, doc_updater, sample_content):
+        new_content = """Line 1
+Line 2
+Line 3"""
+        updated, was_updated = doc_updater.update_section(sample_content, "test-section", new_content)
+
+        assert was_updated
+        assert "Line 1" in updated
+        assert "Line 2" in updated
+        assert "Line 3" in updated
+
+    def test_update_section_preserves_surrounding_content(self, doc_updater):
+        """Test that content around markers is preserved."""
+        content = """Header
+
+<!-- BEGIN GENERATED: section1 -->
+Old content
+<!-- END GENERATED: section1 -->
+
+Middle text
+
+<!-- BEGIN GENERATED: section2 -->
+More old content
+<!-- END GENERATED: section2 -->
+
+Footer"""
+
+        updated, was_updated = doc_updater.update_section(content, "section1", "New content 1")
+
+        assert was_updated
+        assert "Header" in updated
+        assert "New content 1" in updated
+        assert "Middle text" in updated
+        assert "More old content" in updated  # section2 unchanged
+        assert "Footer" in updated
+
+
+class TestUpdateMultipleSections:
+    """Tests for update_multiple_sections method."""
+
+    def test_update_multiple_sections(self, doc_updater):
+        """Test updating multiple sections."""
+        content = """# Page
+
+<!-- BEGIN GENERATED: section1 -->
+Old 1
+<!-- END GENERATED: section1 -->
+
+Text
+
+<!-- BEGIN GENERATED: section2 -->
+Old 2
+<!-- END GENERATED: section2 -->
+"""
+
+        updates = {"section1": "New 1", "section2": "New 2"}
+        updated, results = doc_updater.update_multiple_sections(content, updates)
+
+        assert results["section1"]
+        assert results["section2"]
+        assert "New 1" in updated
+        assert "New 2" in updated
+        assert "Old 1" not in updated
+        assert "Old 2" not in updated
+
+    def test_update_multiple_sections_partial(self, doc_updater):
+        """Test updating multiple sections when some don't exist."""
+        content = """# Page
+
+<!-- BEGIN GENERATED: section1 -->
+Old 1
+<!-- END GENERATED: section1 -->
+"""
+
+        updates = {"section1": "New 1", "section2": "New 2"}
+        updated, results = doc_updater.update_multiple_sections(content, updates)
+
+        assert results["section1"]
+        assert not results["section2"]
+        assert "New 1" in updated
+
+
+class TestUpdateFile:
+    """Tests for update_file method."""
+
+    def test_update_file(self, doc_updater, sample_content):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(sample_content)
+            temp_path = Path(f.name)
+
+        try:
+            success = doc_updater.update_file(temp_path, "test-section", "Updated file content")
+
+            assert success
+            updated_content = temp_path.read_text()
+            assert "Updated file content" in updated_content
+            assert "Old generated content here" not in updated_content
+        finally:
+            temp_path.unlink()
+
+    def test_update_file_not_found(self, doc_updater):
+        with pytest.raises(FileNotFoundError):
+            doc_updater.update_file("/nonexistent/file.md", "test", "content")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 dependencies = [
     "collector-watcher",
+    "documentation-sync",
 ]
 
 [tool.uv.workspace]
@@ -16,6 +17,7 @@ members = [
 
 [tool.uv.sources]
 collector-watcher = { workspace = true }
+documentation-sync = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,11 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [manifest]
 members = [
     "collector-watcher",
+    "documentation-sync",
     "opentelemetry-ecosystem-explorer",
 ]
 
@@ -368,6 +369,24 @@ wheels = [
 ]
 
 [[package]]
+name = "documentation-sync"
+version = "0.1.0"
+source = { editable = "ecosystem-automation/documentation-sync" }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -442,6 +461,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "collector-watcher" },
+    { name = "documentation-sync" },
 ]
 
 [package.dev-dependencies]
@@ -453,7 +473,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "collector-watcher", editable = "ecosystem-automation/collector-watcher" }]
+requires-dist = [
+    { name = "collector-watcher", editable = "ecosystem-automation/collector-watcher" },
+    { name = "documentation-sync", editable = "ecosystem-automation/documentation-sync" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Part of #30 

This mostly just scaffolds the new `documentation-sync` module and adds the first piece of code for the marker replacement (to keep the changeset smallish)

Will follow up with the rest of the functionality in another PR.