### PR TITLE
Fix doc sync action

### DIFF
--- a/.github/workflows/documentation-sync.yml
+++ b/.github/workflows/documentation-sync.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run documentation sync
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          SOURCE_FORK: ${{ secrets.DOCS_REPO_OWNER }}
+          SOURCE_FORK: otelbot
           DESTINATION_REPO: open-telemetry
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bash .github/scripts/sync-documentation.sh


### PR DESCRIPTION
to fix this [error](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/actions/runs/21822296924/job/62958419095):

```
Run bash .github/scripts/sync-documentation.sh
Error: SOURCE_FORK environment variable is required
Error: Process completed with exit code 1.
```