### PR TITLE
Fix doc sync action

### DIFF
--- a/.github/workflows/documentation-sync.yml
+++ b/.github/workflows/documentation-sync.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run documentation sync
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          SOURCE_FORK: otelbot
+          SOURCE_FORK: open-telemetry
           DESTINATION_REPO: open-telemetry
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bash .github/scripts/sync-documentation.sh


### PR DESCRIPTION
i didnt realize we didn't need a fork for otelbot (looking at [this as an example](https://github.com/open-telemetry/opentelemetry.io/pull/9126))


so this will fix 
```
PR Plan:
  • Push branch to:    otelbot/opentelemetry.io
  • Create PR against: open-telemetry/opentelemetry.io
remote: Repository not found.
fatal: repository 'https://github.com/otelbot/opentelemetry.io.git/' not found
```