### PR TITLE
Add otelbot to branch name

### DIFF
--- a/.github/scripts/sync-documentation.sh
+++ b/.github/scripts/sync-documentation.sh
@@ -121,7 +121,7 @@ fi
 echo "Documentation changes detected:"
 echo "$CHANGED_FILES"
 echo ""
-BRANCH_NAME="collector-docs-${VERSION//\./-}"
+BRANCH_NAME="otelbot/collector-docs-${VERSION//\./-}"
 
 echo "Branch: $BRANCH_NAME"
 echo ""


### PR DESCRIPTION
As per [documentation](https://github.com/open-telemetry/community/blob/main/assets.md#otelbot), otelbot PRs need to have `otelbot/` prefix