### PR TITLE
Specify repository for otelbot token generation

### DIFF
--- a/.github/workflows/documentation-sync.yml
+++ b/.github/workflows/documentation-sync.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          owner: open-telemetry
+          repositories: |
+            opentelemetry-ecosystem-explorer
+            opentelemetry.io
 
       - name: Checkout opentelemetry.io
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Another fix. Since we are creating a PR for another repo, we need to specify that

Saw this in the logs:

```
Run actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
  with:
    app-id: 1130599
    private-key: ***
  
    skip-token-revoke: false
    github-api-url: https://api.github.com/
Inputs 'owner' and 'repositories' are not set. Creating token for this repository (open-telemetry/opentelemetry-ecosystem-explorer).
```

which explains

```
remote: Permission to open-telemetry/opentelemetry.io.git denied to otelbot[bot].
fatal: unable to access 'https://github.com/open-telemetry/opentelemetry.io.git/': The requested URL returned error: 403
```