### PR TITLE
Add new collector component exclusion and add backfilling

### DIFF
--- a/ecosystem-automation/collector-watcher/README.md
+++ b/ecosystem-automation/collector-watcher/README.md
@@ -31,11 +31,67 @@ If not set, repositories will be automatically cloned to `tmp_repos/`.
 
 ## Usage
 
+### Normal Sync Mode
+
 From the repository root:
 
 ```bash
 uv run collector-watcher
 ```
+
+This will:
+
+* Process the latest release version for each distribution (if not already tracked)
+* Update the SNAPSHOT version from the main branch
+* Skip versions that already exist in the inventory
+
+### Backfill Mode
+
+Backfill mode allows you to regenerate existing versions in the inventory. This is useful when:
+
+* Scanner logic changes (e.g., new component exclusions)
+* Metadata parsing improvements are made
+* You need to apply updates to historical data
+
+#### Backfill All Versions
+
+Regenerate all existing versions for all distributions:
+
+```bash
+uv run collector-watcher --backfill
+```
+
+#### Backfill Specific Distribution
+
+Regenerate all versions for a single distribution:
+
+```bash
+uv run collector-watcher --backfill --distribution contrib
+```
+
+#### Backfill Specific Versions
+
+Regenerate specific versions for a distribution:
+
+```bash
+uv run collector-watcher --backfill --distribution contrib --versions "0.144.0,0.145.0"
+```
+
+Apply a version list to all distributions:
+
+```bash
+uv run collector-watcher --backfill --versions "0.144.0,0.145.0"
+```
+
+#### Options
+
+* `--backfill` - Enable backfill mode (regenerates existing versions)
+* `--distribution {core,contrib}` - Target a specific distribution
+* `--versions VERSION_LIST` - Comma-separated list of versions (e.g., "0.144.0,0.145.0")
+* `--inventory-dir PATH` - Custom path to inventory directory (default: ecosystem-registry/collector)
+
+**Note:** Backfill mode will delete and regenerate the specified versions. The tool automatically checks out the correct
+git tags for each version.
 
 ## Development
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
@@ -23,6 +23,10 @@ class ComponentScanner:
         "opampcustommessages",  # OpAMP utilities
     ]
 
+    EXCLUDED_COMPONENTS = [
+        "endpointswatcher",  # Utility component for watching endpoints, not a component
+    ]
+
     # Directories that contain nested components (subtypes)
     NESTED_COMPONENT_DIRS = {"encoding", "observer", "storage"}
 
@@ -111,6 +115,9 @@ class ComponentScanner:
             return False
         if path.name.endswith("test") or path.name.endswith("helper"):
             return False
+        for excluded in self.EXCLUDED_COMPONENTS:
+            if path.name == excluded:
+                return False
         return True
 
     def _has_go_code(self, path: Path) -> bool:

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -180,3 +180,20 @@ class InventoryManager:
         """
         version_dir = self.get_version_dir(distribution, version)
         return version_dir.exists()
+
+    def delete_version(self, distribution: DistributionName, version: Version) -> bool:
+        """
+        Delete a specific version directory for a distribution.
+
+        Args:
+            distribution: Distribution name
+            version: Version to delete
+
+        Returns:
+            True if version was deleted, False if it didn't exist
+        """
+        version_dir = self.get_version_dir(distribution, version)
+        if version_dir.exists():
+            shutil.rmtree(version_dir)
+            return True
+        return False

--- a/ecosystem-registry/collector/contrib/v0.144.0/connector.yaml
+++ b/ecosystem-registry/collector/contrib/v0.144.0/connector.yaml
@@ -1,5 +1,5 @@
 distribution: contrib
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector-contrib
 component_type: connector
 components:

--- a/ecosystem-registry/collector/contrib/v0.144.0/exporter.yaml
+++ b/ecosystem-registry/collector/contrib/v0.144.0/exporter.yaml
@@ -1,5 +1,5 @@
 distribution: contrib
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector-contrib
 component_type: exporter
 components:

--- a/ecosystem-registry/collector/contrib/v0.144.0/extension.yaml
+++ b/ecosystem-registry/collector/contrib/v0.144.0/extension.yaml
@@ -1,5 +1,5 @@
 distribution: contrib
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector-contrib
 component_type: extension
 components:
@@ -468,9 +468,6 @@ components:
         - dmitryax
         emeritus:
         - rmfitzpatrick
-- name: endpointswatcher
-  subtype: observer
-  has_metadata: false
 - name: hostobserver
   subtype: observer
   metadata:

--- a/ecosystem-registry/collector/contrib/v0.144.0/processor.yaml
+++ b/ecosystem-registry/collector/contrib/v0.144.0/processor.yaml
@@ -1,5 +1,5 @@
 distribution: contrib
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector-contrib
 component_type: processor
 components:

--- a/ecosystem-registry/collector/contrib/v0.144.0/receiver.yaml
+++ b/ecosystem-registry/collector/contrib/v0.144.0/receiver.yaml
@@ -1,5 +1,5 @@
 distribution: contrib
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector-contrib
 component_type: receiver
 components:

--- a/ecosystem-registry/collector/contrib/v0.145.0/extension.yaml
+++ b/ecosystem-registry/collector/contrib/v0.145.0/extension.yaml
@@ -555,9 +555,6 @@ components:
         - dmitryax
         emeritus:
         - rmfitzpatrick
-- name: endpointswatcher
-  subtype: observer
-  has_metadata: false
 - name: hostobserver
   subtype: observer
   metadata:

--- a/ecosystem-registry/collector/contrib/v0.145.1-SNAPSHOT/extension.yaml
+++ b/ecosystem-registry/collector/contrib/v0.145.1-SNAPSHOT/extension.yaml
@@ -563,9 +563,6 @@ components:
         - dmitryax
         emeritus:
         - rmfitzpatrick
-- name: endpointswatcher
-  subtype: observer
-  has_metadata: false
 - name: hostobserver
   subtype: observer
   metadata:

--- a/ecosystem-registry/collector/core/v0.144.0/connector.yaml
+++ b/ecosystem-registry/collector/core/v0.144.0/connector.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector
 component_type: connector
 components:

--- a/ecosystem-registry/collector/core/v0.144.0/exporter.yaml
+++ b/ecosystem-registry/collector/core/v0.144.0/exporter.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector
 component_type: exporter
 components:

--- a/ecosystem-registry/collector/core/v0.144.0/extension.yaml
+++ b/ecosystem-registry/collector/core/v0.144.0/extension.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector
 component_type: extension
 components:

--- a/ecosystem-registry/collector/core/v0.144.0/processor.yaml
+++ b/ecosystem-registry/collector/core/v0.144.0/processor.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector
 component_type: processor
 components:

--- a/ecosystem-registry/collector/core/v0.144.0/receiver.yaml
+++ b/ecosystem-registry/collector/core/v0.144.0/receiver.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.144.0
+version: 0.144.0
 repository: opentelemetry-collector
 component_type: receiver
 components:

--- a/ecosystem-registry/collector/core/v0.145.0/connector.yaml
+++ b/ecosystem-registry/collector/core/v0.145.0/connector.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.145.0
+version: 0.145.0
 repository: opentelemetry-collector
 component_type: connector
 components:

--- a/ecosystem-registry/collector/core/v0.145.0/exporter.yaml
+++ b/ecosystem-registry/collector/core/v0.145.0/exporter.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.145.0
+version: 0.145.0
 repository: opentelemetry-collector
 component_type: exporter
 components:

--- a/ecosystem-registry/collector/core/v0.145.0/extension.yaml
+++ b/ecosystem-registry/collector/core/v0.145.0/extension.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.145.0
+version: 0.145.0
 repository: opentelemetry-collector
 component_type: extension
 components:

--- a/ecosystem-registry/collector/core/v0.145.0/processor.yaml
+++ b/ecosystem-registry/collector/core/v0.145.0/processor.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.145.0
+version: 0.145.0
 repository: opentelemetry-collector
 component_type: processor
 components:

--- a/ecosystem-registry/collector/core/v0.145.0/receiver.yaml
+++ b/ecosystem-registry/collector/core/v0.145.0/receiver.yaml
@@ -1,5 +1,5 @@
 distribution: core
-version: v0.145.0
+version: 0.145.0
 repository: opentelemetry-collector
 component_type: receiver
 components:


### PR DESCRIPTION
Fixes #64 and adds ability to run a backfill when we make changes to our parsers etc

example output when running `uv run collector-watcher --backfill`:

```
Collector Watcher
Inventory directory: ecosystem-registry/collector
Mode: BACKFILL
Versions: auto-detect all existing versions

Setting up repositories...
Updating core repository at tmp_repos/opentelemetry-collector-core
Successfully pulled latest changes at tmp_repos/opentelemetry-collector-core
Updating contrib repository at tmp_repos/opentelemetry-collector-contrib
Successfully pulled latest changes at tmp_repos/opentelemetry-collector-contrib
Repositories ready.

============================================================
BACKFILL MODE
============================================================

============================================================
BACKFILL MODE: CORE
============================================================
Versions to backfill: 3
  - 0.145.1-SNAPSHOT
  - 0.145.0
  - 0.144.0

Backfilling core 0.145.1-SNAPSHOT...
  Deleted existing data
  Checking out core main branch...
  Scanning core 0.145.1-SNAPSHOT...
    Found 16 components
  Saved core 0.145.1-SNAPSHOT

Backfilling core 0.145.0...
  Deleted existing data
  Checking out core 0.145.0...
  Scanning core 0.145.0...
    Found 16 components
  Saved core 0.145.0

Backfilling core 0.144.0...
  Deleted existing data
  Checking out core 0.144.0...
  Scanning core 0.144.0...
    Found 16 components
  Saved core 0.144.0

Backfill complete for core: 3 versions processed

============================================================
BACKFILL MODE: CONTRIB
============================================================
Versions to backfill: 3
  - 0.145.1-SNAPSHOT
  - 0.145.0
  - 0.144.0

Backfilling contrib 0.145.1-SNAPSHOT...
  Deleted existing data
  Checking out contrib main branch...
  Scanning contrib 0.145.1-SNAPSHOT...
    Found 250 components
  Saved contrib 0.145.1-SNAPSHOT

Backfilling contrib 0.145.0...
  Deleted existing data
  Checking out contrib 0.145.0...
  Scanning contrib 0.145.0...
    Found 249 components
  Saved contrib 0.145.0

Backfilling contrib 0.144.0...
  Deleted existing data
  Checking out contrib 0.144.0...
  Scanning contrib 0.144.0...
    Found 249 components
  Saved contrib 0.144.0

Backfill complete for contrib: 3 versions processed

============================================================
BACKFILL COMPLETE
============================================================
Total versions backfilled: 6
  core: 3 versions
  contrib: 3 versions
```