### PR TITLE
Add minimum release age to renovate rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "groupName": "all dependencies",


### PR DESCRIPTION
This will delay updates for 2 weeks to reduce risks of supply chain attacks. Discussed [here](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/pull/92#issuecomment-3908196305) with @mx-psi 

https://docs.renovatebot.com/key-concepts/minimum-release-age/

Note: if there are security patches, they will bypass this rule.
