### PR TITLE
Add back checkout step

### DIFF
--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -19,6 +19,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Open issue or add comment if issue already open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #136

The checkout step was removed based on a Copilot suggestion, Adding it back fixes the 
error

failed to run git: fatal: not a git repository (or any of the parent directories): .git