### PR TITLE
feat: add support for file_format 0.3

### DIFF
--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_parser.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_parser.py
@@ -144,12 +144,52 @@ class ParserV02(ParserV01):
             raise ValueError(f"Error parsing instrumentation YAML: {e}") from e
 
 
+class ParserV03(ParserV02):
+    """Parser for file_format 0.3."""
+
+    def get_file_format(self) -> float:
+        return 0.3
+
+    def parse(self, yaml_content: str) -> dict[str, Any]:
+        """
+        Parse and normalize file_format 0.3 YAML content.
+
+        Changes from 0.2:
+        - 'type' field renamed to 'data_type'
+        """
+        try:
+            data = yaml.safe_load(yaml_content) or {}
+            cleaned_data = self._clean_strings(data)
+            flattened_data = self._flatten_libraries(cleaned_data)
+            return self._normalize_metrics(flattened_data)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Error parsing instrumentation YAML: {e}") from e
+
+    @staticmethod
+    def _normalize_metrics(data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Normalize metrics: handle 'data_type' and 'instrument' fields.
+        """
+        if "libraries" not in data:
+            return data
+        for library in data["libraries"]:
+            if not isinstance(library, dict):
+                continue
+            for metric in library.get("metrics", []):
+                if not isinstance(metric, dict):
+                    continue
+                if "type" in metric and "data_type" not in metric:
+                    metric["data_type"] = metric.pop("type")
+        return data
+
+
 class ParserFactory:
     """Factory for creating version-specific parsers."""
 
     _parsers: dict[float, type[InstrumentationParser]] = {
         0.1: ParserV01,
         0.2: ParserV02,
+        0.3: ParserV03,
     }
 
     @classmethod

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_parser.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_parser.py
@@ -20,6 +20,7 @@ from java_instrumentation_watcher.instrumentation_parser import (
     ParserFactory,
     ParserV01,
     ParserV02,
+    ParserV03,
     parse_instrumentation_yaml,
 )
 
@@ -189,6 +190,31 @@ libraries:
         assert data["libraries"][1]["tags"] == ["akka"]
 
 
+class TestParserV03:
+    def test_get_file_format(self):
+        parser = ParserV03()
+        assert parser.get_file_format() == 0.3
+
+    def test_parse_renames_type_to_data_type(self):
+        yaml_content = """
+file_format: 0.3
+libraries:
+  test:
+  - name: test-lib
+    metrics:
+    - name: test.metric
+      type: LONG_SUM
+      instrument: counter
+"""
+        parser = ParserV03()
+        data = parser.parse(yaml_content)
+
+        metric = data["libraries"][0]["metrics"][0]
+        assert "data_type" in metric
+        assert "type" not in metric
+        assert metric["data_type"] == "LONG_SUM"
+
+
 class TestParserFactory:
     def test_get_parser_v0_1(self):
         parser = ParserFactory.get_parser(0.1)
@@ -200,6 +226,11 @@ class TestParserFactory:
         assert isinstance(parser, ParserV02)
         assert parser.get_file_format() == 0.2
 
+    def test_get_parser_v0_3(self):
+        parser = ParserFactory.get_parser(0.3)
+        assert isinstance(parser, ParserV03)
+        assert parser.get_file_format() == 0.3
+
     def test_get_parser_unsupported_version(self):
         with pytest.raises(ValueError, match="Unsupported file_format: 999.0"):
             ParserFactory.get_parser(999.0)
@@ -207,8 +238,8 @@ class TestParserFactory:
     def test_get_default_parser(self):
         parser = ParserFactory.get_default_parser()
         assert isinstance(parser, InstrumentationParser)
-        # Should return the latest version (0.2 currently)
-        assert parser.get_file_format() == 0.2
+        # Should return the latest version (0.3 currently)
+        assert parser.get_file_format() == 0.3
 
 
 class TestParseInstrumentationYaml:


### PR DESCRIPTION
Fixes #138

The nightly registry update was failing because the parser did not
support file_format 0.3. This PR adds ParserV03 to handle the new format.

### Changes
- Add `ParserV03` class for file_format 0.3
- Rename `type` field to `data_type` in metrics normalization
- written the test cases with all success pass.