### PR TITLE
Change dev server start command

### DIFF
--- a/ecosystem-explorer/README.md
+++ b/ecosystem-explorer/README.md
@@ -13,7 +13,7 @@ npm install
 Run development server:
 
 ```bash
-npm run dev
+npm run serve
 ```
 
 Build for production:

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "serve": "vite",
     "build": "tsc -b && vite build",
     "netlify-build:preview": "tsc -b && vite build",
     "netlify-build:production": "tsc -b && vite build",


### PR DESCRIPTION
opentelemetry.io [uses](https://github.com/open-telemetry/opentelemetry.io/blob/f9962ae62b214901f8f8923e7dc7c1f629569fc8/content/en/docs/contributing/development.md?plain=1#L122) `npm run serve`, so changing this to be consistent with that. I keep getting confused when bouncing between projects.