### PR TITLE
Update renovate configs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,16 +4,66 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  "minimumReleaseAge": "14 days",
+  "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
+  "labels": ["dependencies"],
+  "schedule": ["before 8am on Monday"],
+
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on Monday"]
+  },
+
   "packageRules": [
+    // Dev dependencies (patch/minor)
     {
-      "groupName": "all dependencies",
-      "matchUpdateTypes": ["patch", "minor", "major"],
-      "schedule": ["before 8am on Monday"]
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dev dependencies (non-major)",
+    },
+
+    // Dev dependencies (major)
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+
+    // Production dependencies (patch)
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "production patches",
+    },
+
+    // Production dependencies (minor)
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "production minor updates"
+    },
+
+    // Production dependencies (major)
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+
+    // GitHub Actions (patch/minor)
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "7 days",
+      "groupName": "GitHub Actions",
+    },
+
+    // GitHub Actions (major)
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "7 days",
+      "groupName": null
     }
-  ],
-  "labels": [
-    "dependencies"
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,8 +25,7 @@
     // Dev dependencies (major)
     {
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major"],
-      "groupName": null
+      "matchUpdateTypes": ["major"]
     },
 
     // Production dependencies (patch)
@@ -46,8 +45,7 @@
     // Production dependencies (major)
     {
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["major"],
-      "groupName": null
+      "matchUpdateTypes": ["major"]
     },
 
     // GitHub Actions (patch/minor)
@@ -62,8 +60,7 @@
     {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "7 days",
-      "groupName": null
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
The current strategy of grouping all of these updates along with requiring the 14 day wait period was resulting in some PRs hanging around for a long time, blocking other updates.

This change will split things out with some more granular rules so that we can better stay on top of and review the dependency updates, as well as reducing the wait time from 14 days to 7