### PR TITLE
feat(explorer): display semantic conventions as linked badges on inst…

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -56,6 +56,11 @@ const mockInstrumentation: InstrumentationData = {
   has_standalone_library: true,
 };
 
+const mockInstrumentationWithSemconv: InstrumentationData = {
+  ...mockInstrumentation,
+  semantic_conventions: ["HTTP_CLIENT_SPANS", "DATABASE_CLIENT_SPANS", "UNKNOWN_CONVENTION"],
+};
+
 function renderWithRouter(initialPath: string) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -170,5 +175,56 @@ describe("InstrumentationDetailPage", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/2.0.0/jdbc", {
       replace: true,
     });
+  });
+
+  it("renders semantic conventions as linked badges for known values", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: mockInstrumentationWithSemconv,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+
+    expect(screen.getByRole("heading", { name: "Semantic Conventions" })).toBeInTheDocument();
+
+    const httpLink = screen.getByRole("link", { name: "HTTP Client Spans" });
+    expect(httpLink).toBeInTheDocument();
+    expect(httpLink).toHaveAttribute(
+      "href",
+      "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client"
+    );
+    expect(httpLink).toHaveAttribute("target", "_blank");
+
+    const dbLink = screen.getByRole("link", { name: "Database Client Spans" });
+    expect(dbLink).toBeInTheDocument();
+    expect(dbLink).toHaveAttribute(
+      "href",
+      "https://opentelemetry.io/docs/specs/semconv/database/database-spans/"
+    );
+  });
+
+  it("renders unknown semantic conventions as plain text", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: mockInstrumentationWithSemconv,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+
+    expect(screen.getByText("UNKNOWN_CONVENTION")).toBeInTheDocument();
+  });
+
+  it("does not render semantic conventions section when none are present", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: mockInstrumentation,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+
+    expect(screen.queryByRole("heading", { name: "Semantic Conventions" })).not.toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -192,7 +192,7 @@ describe("InstrumentationDetailPage", () => {
     expect(httpLink).toBeInTheDocument();
     expect(httpLink).toHaveAttribute(
       "href",
-      "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client"
+      "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span"
     );
     expect(httpLink).toHaveAttribute("target", "_blank");
 

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -31,7 +31,7 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SectionHeader } from "@/components/ui/section-header";
 import { useVersions, useInstrumentation } from "@/hooks/use-javaagent-data";
-import { getInstrumentationDisplayName } from "./utils/format";
+import { getInstrumentationDisplayName, getSemanticConventionInfo } from "./utils/format";
 import { TelemetrySection } from "./components/telemetry-section";
 
 function buildSourceUrl(sourcePath: string): string {
@@ -394,11 +394,27 @@ export function InstrumentationDetailPage() {
                                 Semantic Conventions
                               </h3>
                               <div className="flex flex-wrap gap-2">
-                                {instrumentation.semantic_conventions.map((convention) => (
-                                  <GlowBadge key={convention} variant="muted">
-                                    {convention}
-                                  </GlowBadge>
-                                ))}
+                                {instrumentation.semantic_conventions.map((convention) => {
+                                  const info = getSemanticConventionInfo(convention);
+                                  if (info) {
+                                    return (
+                                      <a
+                                        key={convention}
+                                        href={info.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="px-3 py-1 text-sm rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                                      >
+                                        {info.label}
+                                      </a>
+                                    );
+                                  }
+                                  return (
+                                    <GlowBadge key={convention} variant="muted">
+                                      {convention}
+                                    </GlowBadge>
+                                  );
+                                })}
                               </div>
                             </div>
                           </DetailCard>

--- a/ecosystem-explorer/src/features/java-agent/utils/format.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/format.test.ts
@@ -88,7 +88,7 @@ describe("getSemanticConventionInfo", () => {
     const info = getSemanticConventionInfo("HTTP_CLIENT_SPANS");
     expect(info).toEqual({
       label: "HTTP Client Spans",
-      url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client",
+      url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span",
     });
   });
 

--- a/ecosystem-explorer/src/features/java-agent/utils/format.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/format.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { getInstrumentationDisplayName } from "./format";
+import { getInstrumentationDisplayName, getSemanticConventionInfo } from "./format";
 import type { InstrumentationData } from "@/types/javaagent";
 
 describe("getInstrumentationDisplayName", () => {
@@ -80,5 +80,47 @@ describe("getInstrumentationDisplayName", () => {
     };
 
     expect(getInstrumentationDisplayName(instrumentation)).toBe("Jdbc");
+  });
+});
+
+describe("getSemanticConventionInfo", () => {
+  it("returns label and url for a known value", () => {
+    const info = getSemanticConventionInfo("HTTP_CLIENT_SPANS");
+    expect(info).toEqual({
+      label: "HTTP Client Spans",
+      url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client",
+    });
+  });
+
+  it("returns label and url for DATABASE_CLIENT_SPANS", () => {
+    const info = getSemanticConventionInfo("DATABASE_CLIENT_SPANS");
+    expect(info).toEqual({
+      label: "Database Client Spans",
+      url: "https://opentelemetry.io/docs/specs/semconv/database/database-spans/",
+    });
+  });
+
+  it("returns label and url for MESSAGING_SPANS", () => {
+    const info = getSemanticConventionInfo("MESSAGING_SPANS");
+    expect(info).toEqual({
+      label: "Messaging Spans",
+      url: "https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/",
+    });
+  });
+
+  it("returns label and url for GENAI_CLIENT_SPANS", () => {
+    const info = getSemanticConventionInfo("GENAI_CLIENT_SPANS");
+    expect(info).toEqual({
+      label: "GenAI Client Spans",
+      url: "https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/",
+    });
+  });
+
+  it("returns null for an unknown value", () => {
+    expect(getSemanticConventionInfo("UNKNOWN_CONVENTION")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(getSemanticConventionInfo("")).toBeNull();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/utils/format.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/format.ts
@@ -23,11 +23,11 @@ export interface SemanticConventionInfo {
 const SEMANTIC_CONVENTION_MAP: Record<string, SemanticConventionInfo> = {
   HTTP_CLIENT_SPANS: {
     label: "HTTP Client Spans",
-    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span",
   },
   HTTP_SERVER_SPANS: {
     label: "HTTP Server Spans",
-    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span",
   },
   HTTP_CLIENT_METRICS: {
     label: "HTTP Client Metrics",
@@ -36,10 +36,6 @@ const SEMANTIC_CONVENTION_MAP: Record<string, SemanticConventionInfo> = {
   HTTP_SERVER_METRICS: {
     label: "HTTP Server Metrics",
     url: "https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-server",
-  },
-  HTTP_ROUTE: {
-    label: "HTTP Route",
-    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/",
   },
   DATABASE_CLIENT_SPANS: {
     label: "Database Client Spans",
@@ -88,14 +84,6 @@ const SEMANTIC_CONVENTION_MAP: Record<string, SemanticConventionInfo> = {
   GENAI_CLIENT_METRICS: {
     label: "GenAI Client Metrics",
     url: "https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/",
-  },
-  CONTEXT_PROPAGATION: {
-    label: "Context Propagation",
-    url: "https://opentelemetry.io/docs/specs/otel/context/api-propagators/",
-  },
-  AUTO_INSTRUMENTATION_SHIM: {
-    label: "Auto Instrumentation Shim",
-    url: "https://opentelemetry.io/docs/specs/otel/trace/api/",
   },
 };
 

--- a/ecosystem-explorer/src/features/java-agent/utils/format.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/format.ts
@@ -15,6 +15,94 @@
  */
 import type { InstrumentationData } from "@/types/javaagent";
 
+export interface SemanticConventionInfo {
+  label: string;
+  url: string;
+}
+
+const SEMANTIC_CONVENTION_MAP: Record<string, SemanticConventionInfo> = {
+  HTTP_CLIENT_SPANS: {
+    label: "HTTP Client Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client",
+  },
+  HTTP_SERVER_SPANS: {
+    label: "HTTP Server Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server",
+  },
+  HTTP_CLIENT_METRICS: {
+    label: "HTTP Client Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-client",
+  },
+  HTTP_SERVER_METRICS: {
+    label: "HTTP Server Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-server",
+  },
+  HTTP_ROUTE: {
+    label: "HTTP Route",
+    url: "https://opentelemetry.io/docs/specs/semconv/http/http-spans/",
+  },
+  DATABASE_CLIENT_SPANS: {
+    label: "Database Client Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/database/database-spans/",
+  },
+  DATABASE_CLIENT_METRICS: {
+    label: "Database Client Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/database/database-metrics/",
+  },
+  DATABASE_POOL_METRICS: {
+    label: "Database Pool Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/database/database-metrics/#connection-pools",
+  },
+  MESSAGING_SPANS: {
+    label: "Messaging Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/",
+  },
+  RPC_CLIENT_SPANS: {
+    label: "RPC Client Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/",
+  },
+  RPC_SERVER_SPANS: {
+    label: "RPC Server Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/",
+  },
+  RPC_CLIENT_METRICS: {
+    label: "RPC Client Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/",
+  },
+  RPC_SERVER_METRICS: {
+    label: "RPC Server Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/",
+  },
+  FAAS_SERVER_SPANS: {
+    label: "FaaS Server Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/faas/faas-spans/",
+  },
+  GRAPHQL_SERVER_SPANS: {
+    label: "GraphQL Server Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/",
+  },
+  GENAI_CLIENT_SPANS: {
+    label: "GenAI Client Spans",
+    url: "https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/",
+  },
+  GENAI_CLIENT_METRICS: {
+    label: "GenAI Client Metrics",
+    url: "https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/",
+  },
+  CONTEXT_PROPAGATION: {
+    label: "Context Propagation",
+    url: "https://opentelemetry.io/docs/specs/otel/context/api-propagators/",
+  },
+  AUTO_INSTRUMENTATION_SHIM: {
+    label: "Auto Instrumentation Shim",
+    url: "https://opentelemetry.io/docs/specs/otel/trace/api/",
+  },
+};
+
+export function getSemanticConventionInfo(value: string): SemanticConventionInfo | null {
+  return SEMANTIC_CONVENTION_MAP[value] ?? null;
+}
+
 export function getInstrumentationDisplayName(instrumentation: InstrumentationData): string {
   if (instrumentation.display_name) {
     return instrumentation.display_name;


### PR DESCRIPTION
## Summary
- Adds a `getSemanticConventionInfo` utility that maps raw semantic convention
  enum values (e.g. `HTTP_CLIENT_SPANS`) to human-readable labels and links to
  the official OpenTelemetry specification docs
- Renders semantic conventions as clickable linked badges in the instrumentation
  detail page, with a plain monospace fallback for any unknown values
- Closes #210

## Test plan
- [x] Unit tests for `getSemanticConventionInfo` — known values, unknown values, empty string
- [x] Detail page tests — linked badges render with correct href and target, unknown values render as plain text, section is hidden when no conventions are present
- [x] All 144 JS tests pass (`npm test`)
- [x] All Python tests pass across all automation components