### PR TITLE
feat(explorer): add about page and footer navigation links

### DIFF
--- a/ecosystem-explorer/src/App.tsx
+++ b/ecosystem-explorer/src/App.tsx
@@ -24,6 +24,7 @@ import { JavaInstrumentationListPage } from "@/features/java-agent/java-instrume
 import { JavaConfigurationListPage } from "@/features/java-agent/java-configuration-list-page";
 import { InstrumentationDetailPage } from "@/features/java-agent/instrumentation-detail-page";
 import { ConfigurationBuilderPage } from "@/features/java-agent/configuration/configuration-builder-page";
+import { AboutPage } from "@/features/about/about-page";
 
 export default function App() {
   return (
@@ -45,6 +46,7 @@ export default function App() {
               element={<ConfigurationBuilderPage />}
             />
             <Route path="/collector" element={<CollectorPage />} />
+            <Route path="/about" element={<AboutPage />} />
             <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </main>

--- a/ecosystem-explorer/src/components/layout/footer.test.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { Footer } from "./footer";
+
+describe("Footer", () => {
+  it("renders the app name", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("OpenTelemetry Ecosystem Explorer")).toBeInTheDocument();
+  });
+
+  it("renders the About link pointing to /about", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    const aboutLink = screen.getByRole("link", { name: "About" });
+    expect(aboutLink).toBeInTheDocument();
+    expect(aboutLink).toHaveAttribute("href", "/about");
+  });
+
+  it("renders the GitHub link", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    const githubLink = screen.getByRole("link", { name: "GitHub" });
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
+    );
+    expect(githubLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders the opentelemetry.io link", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    const otelLink = screen.getByRole("link", { name: "opentelemetry.io" });
+    expect(otelLink).toHaveAttribute("href", "https://opentelemetry.io");
+    expect(otelLink).toHaveAttribute("target", "_blank");
+  });
+});

--- a/ecosystem-explorer/src/components/layout/footer.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Link } from "react-router-dom";
 import { OtelLogo } from "@/components/icons/otel-logo";
 
 export function Footer() {
   return (
-    <footer className="border-t border-border/30 h-16 px-6 bg-background flex-shrink-0">
-      <div className="max-w-6xl mx-auto h-full flex items-center justify-between">
+    <footer className="border-t border-border/30 px-6 py-4 bg-background flex-shrink-0">
+      <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-muted-foreground">
           <OtelLogo className="h-5 w-5 text-primary" />
           <span className="text-sm">OpenTelemetry Ecosystem Explorer</span>
@@ -26,6 +27,27 @@ export function Footer() {
         <p className="text-sm text-muted-foreground hidden md:block">
           Charting the observability landscape
         </p>
+        <nav className="flex items-center gap-4 text-sm text-muted-foreground">
+          <Link to="/about" className="hover:text-foreground transition-colors">
+            About
+          </Link>
+          <a
+            href="https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://opentelemetry.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            opentelemetry.io
+          </a>
+        </nav>
       </div>
     </footer>
   );

--- a/ecosystem-explorer/src/features/about/about-page.test.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { AboutPage } from "./about-page";
+
+describe("AboutPage", () => {
+  it("renders the page heading", () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "About", level: 1 })).toBeInTheDocument();
+  });
+
+  it("renders the Goals section", () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Goals" })).toBeInTheDocument();
+  });
+
+  it("renders the Get Involved section with links", () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Get Involved" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /source code/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /report a bug/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /request a feature/i })).toBeInTheDocument();
+  });
+
+  it("renders the Contributing section", () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Contributing" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /contributing guide/i })).toBeInTheDocument();
+  });
+
+  it("source code link points to the GitHub repo", () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole("link", { name: /source code/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
+    );
+  });
+});

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Github, BookOpen, Bug, MessageSquare } from "lucide-react";
+
+const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
+
+export function AboutPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-12 space-y-10">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-bold text-foreground">About</h1>
+        <p className="text-muted-foreground text-base leading-relaxed">
+          The OpenTelemetry Ecosystem Explorer is a community-driven tool for discovering and
+          exploring projects, instrumentations, and components across the{" "}
+          <a
+            href="https://opentelemetry.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            OpenTelemetry
+          </a>{" "}
+          ecosystem.
+        </p>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-foreground">Goals</h2>
+        <div className="rounded-lg border border-border/50 bg-card/50 p-6 space-y-3 text-sm text-muted-foreground leading-relaxed">
+          <p>
+            The ecosystem is large and growing. Finding what instrumentation exists, what it
+            produces, and how to configure it can be difficult. This project aims to make that
+            information accessible and easy to navigate.
+          </p>
+          <p>
+            By building a structured registry and an interactive explorer, we help developers
+            understand what is available, what signals each component emits, and how components
+            relate to OpenTelemetry semantic conventions.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-foreground">Get Involved</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
+          >
+            <Github className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-foreground">Source Code</h3>
+              <p className="text-xs text-muted-foreground">
+                Browse the repository, review open issues, and submit pull requests.
+              </p>
+            </div>
+          </a>
+
+          <a
+            href="https://opentelemetry.io/docs/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
+          >
+            <BookOpen className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-foreground">OpenTelemetry Docs</h3>
+              <p className="text-xs text-muted-foreground">
+                Learn about OpenTelemetry concepts, APIs, and SDKs at opentelemetry.io.
+              </p>
+            </div>
+          </a>
+
+          <a
+            href={`${REPO_URL}/issues/new?labels=bug`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
+          >
+            <Bug className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-foreground">Report a Bug</h3>
+              <p className="text-xs text-muted-foreground">
+                Found something wrong? Open an issue on GitHub and let us know.
+              </p>
+            </div>
+          </a>
+
+          <a
+            href={`${REPO_URL}/issues/new?labels=enhancement`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
+          >
+            <MessageSquare
+              className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary"
+              aria-hidden="true"
+            />
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-foreground">Request a Feature</h3>
+              <p className="text-xs text-muted-foreground">
+                Have an idea? Open an issue to discuss it with the maintainers.
+              </p>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-foreground">Contributing</h2>
+        <div className="rounded-lg border border-border/50 bg-card/50 p-6 space-y-3 text-sm text-muted-foreground leading-relaxed">
+          <p>
+            Contributions of all sizes are welcome — from fixing a typo to adding new ecosystem
+            coverage. To get started, read the{" "}
+            <a
+              href={`${REPO_URL}/blob/main/CONTRIBUTING.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              contributing guide
+            </a>
+            .
+          </p>
+          <p>
+            The project is part of the{" "}
+            <a
+              href="https://cloud-native.slack.com/archives/C09N6DDGSPQ"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              #otel-ecosystem-explorer
+            </a>{" "}
+            channel on CNCF Slack. Join us there for questions, discussions, and updates.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `/about` page with project goals, contribution guidance, bug reporting and feature request links, and a link to the CNCF Slack channel
- Updates the footer with navigation links to the About page, the GitHub repository, and opentelemetry.io
- Closes #183

## Test plan
- [x] Unit tests for `AboutPage` — heading, sections, and link hrefs
- [x] Unit tests for `Footer` — About link, GitHub link, opentelemetry.io link
- [x] All 287 JS tests pass (`npm test`)
- [x] Manually verified at `/about` and footer links render correctly