### PR TITLE
feat(explorer): add icons and copyright notice to footer

### DIFF
--- a/ecosystem-explorer/src/components/layout/footer.test.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.test.tsx
@@ -48,7 +48,7 @@ describe("Footer", () => {
       </MemoryRouter>
     );
 
-    const githubLink = screen.getByRole("link", { name: "GitHub" });
+    const githubLink = screen.getByRole("link", { name: "GitHub repository" });
     expect(githubLink).toHaveAttribute(
       "href",
       "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
@@ -63,8 +63,28 @@ describe("Footer", () => {
       </MemoryRouter>
     );
 
-    const otelLink = screen.getByRole("link", { name: "opentelemetry.io" });
+    const otelLink = screen.getByRole("link", { name: "OpenTelemetry website" });
     expect(otelLink).toHaveAttribute("href", "https://opentelemetry.io");
     expect(otelLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders the tagline", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Charting the observability landscape")).toBeInTheDocument();
+  });
+
+  it("renders the copyright notice", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("© 2026–present OpenTelemetry Authors")).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/components/layout/footer.test.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.test.tsx
@@ -85,6 +85,6 @@ describe("Footer", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText("© 2026–present OpenTelemetry Authors")).toBeInTheDocument();
+    expect(screen.getByText("© 2026–Present OpenTelemetry Authors")).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/components/layout/footer.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.tsx
@@ -13,41 +13,52 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Github, Map } from "lucide-react";
 import { Link } from "react-router-dom";
 import { OtelLogo } from "@/components/icons/otel-logo";
 
 export function Footer() {
   return (
     <footer className="border-t border-border/30 px-6 py-4 bg-background flex-shrink-0">
-      <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <OtelLogo className="h-5 w-5 text-primary" />
-          <span className="text-sm">OpenTelemetry Ecosystem Explorer</span>
+      <div className="max-w-6xl mx-auto flex flex-col items-center gap-3">
+        <div className="flex flex-col md:grid md:grid-cols-3 items-center gap-3 w-full">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <OtelLogo className="h-5 w-5 text-primary" />
+            <span className="text-sm">OpenTelemetry Ecosystem Explorer</span>
+          </div>
+          <p className="text-sm text-muted-foreground hidden md:flex items-center justify-center gap-1.5">
+            <Map className="h-4 w-4" aria-hidden="true" />
+            Charting the observability landscape
+          </p>
+          <nav className="flex items-center justify-end gap-4 text-sm text-muted-foreground">
+            <Link to="/about" className="hover:text-foreground transition-colors">
+              About
+            </Link>
+            <a
+              href="https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors flex items-center gap-1"
+              aria-label="GitHub repository"
+            >
+              <Github className="h-4 w-4" aria-hidden="true" />
+              GitHub
+            </a>
+            <a
+              href="https://opentelemetry.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors flex items-center gap-1"
+              aria-label="OpenTelemetry website"
+            >
+              <OtelLogo className="h-4 w-4" aria-hidden="true" />
+              opentelemetry.io
+            </a>
+          </nav>
         </div>
-        <p className="text-sm text-muted-foreground hidden md:block">
-          Charting the observability landscape
+        <p className="text-xs text-muted-foreground">
+          &copy; 2026–Present OpenTelemetry Authors
         </p>
-        <nav className="flex items-center gap-4 text-sm text-muted-foreground">
-          <Link to="/about" className="hover:text-foreground transition-colors">
-            About
-          </Link>
-          <a
-            href="https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
-          >
-            GitHub
-          </a>
-          <a
-            href="https://opentelemetry.io"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
-          >
-            opentelemetry.io
-          </a>
-        </nav>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary                                                                                                                                                                
                                                                                                                                                                              
  * Added icons (GitHub, OpenTelemetry, Map) alongside footer links and tagline, added copyright notice, and improved column alignment with CSS grid                          
  * Closes #127
                                                                                                                                                                              
  ## Test plan                                                                                                                                                              
                                                                                                                                                                              
  * [x] Unit tests added for tagline and copyright notice rendering                                                                                                           
  * [x] Existing tests updated to match new accessible link names
  * [x] All 289 tests pass (`bun run test`)                                                                                                                                   
  * [x] Typecheck and lint pass                                                                                                                                               
  * [x] Visual verification on desktop and mobile viewports    