### PR TITLE
feat(explorer): add Java agent version selector to list and detail pages

### DIFF
--- a/ecosystem-explorer/src/App.tsx
+++ b/ecosystem-explorer/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/java-agent" element={<JavaAgentPage />} />
             <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
+            <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
             <Route
               path="/java-agent/instrumentation/:version/:name"
               element={<InstrumentationDetailPage />}

--- a/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChevronDown } from "lucide-react";
+import type { VersionInfo } from "@/types/javaagent";
+
+interface VersionSelectorProps {
+  versions: VersionInfo[];
+  currentVersion: string;
+  onVersionChange: (version: string) => void;
+}
+
+export function VersionSelector({ versions, currentVersion, onVersionChange }: VersionSelectorProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="version-select" className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+        Version
+      </label>
+      <div className="relative">
+        <select
+          id="version-select"
+          value={currentVersion}
+          onChange={(e) => onVersionChange(e.target.value)}
+          className="appearance-none rounded-lg border border-border/60 bg-background/80 pl-3 pr-8 py-1.5 text-sm font-medium backdrop-blur-sm transition-all duration-200 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 cursor-pointer"
+        >
+          {versions.map((v) => (
+            <option key={v.version} value={v.version}>
+              {v.version}{v.is_latest ? " (latest)" : ""}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { InstrumentationDetailPage } from "./instrumentation-detail-page";
 import type { InstrumentationData } from "@/types/javaagent";
@@ -142,13 +142,41 @@ describe("InstrumentationDetailPage", () => {
     const scopeNameCode = within(header).getByText("jdbc");
     expect(scopeNameCode.tagName).toBe("CODE");
 
-    expect(within(header).getByText("v2.0.0")).toBeInTheDocument();
-
     expect(within(header).getByText("Enabled by Default")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Details/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Telemetry/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Configuration/i })).toBeInTheDocument();
+  });
+
+  it("renders version selector with available versions", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: mockInstrumentation,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+
+    const select = screen.getByRole("combobox", { name: /version/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /2\.0\.0/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /1\.9\.0/ })).toBeInTheDocument();
+  });
+
+  it("navigates to new version when version selector changes", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: mockInstrumentation,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+
+    const select = screen.getByRole("combobox", { name: /version/i });
+    fireEvent.change(select, { target: { value: "1.9.0" } });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/1.9.0/jdbc");
   });
 
   it("does not fetch instrumentation when version is 'latest'", () => {

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -33,6 +33,7 @@ import { SectionHeader } from "@/components/ui/section-header";
 import { useVersions, useInstrumentation } from "@/hooks/use-javaagent-data";
 import { getInstrumentationDisplayName, getSemanticConventionInfo, getFeatureInfo } from "./utils/format";
 import { TelemetrySection } from "./components/telemetry-section";
+import { VersionSelector } from "./components/version-selector";
 
 function buildSourceUrl(sourcePath: string): string {
   try {
@@ -71,6 +72,10 @@ export function InstrumentationDetailPage() {
       }
     }
   }, [version, name, versionsData, navigate]);
+
+  const handleVersionChange = (newVersion: string) => {
+    navigate(`/java-agent/instrumentation/${newVersion}/${name}`);
+  };
 
   if (loading) {
     return (
@@ -171,9 +176,13 @@ export function InstrumentationDetailPage() {
               </div>
 
               <div className="flex flex-shrink-0 items-center gap-3">
-                <GlowBadge variant="primary" withGlow>
-                  v{version}
-                </GlowBadge>
+                {versionsData && versionsData.versions.length > 0 && version && (
+                  <VersionSelector
+                    versions={versionsData.versions}
+                    currentVersion={version}
+                    onVersionChange={handleVersionChange}
+                  />
+                )}
                 <GlowBadge
                   variant={instrumentation.disabled_by_default ? "warning" : "success"}
                   withGlow

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -176,13 +176,16 @@ export function InstrumentationDetailPage() {
               </div>
 
               <div className="flex flex-shrink-0 items-center gap-3">
-                {versionsData && versionsData.versions.length > 0 && version && (
-                  <VersionSelector
-                    versions={versionsData.versions}
-                    currentVersion={version}
-                    onVersionChange={handleVersionChange}
-                  />
-                )}
+                {versionsData &&
+                  versionsData.versions.length > 0 &&
+                  version &&
+                  version !== "latest" && (
+                    <VersionSelector
+                      versions={versionsData.versions}
+                      currentVersion={version}
+                      onVersionChange={handleVersionChange}
+                    />
+                  )}
                 <GlowBadge
                   variant={instrumentation.disabled_by_default ? "warning" : "success"}
                   withGlow

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { JavaInstrumentationListPage } from "./java-instrumentation-list-page";
 import type { InstrumentationData } from "@/types/javaagent";
@@ -31,11 +31,14 @@ vi.mock("@/components/ui/back-button", () => ({
 
 import { useVersions, useInstrumentations } from "@/hooks/use-javaagent-data";
 
-function renderPage() {
+function renderPage(initialPath = "/java-agent/instrumentation/2.0.0") {
   return render(
-    <BrowserRouter>
-      <JavaInstrumentationListPage />
-    </BrowserRouter>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
+        <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
+      </Routes>
+    </MemoryRouter>
   );
 }
 
@@ -103,7 +106,10 @@ describe("JavaInstrumentationListPage - Filtering", () => {
   beforeEach(() => {
     vi.mocked(useVersions).mockReturnValue({
       data: {
-        versions: [{ version: "2.0.0", is_latest: true }],
+        versions: [
+          { version: "2.0.0", is_latest: true },
+          { version: "1.9.0", is_latest: false },
+        ],
       },
       loading: false,
       error: null,
@@ -127,6 +133,19 @@ describe("JavaInstrumentationListPage - Filtering", () => {
     });
 
     expect(screen.getByText("Showing 4 of 4 instrumentations")).toBeInTheDocument();
+  });
+
+  it("renders the version selector with available versions", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("HTTP Client")).toBeInTheDocument();
+    });
+
+    const select = screen.getByRole("combobox", { name: /version/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /2\.0\.0/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /1\.9\.0/ })).toBeInTheDocument();
   });
 
   it("filters instrumentations by search term in name", async () => {

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -19,21 +19,37 @@ import {
   type FilterState,
   InstrumentationFilterBar,
 } from "@/features/java-agent/components/instrumentation-filter-bar.tsx";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import { InstrumentationGroupCard } from "@/features/java-agent/components/instrumentation-group-card.tsx";
+import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import { getInstrumentationDisplayName } from "./utils/format";
 import { groupInstrumentationsByDisplayName } from "./utils/group-instrumentations";
 
 export function JavaInstrumentationListPage() {
+  const { version: versionParam } = useParams<{ version?: string }>();
+  const navigate = useNavigate();
+
   const { data: versionsData, loading: versionsLoading } = useVersions();
 
   const latestVersion = versionsData?.versions.find((v) => v.is_latest)?.version ?? "";
+
+  // Redirect /java-agent/instrumentation (no version) or /latest to the actual latest version
+  useEffect(() => {
+    if (versionsData && latestVersion) {
+      if (!versionParam || versionParam === "latest") {
+        navigate(`/java-agent/instrumentation/${latestVersion}`, { replace: true });
+      }
+    }
+  }, [versionParam, versionsData, latestVersion, navigate]);
+
+  const resolvedVersion = versionParam && versionParam !== "latest" ? versionParam : "";
 
   const {
     data: instrumentations,
     loading: instrumentationsLoading,
     error,
-  } = useInstrumentations(latestVersion);
+  } = useInstrumentations(resolvedVersion);
 
   const [filters, setFilters] = useState<FilterState>({
     search: "",
@@ -89,6 +105,10 @@ export function JavaInstrumentationListPage() {
     [filteredInstrumentations]
   );
 
+  const handleVersionChange = (newVersion: string) => {
+    navigate(`/java-agent/instrumentation/${newVersion}`);
+  };
+
   if (versionsLoading || instrumentationsLoading) {
     return (
       <div className="max-w-7xl mx-auto px-6 py-12">
@@ -113,7 +133,7 @@ export function JavaInstrumentationListPage() {
     );
   }
 
-  if (!latestVersion) {
+  if (!resolvedVersion) {
     return (
       <div className="max-w-7xl mx-auto px-6 py-12">
         <div className="p-6 border border-yellow-500/50 rounded-lg bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
@@ -129,15 +149,25 @@ export function JavaInstrumentationListPage() {
         <BackButton />
 
         {/* Header Section */}
-        <div className="space-y-3">
-          <h1 className="text-3xl font-bold md:text-4xl">
-            <span className="bg-gradient-to-r from-[hsl(var(--secondary-hsl))] to-[hsl(var(--primary-hsl))] bg-clip-text text-transparent">
-              OpenTelemetry Java Agent
-            </span>
-          </h1>
-          <p className="text-base text-muted-foreground">
-            Explore {instrumentations?.length ?? 0} available instrumentations.
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-3">
+            <h1 className="text-3xl font-bold md:text-4xl">
+              <span className="bg-gradient-to-r from-[hsl(var(--secondary-hsl))] to-[hsl(var(--primary-hsl))] bg-clip-text text-transparent">
+                OpenTelemetry Java Agent
+              </span>
+            </h1>
+            <p className="text-base text-muted-foreground">
+              Explore {instrumentations?.length ?? 0} available instrumentations.
+            </p>
+          </div>
+
+          {versionsData && versionsData.versions.length > 0 && (
+            <VersionSelector
+              versions={versionsData.versions}
+              currentVersion={resolvedVersion}
+              onVersionChange={handleVersionChange}
+            />
+          )}
         </div>
 
         <InstrumentationFilterBar filters={filters} onFiltersChange={setFilters} />
@@ -167,7 +197,7 @@ export function JavaInstrumentationListPage() {
                 key={group.displayName}
                 group={group}
                 activeFilters={filters}
-                version={latestVersion}
+                version={resolvedVersion}
               />
             ))}
           </div>

--- a/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
@@ -88,8 +88,10 @@ describe("InstrumentationDetailPage — integration", () => {
       { timeout: 20_000 }
     );
 
-    // The version appears in the version badge/selector area with a "v" prefix.
-    expect(screen.getByText(`v${latestVersion}`)).toBeInTheDocument();
+    // The version appears in the version selector dropdown.
+    const select = screen.getByRole("combobox", { name: /version/i }) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe(latestVersion);
   });
 
   it("shows the instrumentation description on the page when present", async () => {

--- a/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
@@ -16,17 +16,26 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
 import { JavaInstrumentationListPage } from "@/features/java-agent/java-instrumentation-list-page";
+import { loadVersions } from "@/lib/api/javaagent-data";
 
-beforeAll(() => installFetchInterceptor());
+let latestVersion: string;
+
+beforeAll(async () => {
+  installFetchInterceptor();
+  const { versions } = await loadVersions();
+  latestVersion = versions.find((v) => v.is_latest)!.version;
+});
 afterAll(() => uninstallFetchInterceptor());
 
 function renderPage() {
   return render(
-    <MemoryRouter>
-      <JavaInstrumentationListPage />
+    <MemoryRouter initialEntries={[`/java-agent/instrumentation/${latestVersion}`]}>
+      <Routes>
+        <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
+      </Routes>
     </MemoryRouter>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a `VersionSelector` dropdown to the instrumentation list page and detail page, replacing the static version badge on the detail page
- Incorporates the selected version into the URL (`/java-agent/instrumentation/:version`) — navigating to `/java-agent/instrumentation` or `/latest` redirects to the resolved latest version
- Version selection is sticky across list ↔ detail navigation; changing the version on either page updates the URL and reloads data accordingly

Closes open-telemetry/opentelemetry-ecosystem-explorer#195

## Test plan

- [x] All 292 unit tests pass (`bun run test`)
- [x] All 20 integration tests pass (`bun run vitest --config vitest.integration.config.ts run`)
- [x] `/java-agent/instrumentation` redirects to `/java-agent/instrumentation/<latest>`
- [x] Version dropdown renders on both list and detail pages with all available versions
- [x] Changing the version on the list page navigates to `/java-agent/instrumentation/<new-version>` and reloads instrumentations
- [x] Changing the version on the detail page navigates to `/java-agent/instrumentation/<new-version>/<name>`
- [x] `/java-agent/instrumentation/latest/<name>` still redirects to the resolved version