### PR TITLE
feat(explorer): add PR screenshot automation with Playwright

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,57 @@
+name: PR Screenshots
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  screenshots:
+    if: contains(github.event.pull_request.labels.*.name, 'add-screenshots')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ecosystem-explorer
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build the frontend
+        run: bun run build
+
+      - name: Create screenshots directory
+        run: mkdir -p screenshots
+
+      - name: Take screenshots
+        run: node scripts/take-screenshots.mjs
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add and commit screenshots
+        run: |
+          git add screenshots/
+          git diff --quiet --exit-code --cached || git commit -m "docs: add screenshots for PR #$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -2,20 +2,27 @@ name: PR Screenshots
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   screenshots:
     if: contains(github.event.pull_request.labels.*.name, 'add-screenshots')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: ecosystem-explorer
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -23,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.12"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -51,7 +58,4 @@ jobs:
           git diff --quiet --exit-code --cached || git commit -m "docs: add screenshots for PR #$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
 
       - name: Push changes
-        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref }}
+        run: git push origin HEAD:${{ github.head_ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,35 @@ uv run pytest -k "test_pattern"
 * Tests are located alongside the components they test in the `src/` directory
 * Test setup file at `src/test/setup.ts` imports jest-dom matchers
 
+## PR Screenshots
+
+When working on UI changes, you can automatically generate screenshots of key Explorer pages to
+include in your PR for visual review.
+
+### Automatic Screenshots via GitHub Actions
+
+Add the `add-screenshots` label to your PR. A GitHub Actions workflow will:
+
+1. Build the frontend
+2. Launch a local server and use Playwright to capture screenshots of key pages (home, instrumentation
+   list, and instrumentation detail tabs)
+3. Commit the screenshots to `ecosystem-explorer/screenshots/` on your PR branch
+
+The workflow re-runs automatically on new commits while the label is present.
+
+### Local Screenshots
+
+You can also generate screenshots locally:
+
+```bash
+cd ecosystem-explorer
+bun install
+bun run build
+bunx playwright install --with-deps chromium
+node scripts/take-screenshots.mjs
+# Screenshots are saved to ecosystem-explorer/screenshots/
+```
+
 ## Contributing Rules
 
 ### AI Usage

--- a/ecosystem-explorer/bun.lock
+++ b/ecosystem-explorer/bun.lock
@@ -32,6 +32,7 @@
         "fake-indexeddb": "6.2.5",
         "globals": "17.4.0",
         "jsdom": "29.0.2",
+        "playwright": "^1.59.1",
         "postcss": "8.5.9",
         "prettier": "3.8.2",
         "tailwindcss": "4.2.2",
@@ -456,7 +457,7 @@
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -577,6 +578,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -723,5 +728,7 @@
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
   }
 }

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -50,6 +50,7 @@
     "fake-indexeddb": "6.2.5",
     "globals": "17.4.0",
     "jsdom": "29.0.2",
+    "playwright": "^1.59.1",
     "postcss": "8.5.9",
     "prettier": "3.8.2",
     "tailwindcss": "4.2.2",

--- a/ecosystem-explorer/scripts/take-screenshots.mjs
+++ b/ecosystem-explorer/scripts/take-screenshots.mjs
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { chromium } from "playwright";
+import http from "http";
+import fs from "fs";
+import path from "path";
+
+const DIST_DIR = path.resolve("dist");
+const SCREENSHOTS_DIR = path.resolve("screenshots");
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+// Pick an instrumentation known to have telemetry and configuration data
+const DETAIL_VERSION = "2.25.0";
+const DETAIL_NAME = "spring-webmvc-6.0";
+
+async function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = req.url.split("?")[0];
+      let filePath = path.join(DIST_DIR, urlPath);
+
+      // Serve index.html for the root path
+      if (urlPath === "/") {
+        filePath = path.join(DIST_DIR, "index.html");
+      }
+
+      // If the file doesn't exist on disk, fall back to index.html for SPA routing
+      if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+        filePath = path.join(DIST_DIR, "index.html");
+      }
+
+      const ext = path.extname(filePath);
+      const contentTypes = {
+        ".html": "text/html",
+        ".js": "application/javascript",
+        ".css": "text/css",
+        ".json": "application/json",
+        ".png": "image/png",
+        ".svg": "image/svg+xml",
+        ".ico": "image/x-icon",
+      };
+
+      res.writeHead(200, {
+        "Content-Type": contentTypes[ext] || "application/octet-stream",
+      });
+      fs.createReadStream(filePath).pipe(res);
+    });
+
+    server.listen(PORT, () => {
+      console.log(`Server listening on ${BASE_URL}`);
+      resolve(server);
+    });
+  });
+}
+
+async function takeScreenshots() {
+  const server = await startServer();
+  let browser;
+
+  try {
+    const startTime = Date.now();
+    const logTime = (label) =>
+      console.log(`[${((Date.now() - startTime) / 1000).toFixed(1)}s] ${label}`);
+
+    logTime("Launching browser...");
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 1800, height: 1200 });
+
+    // Block external requests that can cause timeouts
+    await page.route("**/*", (route) => {
+      const url = route.request().url();
+      if (
+        url.includes("googletagmanager.com") ||
+        url.includes("google-analytics.com") ||
+        url.includes("fonts.googleapis.com") ||
+        url.includes("fonts.gstatic.com")
+      ) {
+        route.abort();
+      } else {
+        route.continue();
+      }
+    });
+
+    logTime("Browser ready");
+
+    // 1. Home page
+    logTime("Taking home page screenshot...");
+    await page.goto(BASE_URL, { waitUntil: "domcontentloaded", timeout: 10000 });
+    await page.waitForSelector("h1", { state: "visible", timeout: 5000 });
+    await page.screenshot({ path: path.join(SCREENSHOTS_DIR, "home.png") });
+    logTime("Home page screenshot done");
+
+    // 2. Java agent instrumentation list
+    logTime("Taking instrumentation list screenshot...");
+    await page.goto(`${BASE_URL}/java-agent/instrumentation`, {
+      waitUntil: "domcontentloaded",
+      timeout: 10000,
+    });
+    await page.waitForFunction(
+      () => document.body.textContent.includes("Showing"),
+      { timeout: 15000 }
+    );
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, "instrumentation-list.png"),
+    });
+    logTime("Instrumentation list screenshot done");
+
+    // 3. Java agent instrumentation detail - Details tab
+    logTime("Taking instrumentation detail screenshots...");
+    const detailUrl = `${BASE_URL}/java-agent/instrumentation/${DETAIL_VERSION}/${DETAIL_NAME}`;
+    await page.goto(detailUrl, {
+      waitUntil: "domcontentloaded",
+      timeout: 10000,
+    });
+    await page.waitForSelector('[role="tablist"]', {
+      state: "visible",
+      timeout: 10000,
+    });
+    // Details tab is active by default
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, "detail-details.png"),
+      fullPage: true,
+    });
+    logTime("Details tab screenshot done");
+
+    // 4. Telemetry tab
+    await page.getByRole("tab", { name: "Telemetry" }).click();
+    await page.waitForSelector('[role="tabpanel"][data-state="active"]', {
+      state: "visible",
+      timeout: 5000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, "detail-telemetry.png"),
+      fullPage: true,
+    });
+    logTime("Telemetry tab screenshot done");
+
+    // 5. Configuration tab
+    await page.getByRole("tab", { name: "Configuration" }).click();
+    await page.waitForSelector('[role="tabpanel"][data-state="active"]', {
+      state: "visible",
+      timeout: 5000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, "detail-configuration.png"),
+      fullPage: true,
+    });
+    logTime("Configuration tab screenshot done");
+
+    logTime("All screenshots completed successfully!");
+  } catch (error) {
+    console.error("Error during screenshot process:", error);
+    throw error;
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+takeScreenshots();

--- a/ecosystem-explorer/scripts/take-screenshots.mjs
+++ b/ecosystem-explorer/scripts/take-screenshots.mjs
@@ -18,8 +18,17 @@ const DETAIL_NAME = "spring-webmvc-6.0";
 async function startServer() {
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
-      const urlPath = req.url.split("?")[0];
-      let filePath = path.join(DIST_DIR, urlPath);
+      const urlPath = decodeURIComponent(req.url.split("?")[0]);
+
+      // Resolve the requested path and ensure it stays within DIST_DIR
+      const resolvedPath = path.resolve(DIST_DIR, urlPath.replace(/^\/+/, ""));
+      if (!resolvedPath.startsWith(DIST_DIR)) {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+
+      let filePath = resolvedPath;
 
       // Serve index.html for the root path
       if (urlPath === "/") {
@@ -70,18 +79,23 @@ async function takeScreenshots() {
     await page.setViewportSize({ width: 1800, height: 1200 });
 
     // Block external requests that can cause timeouts
+    const BLOCKED_HOSTS = new Set([
+      "googletagmanager.com",
+      "google-analytics.com",
+      "fonts.googleapis.com",
+      "fonts.gstatic.com",
+    ]);
     await page.route("**/*", (route) => {
-      const url = route.request().url();
-      if (
-        url.includes("googletagmanager.com") ||
-        url.includes("google-analytics.com") ||
-        url.includes("fonts.googleapis.com") ||
-        url.includes("fonts.gstatic.com")
-      ) {
-        route.abort();
-      } else {
-        route.continue();
+      try {
+        const hostname = new URL(route.request().url()).hostname;
+        if (BLOCKED_HOSTS.has(hostname) || [...BLOCKED_HOSTS].some((h) => hostname.endsWith(`.${h}`))) {
+          route.abort();
+          return;
+        }
+      } catch {
+        // If URL parsing fails, allow the request
       }
+      route.continue();
     });
 
     logTime("Browser ready");


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that captures screenshots of key Explorer pages when a PR is labeled with `add-screenshots`
- Creates a Playwright script that navigates the built app and screenshots: home page, instrumentation list, and instrumentation detail page (Details, Telemetry, and Configuration tabs)
- Screenshots are committed to `ecosystem-explorer/screenshots/` on the PR branch, enabling visual review of UI changes
- Workflow re-runs automatically on new commits while the label is present
- Closes #182

## Test plan
- [x] Ran screenshot script locally — all 5 screenshots generated successfully
- [x] Tested in fork by creating a PR and adding `add-screenshots` label — workflow triggered and screenshots committed
- [x] All 287 JS tests pass (`bun run test`)
- [x] All 20 integration tests pass (`bun run test:integration`)
- [x] ESLint, TypeScript typecheck, ruff, markdown lint, copyright headers all pass