### PR TITLE
fix: snapshot cleanup runs after successful fetch and parse

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -285,9 +285,9 @@ class CollectorSync:
         Update or create the SNAPSHOT version for a distribution.
 
         This:
-        1. Cleans up old snapshots
-        2. Determines next snapshot version
-        3. Scans main branch
+        1. Determines next snapshot version
+        2. Scans main branch
+        3. Cleans up old snapshots
         4. Saves as new snapshot
 
         Args:
@@ -298,18 +298,19 @@ class CollectorSync:
         """
         detector = self.version_detectors[distribution]
 
-        logger.info("")
-        logger.info("Cleaning up old %s snapshots...", distribution)
-        removed = self.inventory_manager.cleanup_snapshots(distribution)
-        if removed > 0:
-            logger.info("  Removed %d old snapshot(s)", removed)
-
         snapshot_version = detector.determine_next_snapshot_version()
         logger.info("")
         logger.info("Updating %s %s...", distribution, snapshot_version)
 
         self.initialize_previous_version(distribution)
         components = self.scan_version(distribution, snapshot_version, checkout=True)
+
+        logger.info("")
+        logger.info("Cleaning up old %s snapshots...", distribution)
+        removed = self.inventory_manager.cleanup_snapshots(distribution)
+        if removed > 0:
+            logger.info("  Removed %d old snapshot(s)", removed)
+
         self.save_version(distribution, snapshot_version, components)
         self.detect_and_track_deprecations(distribution, snapshot_version, components)
 

--- a/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
+++ b/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
@@ -101,21 +101,14 @@ class ConfigurationSync:
         Update or create the SNAPSHOT version.
 
         This:
-        1. Cleans up old snapshots
-        2. Determines next snapshot version
-        3. Checks out main branch
-        4. Copies schema files
-        5. Saves as new snapshot
+        1. Determines next snapshot version
+        2. Checks out main branch
+        3. Copies schema files
+        4. Cleans up old snapshots
 
         Returns:
             Snapshot version that was created
         """
-        logger.info("")
-        logger.info("Cleaning up old snapshots...")
-        removed = self.inventory_manager.cleanup_snapshots()
-        if removed > 0:
-            logger.info("  Removed %d old snapshot(s)", removed)
-
         snapshot_version = self.version_detector.determine_next_snapshot_version()
         logger.info("")
         logger.info("Updating %s...", snapshot_version)
@@ -123,6 +116,12 @@ class ConfigurationSync:
         self.version_detector.checkout_main()
         copied = self.copy_schemas_to_inventory(snapshot_version)
         logger.info("  Copied %d schema files", len(copied))
+
+        logger.info("")
+        logger.info("Cleaning up old snapshots...")
+        removed = self.inventory_manager.cleanup_snapshots()
+        if removed > 0:
+            logger.info("  Removed %d old snapshot(s)", removed)
 
         return snapshot_version
 

--- a/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
+++ b/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
@@ -103,8 +103,8 @@ class ConfigurationSync:
         This:
         1. Determines next snapshot version
         2. Checks out main branch
-        3. Copies schema files
-        4. Cleans up old snapshots
+        3. Cleans up old snapshots
+        4. Copies schema files
 
         Returns:
             Snapshot version that was created
@@ -114,14 +114,15 @@ class ConfigurationSync:
         logger.info("Updating %s...", snapshot_version)
 
         self.version_detector.checkout_main()
-        copied = self.copy_schemas_to_inventory(snapshot_version)
-        logger.info("  Copied %d schema files", len(copied))
 
         logger.info("")
         logger.info("Cleaning up old snapshots...")
         removed = self.inventory_manager.cleanup_snapshots()
         if removed > 0:
             logger.info("  Removed %d old snapshot(s)", removed)
+
+        copied = self.copy_schemas_to_inventory(snapshot_version)
+        logger.info("  Copied %d schema files", len(copied))
 
         return snapshot_version
 

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
@@ -104,18 +104,14 @@ class InstrumentationSync:
         Update snapshot version from main branch.
 
         This will:
-        1. Clean up old snapshots
-        2. Determine next snapshot version
-        3. Fetch from main branch
+        1. Determine next snapshot version
+        2. Fetch from main branch
+        3. Clean up old snapshots
         4. Save new snapshot
 
         Returns:
             The snapshot version
         """
-        removed = self.inventory_manager.cleanup_snapshots()
-        if removed > 0:
-            logger.info(f"  Removed {removed} old snapshot(s)")
-
         latest_release_tag = self.client.get_latest_release_tag()
         latest_release = Version(latest_release_tag.lstrip("v"))
 
@@ -130,6 +126,10 @@ class InstrumentationSync:
         logger.info("  Fetching instrumentation list from main branch...")
         yaml_content = self.client.fetch_instrumentation_list(ref="main")
         instrumentations = parse_instrumentation_yaml(yaml_content)
+
+        removed = self.inventory_manager.cleanup_snapshots()
+        if removed > 0:
+            logger.info(f"  Removed {removed} old snapshot(s)")
 
         self.inventory_manager.save_versioned_inventory(
             version=snapshot_version,

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
@@ -171,6 +171,21 @@ instrumentations:
         with pytest.raises(ValueError, match="Error parsing instrumentation YAML"):
             sync.update_snapshot()
 
+    def test_update_snapshot_parse_failure_preserves_existing_snapshot(self, sync, mock_client, inventory_manager):
+        existing = Version("2.9.1-SNAPSHOT")
+        inventory_manager.save_versioned_inventory(
+            version=existing,
+            instrumentations={"file_format": 0.1, "libraries": []},
+        )
+
+        mock_client.get_latest_release_tag.return_value = "v2.10.0"
+        mock_client.fetch_instrumentation_list.return_value = "malformed: [yaml"
+
+        with pytest.raises(ValueError):
+            sync.update_snapshot()
+
+        assert inventory_manager.version_exists(existing)
+
     def test_parse_cleans_whitespace(self, sync, mock_client):
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
         mock_client.fetch_instrumentation_list.return_value = """


### PR DESCRIPTION
`cleanup_snapshots()` was called before fetch and parse in all three watchers. If parsing failed, the old snapshot was already deleted but the new one was never written, causing the nightly update to commit the deletion.

Moved cleanup to after fetch and parse succeed so a failed run is a no-op.

Fixes #255