### PR TITLE
fix(explorer): improve tab styling with segmented control

### DIFF
--- a/ecosystem-explorer/src/components/ui/segmented-tabs.test.tsx
+++ b/ecosystem-explorer/src/components/ui/segmented-tabs.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { Tabs, TabsContent } from "./tabs";
+import { SegmentedTabList } from "./segmented-tabs";
+
+function ControlledTabs({ defaultValue = "tab1" }: { defaultValue?: string }) {
+  return (
+    <Tabs defaultValue={defaultValue}>
+      <SegmentedTabList
+        value={defaultValue}
+        tabs={[
+          { value: "tab1", label: "Tab 1" },
+          { value: "tab2", label: "Tab 2" },
+        ]}
+      />
+      <TabsContent value="tab1">Content 1</TabsContent>
+      <TabsContent value="tab2">Content 2</TabsContent>
+    </Tabs>
+  );
+}
+
+describe("SegmentedTabList", () => {
+  it("renders tabs with correct roles and labels", () => {
+    render(<ControlledTabs />);
+
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tab 1" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tab 2" })).toBeInTheDocument();
+  });
+
+  it("displays the default tab content", () => {
+    render(<ControlledTabs />);
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveTextContent("Content 1");
+  });
+
+  it("switches tab content when clicking a different tab", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledTabs />);
+
+    await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveTextContent("Content 2");
+  });
+
+  it("updates data-state attributes on tab triggers", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledTabs />);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    const tab2 = screen.getByRole("tab", { name: "Tab 2" });
+
+    expect(tab1).toHaveAttribute("data-state", "active");
+    expect(tab2).toHaveAttribute("data-state", "inactive");
+
+    await user.click(tab2);
+
+    expect(tab1).toHaveAttribute("data-state", "inactive");
+    expect(tab2).toHaveAttribute("data-state", "active");
+  });
+
+  it("supports keyboard navigation with arrow keys", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledTabs />);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    tab1.focus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveFocus();
+  });
+
+  it("renders icons when provided", () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <SegmentedTabList
+          value="tab1"
+          tabs={[
+            {
+              value: "tab1",
+              label: "Details",
+              icon: <svg data-testid="icon-details" aria-hidden="true" />,
+            },
+            { value: "tab2", label: "Settings" },
+          ]}
+        />
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByTestId("icon-details")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Details" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Settings" })).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/components/ui/segmented-tabs.tsx
+++ b/ecosystem-explorer/src/components/ui/segmented-tabs.tsx
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useRef, useLayoutEffect, useCallback, useEffect, type JSX } from "react";
+import { useState, useRef, useLayoutEffect, useCallback, useEffect, type ReactNode } from "react";
 import * as RadixTabs from "@radix-ui/react-tabs";
 
 interface TabItem {
   value: string;
   label: string;
-  icon?: JSX.Element;
+  icon?: ReactNode;
 }
 
 interface SegmentedTabListProps {
@@ -78,11 +78,9 @@ export function SegmentedTabList({ tabs, value }: SegmentedTabListProps) {
           ref={(el) => {
             buttonRefs.current[tab.value] = el;
           }}
-          className={`relative z-10 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200 ${
-            value === tab.value ? "text-primary" : "text-muted-foreground hover:text-foreground"
-          }`}
+          className="relative z-10 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200 data-[state=active]:text-primary data-[state=inactive]:text-muted-foreground"
         >
-          {tab.icon && tab.icon}
+          {tab.icon}
           {tab.label}
         </RadixTabs.Trigger>
       ))}

--- a/ecosystem-explorer/src/components/ui/tabs.test.tsx
+++ b/ecosystem-explorer/src/components/ui/tabs.test.tsx
@@ -15,164 +15,43 @@
  */
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
+import { Tabs, TabsContent } from "./tabs";
+import { SegmentedTabList } from "./segmented-tabs";
 
 describe("Tabs", () => {
-  it("renders tabs with correct roles and ARIA attributes", () => {
+  it("renders tab content with correct role", () => {
     render(
       <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-        </TabsList>
+        <SegmentedTabList
+          value="tab1"
+          tabs={[
+            { value: "tab1", label: "Tab 1" },
+            { value: "tab2", label: "Tab 2" },
+          ]}
+        />
         <TabsContent value="tab1">Content 1</TabsContent>
         <TabsContent value="tab2">Content 2</TabsContent>
       </Tabs>
     );
 
-    expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Tab 1" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Tab 2" })).toBeInTheDocument();
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveTextContent("Content 1");
+    expect(panel).toHaveAttribute("data-state", "active");
   });
 
-  it("displays the default tab content", () => {
+  it("applies custom className to TabsContent", () => {
     render(
       <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-        </TabsList>
-        <TabsContent value="tab1">Content 1</TabsContent>
-        <TabsContent value="tab2">Content 2</TabsContent>
-      </Tabs>
-    );
-
-    const tab1Panel = screen.getByRole("tabpanel");
-    expect(tab1Panel).toHaveTextContent("Content 1");
-    expect(tab1Panel).toHaveAttribute("data-state", "active");
-    expect(tab1Panel).not.toHaveAttribute("hidden");
-  });
-
-  it("switches tab content when clicking a different tab", async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-        </TabsList>
-        <TabsContent value="tab1">Content 1</TabsContent>
-        <TabsContent value="tab2">Content 2</TabsContent>
-      </Tabs>
-    );
-
-    const tab2 = screen.getByRole("tab", { name: "Tab 2" });
-    await user.click(tab2);
-
-    const activePanel = screen.getByRole("tabpanel");
-    expect(activePanel).toHaveTextContent("Content 2");
-    expect(activePanel).toHaveAttribute("data-state", "active");
-  });
-
-  it("updates data-state attribute on tab triggers", async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-        </TabsList>
-        <TabsContent value="tab1">Content 1</TabsContent>
-        <TabsContent value="tab2">Content 2</TabsContent>
-      </Tabs>
-    );
-
-    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
-    const tab2 = screen.getByRole("tab", { name: "Tab 2" });
-
-    expect(tab1).toHaveAttribute("data-state", "active");
-    expect(tab2).toHaveAttribute("data-state", "inactive");
-
-    await user.click(tab2);
-
-    expect(tab1).toHaveAttribute("data-state", "inactive");
-    expect(tab2).toHaveAttribute("data-state", "active");
-  });
-
-  it("updates aria-selected attribute when switching tabs", async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-        </TabsList>
-        <TabsContent value="tab1">Content 1</TabsContent>
-        <TabsContent value="tab2">Content 2</TabsContent>
-      </Tabs>
-    );
-
-    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
-    const tab2 = screen.getByRole("tab", { name: "Tab 2" });
-
-    expect(tab1).toHaveAttribute("aria-selected", "true");
-    expect(tab2).toHaveAttribute("aria-selected", "false");
-
-    await user.click(tab2);
-
-    expect(tab1).toHaveAttribute("aria-selected", "false");
-    expect(tab2).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("supports keyboard navigation with arrow keys", async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-          <TabsTrigger value="tab3">Tab 3</TabsTrigger>
-        </TabsList>
-        <TabsContent value="tab1">Content 1</TabsContent>
-        <TabsContent value="tab2">Content 2</TabsContent>
-        <TabsContent value="tab3">Content 3</TabsContent>
-      </Tabs>
-    );
-
-    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
-    tab1.focus();
-
-    await user.keyboard("{ArrowRight}");
-    expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
-
-    await user.keyboard("{ArrowRight}");
-    expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
-
-    await user.keyboard("{ArrowLeft}");
-    expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
-  });
-
-  it("applies custom className to components", () => {
-    render(
-      <Tabs defaultValue="tab1">
-        <TabsList className="custom-list">
-          <TabsTrigger value="tab1" className="custom-trigger">
-            Tab 1
-          </TabsTrigger>
-        </TabsList>
+        <SegmentedTabList
+          value="tab1"
+          tabs={[{ value: "tab1", label: "Tab 1" }]}
+        />
         <TabsContent value="tab1" className="custom-content">
           Content 1
         </TabsContent>
       </Tabs>
     );
 
-    expect(screen.getByRole("tablist")).toHaveClass("custom-list");
-    expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveClass("custom-trigger");
     expect(screen.getByText("Content 1")).toHaveClass("custom-content");
   });
 });

--- a/ecosystem-explorer/src/components/ui/tabs.tsx
+++ b/ecosystem-explorer/src/components/ui/tabs.tsx
@@ -19,30 +19,6 @@ import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 const Tabs = RadixTabs.Root;
 
-const TabsList = forwardRef<
-  ComponentRef<typeof RadixTabs.List>,
-  ComponentPropsWithoutRef<typeof RadixTabs.List>
->(({ className = "", ...props }, ref) => (
-  <RadixTabs.List
-    ref={ref}
-    className={`inline-flex h-12 items-center justify-center rounded-lg border border-border/50 bg-card/80 p-1 ${className}`}
-    {...props}
-  />
-));
-TabsList.displayName = RadixTabs.List.displayName;
-
-const TabsTrigger = forwardRef<
-  ComponentRef<typeof RadixTabs.Trigger>,
-  ComponentPropsWithoutRef<typeof RadixTabs.Trigger>
->(({ className = "", ...props }, ref) => (
-  <RadixTabs.Trigger
-    ref={ref}
-    className={`inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-t-md border-t border-transparent px-6 py-3 text-sm font-medium text-muted-foreground ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:text-foreground hover:bg-card-secondary/60 data-[state=active]:border-primary data-[state=active]:bg-card-secondary data-[state=active]:text-primary data-[state=active]:font-semibold data-[state=active]:shadow-[0_2px_12px_-2px_hsl(var(--primary-hsl)/0.4)] ${className}`}
-    {...props}
-  />
-));
-TabsTrigger.displayName = RadixTabs.Trigger.displayName;
-
 const TabsContent = forwardRef<
   ComponentRef<typeof RadixTabs.Content>,
   ComponentPropsWithoutRef<typeof RadixTabs.Content>
@@ -55,4 +31,4 @@ const TabsContent = forwardRef<
 ));
 TabsContent.displayName = RadixTabs.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent };

--- a/ecosystem-explorer/src/features/java-agent/components/segmented-tabs.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/segmented-tabs.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useRef, useLayoutEffect, useCallback, type JSX } from "react";
+import { useState, useRef, useLayoutEffect, useCallback, useEffect, type JSX } from "react";
 import * as RadixTabs from "@radix-ui/react-tabs";
 
 interface TabItem {
@@ -24,45 +24,48 @@ interface TabItem {
 
 interface SegmentedTabListProps {
   tabs: TabItem[];
-  defaultValue: string;
+  value: string;
 }
 
-export function SegmentedTabList({ tabs, defaultValue }: SegmentedTabListProps) {
-  const [activeTab, setActiveTab] = useState(defaultValue);
+export function SegmentedTabList({ tabs, value }: SegmentedTabListProps) {
   const [pillStyle, setPillStyle] = useState<{ left: number; width: number }>({
     left: 0,
     width: 0,
   });
+  const listRef = useRef<HTMLDivElement | null>(null);
   const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
   const measurePill = useCallback(() => {
-    const el = buttonRefs.current[activeTab];
+    const el = buttonRefs.current[value];
     if (el) {
       setPillStyle({ left: el.offsetLeft, width: el.offsetWidth });
     }
-  }, [activeTab]);
+  }, [value]);
 
   useLayoutEffect(() => {
     measurePill();
   }, [measurePill]);
 
+  useEffect(() => {
+    const listEl = listRef.current;
+    if (!listEl || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measurePill());
+    observer.observe(listEl);
+    return () => observer.disconnect();
+  }, [measurePill]);
+
   return (
     <RadixTabs.List
-      className="relative inline-flex items-center rounded-xl p-1"
-      style={{
-        background: "oklch(0.22 0.035 260 / 0.8)",
-        border: "1px solid oklch(1 0 0 / 0.08)",
-      }}
+      ref={listRef}
+      className="relative inline-flex items-center rounded-xl border border-border/50 bg-muted/80 p-1"
     >
       {/* Sliding pill */}
       <span
-        className="absolute top-1 bottom-1 rounded-lg"
+        className="absolute top-1 bottom-1 rounded-lg border border-primary/40 bg-primary/12"
         aria-hidden="true"
         style={{
           left: pillStyle.left,
           width: pillStyle.width,
-          background: "oklch(0.78 0.16 75 / 0.12)",
-          border: "1px solid oklch(0.78 0.16 75 / 0.4)",
           transition:
             "left 300ms cubic-bezier(0.22, 1, 0.36, 1), width 300ms cubic-bezier(0.22, 1, 0.36, 1)",
         }}
@@ -75,11 +78,9 @@ export function SegmentedTabList({ tabs, defaultValue }: SegmentedTabListProps) 
           ref={(el) => {
             buttonRefs.current[tab.value] = el;
           }}
-          onClick={() => setActiveTab(tab.value)}
           className={`relative z-10 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200 ${
-            activeTab === tab.value ? "" : "text-muted-foreground hover:text-foreground"
+            value === tab.value ? "text-primary" : "text-muted-foreground hover:text-foreground"
           }`}
-          style={activeTab === tab.value ? { color: "oklch(0.78 0.16 75)" } : undefined}
         >
           {tab.icon && tab.icon}
           {tab.label}

--- a/ecosystem-explorer/src/features/java-agent/components/segmented-tabs.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/segmented-tabs.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, useRef, useLayoutEffect, useCallback, type JSX } from "react";
+import * as RadixTabs from "@radix-ui/react-tabs";
+
+interface TabItem {
+  value: string;
+  label: string;
+  icon?: JSX.Element;
+}
+
+interface SegmentedTabListProps {
+  tabs: TabItem[];
+  defaultValue: string;
+}
+
+export function SegmentedTabList({ tabs, defaultValue }: SegmentedTabListProps) {
+  const [activeTab, setActiveTab] = useState(defaultValue);
+  const [pillStyle, setPillStyle] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+  const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const measurePill = useCallback(() => {
+    const el = buttonRefs.current[activeTab];
+    if (el) {
+      setPillStyle({ left: el.offsetLeft, width: el.offsetWidth });
+    }
+  }, [activeTab]);
+
+  useLayoutEffect(() => {
+    measurePill();
+  }, [measurePill]);
+
+  return (
+    <RadixTabs.List
+      className="relative inline-flex items-center rounded-xl p-1"
+      style={{
+        background: "oklch(0.22 0.035 260 / 0.8)",
+        border: "1px solid oklch(1 0 0 / 0.08)",
+      }}
+    >
+      {/* Sliding pill */}
+      <span
+        className="absolute top-1 bottom-1 rounded-lg"
+        aria-hidden="true"
+        style={{
+          left: pillStyle.left,
+          width: pillStyle.width,
+          background: "oklch(0.78 0.16 75 / 0.12)",
+          border: "1px solid oklch(0.78 0.16 75 / 0.4)",
+          transition:
+            "left 300ms cubic-bezier(0.22, 1, 0.36, 1), width 300ms cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+      />
+
+      {tabs.map((tab) => (
+        <RadixTabs.Trigger
+          key={tab.value}
+          value={tab.value}
+          ref={(el) => {
+            buttonRefs.current[tab.value] = el;
+          }}
+          onClick={() => setActiveTab(tab.value)}
+          className={`relative z-10 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200 ${
+            activeTab === tab.value ? "" : "text-muted-foreground hover:text-foreground"
+          }`}
+          style={activeTab === tab.value ? { color: "oklch(0.78 0.16 75)" } : undefined}
+        >
+          {tab.icon && tab.icon}
+          {tab.label}
+        </RadixTabs.Trigger>
+      ))}
+    </RadixTabs.List>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -16,7 +16,7 @@
 import { useMemo, useState } from "react";
 import { BackButton } from "@/components/ui/back-button";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import { SegmentedTabList } from "../components/segmented-tabs";
+import { SegmentedTabList } from "@/components/ui/segmented-tabs";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import {
   useConfigVersions,

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -15,7 +15,8 @@
  */
 import { useMemo, useState } from "react";
 import { BackButton } from "@/components/ui/back-button";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+import { SegmentedTabList } from "../components/segmented-tabs";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import {
   useConfigVersions,
@@ -84,6 +85,7 @@ export function ConfigurationBuilderPage() {
   );
   const [currentVersion, setCurrentVersion] = useState<string>("");
   const version = currentVersion || latest;
+  const [activeTab, setActiveTab] = useState("sdk");
 
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
@@ -97,11 +99,14 @@ export function ConfigurationBuilderPage() {
             Build and customize your OpenTelemetry Java Agent configuration
           </p>
         </div>
-        <Tabs defaultValue="sdk">
-          <TabsList>
-            <TabsTrigger value="sdk">SDK</TabsTrigger>
-            <TabsTrigger value="instrumentation">Instrumentation</TabsTrigger>
-          </TabsList>
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <SegmentedTabList
+            value={activeTab}
+            tabs={[
+              { value: "sdk", label: "SDK" },
+              { value: "instrumentation", label: "Instrumentation" },
+            ]}
+          />
           <TabsContent value="sdk">
             <div className="mt-4 flex items-center justify-end">
               {versions.data && version ? (

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import { BackButton } from "@/components/ui/back-button";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import { SegmentedTabList } from "./components/segmented-tabs";
+import { SegmentedTabList } from "@/components/ui/segmented-tabs";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SectionHeader } from "@/components/ui/section-header";

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useParams, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   Info,
   Activity,
@@ -54,6 +54,7 @@ function buildSourceUrl(sourcePath: string): string {
 export function InstrumentationDetailPage() {
   const { version, name } = useParams<{ version: string; name: string }>();
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState("details");
 
   const { data: versionsData, loading: versionsLoading } = useVersions();
 
@@ -233,10 +234,10 @@ export function InstrumentationDetailPage() {
             />
           </div>
 
-          <Tabs defaultValue="details" className="relative z-10">
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="relative z-10">
             <div className="px-6 pt-4 pb-0">
               <SegmentedTabList
-                defaultValue="details"
+                value={activeTab}
                 tabs={[
                   {
                     value: "details",
@@ -257,7 +258,7 @@ export function InstrumentationDetailPage() {
               />
             </div>
 
-            <TabsContent value="details" className="p-6">
+            <TabsContent value="details" className="mt-0 p-6">
               <div className="space-y-8">
                 {/* Links & Resources Section */}
                 {(instrumentation.library_link || instrumentation.source_path) && (
@@ -460,7 +461,7 @@ export function InstrumentationDetailPage() {
               </div>
             </TabsContent>
 
-            <TabsContent value="telemetry" className="p-6">
+            <TabsContent value="telemetry" className="mt-0 p-6">
               {instrumentation.telemetry && instrumentation.telemetry.length > 0 ? (
                 <TelemetrySection telemetry={instrumentation.telemetry} />
               ) : (
@@ -478,7 +479,7 @@ export function InstrumentationDetailPage() {
               )}
             </TabsContent>
 
-            <TabsContent value="configuration" className="p-6">
+            <TabsContent value="configuration" className="mt-0 p-6">
               {instrumentation.configurations && instrumentation.configurations.length > 0 ? (
                 <div className="grid gap-4 md:grid-cols-2">
                   {instrumentation.configurations.map((config) => (

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -26,7 +26,8 @@ import {
   Loader2,
 } from "lucide-react";
 import { BackButton } from "@/components/ui/back-button";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+import { SegmentedTabList } from "./components/segmented-tabs";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SectionHeader } from "@/components/ui/section-header";
@@ -233,21 +234,27 @@ export function InstrumentationDetailPage() {
           </div>
 
           <Tabs defaultValue="details" className="relative z-10">
-            <div className="bg-card/60 px-6 pt-4 border-b border-border/30">
-              <TabsList className="bg-transparent border-0 h-auto p-0 -mb-px">
-                <TabsTrigger value="details">
-                  <Info className="h-4 w-4" aria-hidden="true" />
-                  Details
-                </TabsTrigger>
-                <TabsTrigger value="telemetry">
-                  <Activity className="h-4 w-4" aria-hidden="true" />
-                  Telemetry
-                </TabsTrigger>
-                <TabsTrigger value="configuration">
-                  <Settings className="h-4 w-4" aria-hidden="true" />
-                  Configuration
-                </TabsTrigger>
-              </TabsList>
+            <div className="px-6 pt-4 pb-0">
+              <SegmentedTabList
+                defaultValue="details"
+                tabs={[
+                  {
+                    value: "details",
+                    label: "Details",
+                    icon: <Info className="h-4 w-4" aria-hidden="true" />,
+                  },
+                  {
+                    value: "telemetry",
+                    label: "Telemetry",
+                    icon: <Activity className="h-4 w-4" aria-hidden="true" />,
+                  },
+                  {
+                    value: "configuration",
+                    label: "Configuration",
+                    icon: <Settings className="h-4 w-4" aria-hidden="true" />,
+                  },
+                ]}
+              />
             </div>
 
             <TabsContent value="details" className="p-6">


### PR DESCRIPTION
## Summary
- Replaces the default tab navigation with a segmented control featuring a sliding pill indicator on both the instrumentation detail page and configuration builder page
- Removes the unwanted glow/shadow on the active tab and unnecessary margin between tabs and content
- Active tab uses an amber highlight with smooth 300ms sliding animation between tabs

Closes #226

## Test plan
- [x] All 366 JS tests pass (`bun run test`)
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] ESLint passes (`bun run lint`)
- [x] Prettier passes on changed files (`bun run format:check`)
- [x] Copyright headers valid
- [x] Verified instrumentation detail page tabs (Details, Telemetry, Configuration) render correctly
- [x] Verified configuration builder page tabs (SDK, Instrumentation) render correctly
- [x] Sliding pill animates smoothly between tabs
- [x] Keyboard navigation works (arrow keys between tabs)