### PR TITLE
Configuration Schema Browser

### DIFF
--- a/ecosystem-explorer/public/data/configuration/versions/1.0.0.starter.json
+++ b/ecosystem-explorer/public/data/configuration/versions/1.0.0.starter.json
@@ -1,0 +1,26 @@
+{
+  "enabledSections": {
+    "resource": true,
+    "tracer_provider": true,
+    "meter_provider": true,
+    "logger_provider": true,
+    "propagator": true
+  },
+  "values": {
+    "resource": {
+      "attributes": [{ "name": "service.name", "value": "unknown_service" }]
+    },
+    "tracer_provider": {
+      "processors": [{ "batch": { "exporter": { "otlp_http": {} } } }]
+    },
+    "meter_provider": {
+      "readers": [{ "periodic": { "exporter": { "otlp_http": {} } } }]
+    },
+    "logger_provider": {
+      "processors": [{ "batch": { "exporter": { "otlp_http": {} } } }]
+    },
+    "propagator": {
+      "composite": [{ "tracecontext": {} }, { "baggage": {} }]
+    }
+  }
+}

--- a/ecosystem-explorer/src/App.tsx
+++ b/ecosystem-explorer/src/App.tsx
@@ -36,7 +36,10 @@ export default function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/java-agent" element={<JavaAgentPage />} />
             <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
-            <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
+            <Route
+              path="/java-agent/instrumentation/:version"
+              element={<JavaInstrumentationListPage />}
+            />
             <Route
               path="/java-agent/instrumentation/:version/:name"
               element={<InstrumentationDetailPage />}

--- a/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 import { ChevronDown } from "lucide-react";
-
-interface VersionInfoLike {
-  version: string;
-  is_latest: boolean;
-}
+import type { VersionInfo } from "@/types/javaagent";
 
 interface VersionSelectorProps {
-  versions: VersionInfoLike[];
+  versions: VersionInfo[];
   currentVersion: string;
   onVersionChange: (version: string) => void;
   label?: string;

--- a/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/version-selector.tsx
@@ -14,30 +14,43 @@
  * limitations under the License.
  */
 import { ChevronDown } from "lucide-react";
-import type { VersionInfo } from "@/types/javaagent";
 
-interface VersionSelectorProps {
-  versions: VersionInfo[];
-  currentVersion: string;
-  onVersionChange: (version: string) => void;
+interface VersionInfoLike {
+  version: string;
+  is_latest: boolean;
 }
 
-export function VersionSelector({ versions, currentVersion, onVersionChange }: VersionSelectorProps) {
+interface VersionSelectorProps {
+  versions: VersionInfoLike[];
+  currentVersion: string;
+  onVersionChange: (version: string) => void;
+  label?: string;
+  id?: string;
+}
+
+export function VersionSelector({
+  versions,
+  currentVersion,
+  onVersionChange,
+  label = "Version",
+  id = "version-select",
+}: VersionSelectorProps) {
   return (
     <div className="flex items-center gap-2">
-      <label htmlFor="version-select" className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-        Version
+      <label htmlFor={id} className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+        {label}
       </label>
       <div className="relative">
         <select
-          id="version-select"
+          id={id}
           value={currentVersion}
           onChange={(e) => onVersionChange(e.target.value)}
           className="appearance-none rounded-lg border border-border/60 bg-background/80 pl-3 pr-8 py-1.5 text-sm font-medium backdrop-blur-sm transition-all duration-200 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 cursor-pointer"
         >
           {versions.map((v) => (
             <option key={v.version} value={v.version}>
-              {v.version}{v.is_latest ? " (latest)" : ""}
+              {v.version}
+              {v.is_latest ? " (latest)" : ""}
             </option>
           ))}
         </select>

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/circular-ref-placeholder.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/circular-ref-placeholder.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CircularRefPlaceholder } from "./circular-ref-placeholder";
+
+describe("CircularRefPlaceholder", () => {
+  it("renders the ref type and a muted note", () => {
+    render(
+      <CircularRefPlaceholder
+        node={{
+          controlType: "circular_ref",
+          key: "parent_based",
+          label: "Parent Based",
+          path: "sampler.parent_based",
+          refType: "Sampler",
+        }}
+      />
+    );
+    expect(screen.getByText(/Circular reference to Sampler/)).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/circular-ref-placeholder.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/circular-ref-placeholder.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { CircularRefNode } from "@/types/configuration";
+
+interface CircularRefPlaceholderProps {
+  node: CircularRefNode;
+}
+
+export function CircularRefPlaceholder({ node }: CircularRefPlaceholderProps) {
+  return (
+    <div className="rounded-md border border-border/40 bg-background/40 px-4 py-2 text-sm text-muted-foreground">
+      <strong className="font-medium text-foreground">{node.label}</strong>
+      <span>
+        {" "}
+        — Circular reference to {node.refType}. Configure this under its canonical section.
+      </span>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.test.tsx
@@ -88,6 +88,16 @@ describe("ControlWrapper", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
+  it("renders the null placeholder in italic so it reads as an annotation", () => {
+    const node = { ...baseNode, nullable: true, defaultBehavior: "512 is used" };
+    render(
+      <ControlWrapper node={node} isNull={true} onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    expect(screen.getByText("512 is used")).toHaveClass("italic");
+  });
+
   it("falls back to defaultBehavior for null placeholder when nullBehavior absent", () => {
     const node = { ...baseNode, nullable: true, defaultBehavior: "30 seconds" };
     render(
@@ -152,14 +162,36 @@ describe("ControlWrapper", () => {
     expect(label).toHaveAttribute("for", "my-input");
   });
 
-  it("renders defaultBehavior hint below input when not in null state", () => {
+  it("renders defaultBehavior via FieldMeta (no 'Default:' prefix) when not in null state", () => {
     const node = { ...baseNode, defaultBehavior: "30 seconds" };
     render(
       <ControlWrapper node={node} onClear={vi.fn()} onActivate={vi.fn()}>
         <input />
       </ControlWrapper>
     );
-    expect(screen.getByText("Default: 30 seconds")).toBeInTheDocument();
+    expect(screen.getByText("30 seconds")).toBeInTheDocument();
+    expect(screen.queryByText(/Default:/)).not.toBeInTheDocument();
+  });
+
+  it("hides FieldMeta when in null state (null-state sentence communicates default)", () => {
+    const node = { ...baseNode, nullable: true, defaultBehavior: "30 seconds" };
+    render(
+      <ControlWrapper node={node} isNull={true} onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    // "30 seconds" appears exactly once — as the null-state sentence, not as FieldMeta.
+    expect(screen.getAllByText("30 seconds")).toHaveLength(1);
+  });
+
+  it("renders nothing from FieldMeta when no constraints and no defaultBehavior", () => {
+    render(
+      <ControlWrapper node={baseNode} onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    // Sanity: no default-hint text leaks in.
+    expect(screen.queryByText(/Default:/)).not.toBeInTheDocument();
   });
 
   it('shows "Using default" when both nullBehavior and defaultBehavior are absent', () => {
@@ -170,5 +202,40 @@ describe("ControlWrapper", () => {
       </ControlWrapper>
     );
     expect(screen.getByText("Using default")).toBeInTheDocument();
+  });
+
+  it("renders the error message when error prop is set", () => {
+    render(
+      <ControlWrapper node={baseNode} error="Required" onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("suppresses the label row when node.hideLabel is true", () => {
+    const hiddenLabelNode = { ...baseNode, hideLabel: true };
+    render(
+      <ControlWrapper node={hiddenLabelNode}>
+        <input aria-label="test-input" />
+      </ControlWrapper>
+    );
+    // Label text must not appear in the document.
+    expect(screen.queryByText(hiddenLabelNode.label)).not.toBeInTheDocument();
+  });
+
+  it("omits the error region when error is null or undefined", () => {
+    const { rerender } = render(
+      <ControlWrapper node={baseNode} error={null} onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    rerender(
+      <ControlWrapper node={baseNode} onClear={vi.fn()} onActivate={vi.fn()}>
+        <input />
+      </ControlWrapper>
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 import type { ReactNode } from "react";
-import type { ConfigNodeBase } from "@/types/configuration";
+import type { ConfigNodeBase, Constraints } from "@/types/configuration";
+import { FieldMeta } from "./field-meta";
 
 interface ControlWrapperProps {
   node: ConfigNodeBase;
   inputId?: string;
   descriptionId?: string;
   isNull?: boolean;
+  error?: string | null;
   onClear?: () => void;
   onActivate?: () => void;
   children: ReactNode;
@@ -31,6 +33,7 @@ export function ControlWrapper({
   inputId,
   descriptionId,
   isNull = false,
+  error,
   onClear,
   onActivate,
   children,
@@ -40,25 +43,27 @@ export function ControlWrapper({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        {inputId ? (
-          <label htmlFor={inputId} className="text-sm font-medium text-foreground">
-            {node.label}
-          </label>
-        ) : (
-          <span className="text-sm font-medium text-foreground">{node.label}</span>
-        )}
-        {node.required && (
-          <span className="text-sm text-red-400" aria-hidden="true">
-            *
-          </span>
-        )}
-        {node.stability === "development" && (
-          <span className="rounded-full bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-500">
-            dev
-          </span>
-        )}
-      </div>
+      {!node.hideLabel && (
+        <div className="flex items-center gap-2">
+          {inputId ? (
+            <label htmlFor={inputId} className="text-sm font-medium text-foreground">
+              {node.label}
+            </label>
+          ) : (
+            <span className="text-sm font-medium text-foreground">{node.label}</span>
+          )}
+          {node.required && (
+            <span className="text-sm text-red-400" aria-hidden="true">
+              *
+            </span>
+          )}
+          {node.stability === "development" && (
+            <span className="rounded-full bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-500">
+              dev
+            </span>
+          )}
+        </div>
+      )}
       {node.description && (
         <p id={descriptionId} className="text-xs text-muted-foreground">
           {node.description}
@@ -66,13 +71,13 @@ export function ControlWrapper({
       )}
       {showNullState ? (
         <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground/70">
+          <span className="text-sm italic text-muted-foreground">
             {node.nullBehavior ?? node.defaultBehavior ?? "Using default"}
           </span>
           <button
             type="button"
             onClick={onActivate}
-            className="rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground transition-all hover:border-primary/40 hover:text-foreground"
+            className="rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-foreground transition-all hover:border-primary/40"
           >
             Set value
           </button>
@@ -85,16 +90,26 @@ export function ControlWrapper({
               type="button"
               onClick={onClear}
               aria-label="Clear value"
-              className="mt-0.5 shrink-0 rounded-md border border-border/60 bg-background/80 px-3 py-2 text-xs text-muted-foreground transition-all hover:border-primary/40 hover:text-foreground"
+              className="mt-0.5 shrink-0 rounded-md border border-border/60 bg-background/80 px-3 py-2 text-xs text-foreground transition-all hover:border-primary/40"
             >
               Clear
             </button>
           )}
         </div>
       )}
-      {node.defaultBehavior && !showNullState && (
-        <p className="text-xs text-muted-foreground/70">Default: {node.defaultBehavior}</p>
+      {!showNullState && (
+        <FieldMeta
+          node={{
+            defaultBehavior: node.defaultBehavior,
+            constraints: (node as ConfigNodeBase & { constraints?: Constraints }).constraints,
+          }}
+        />
       )}
+      {error ? (
+        <p role="alert" className="text-xs text-red-400">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/field-meta.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/field-meta.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FieldMeta } from "./field-meta";
+
+describe("FieldMeta", () => {
+  it("returns null when node has no constraints and no defaultBehavior", () => {
+    const { container } = render(<FieldMeta node={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders inclusive range when minimum and maximum are both set", () => {
+    render(<FieldMeta node={{ constraints: { minimum: 0, maximum: 100 } }} />);
+    expect(screen.getByText("0–100")).toBeInTheDocument();
+  });
+
+  it("renders ≥ min when only minimum is set", () => {
+    render(<FieldMeta node={{ constraints: { minimum: 0 } }} />);
+    expect(screen.getByText("≥ 0")).toBeInTheDocument();
+  });
+
+  it("renders > min when only exclusiveMinimum is set", () => {
+    render(<FieldMeta node={{ constraints: { exclusiveMinimum: 0 } }} />);
+    expect(screen.getByText("> 0")).toBeInTheDocument();
+  });
+
+  it("renders ≤ max when only maximum is set", () => {
+    render(<FieldMeta node={{ constraints: { maximum: 100 } }} />);
+    expect(screen.getByText("≤ 100")).toBeInTheDocument();
+  });
+
+  it("renders < max when only exclusiveMaximum is set", () => {
+    render(<FieldMeta node={{ constraints: { exclusiveMaximum: 100 } }} />);
+    expect(screen.getByText("< 100")).toBeInTheDocument();
+  });
+
+  it("renders '> min & < max' when both exclusive bounds are set", () => {
+    render(<FieldMeta node={{ constraints: { exclusiveMinimum: 0, exclusiveMaximum: 10 } }} />);
+    expect(screen.getByText("> 0 & < 10")).toBeInTheDocument();
+  });
+
+  it("prefers inclusive minimum when both minimum and exclusiveMinimum are set", () => {
+    render(
+      <FieldMeta node={{ constraints: { minimum: 0, exclusiveMinimum: -1, maximum: 100 } }} />
+    );
+    expect(screen.getByText("0–100")).toBeInTheDocument();
+    expect(screen.queryByText("> -1")).not.toBeInTheDocument();
+  });
+
+  it("renders '1–10 items' when both minItems and maxItems are set", () => {
+    render(<FieldMeta node={{ constraints: { minItems: 1, maxItems: 10 } }} />);
+    expect(screen.getByText("1–10 items")).toBeInTheDocument();
+  });
+
+  it("renders '≥ 1 item' (singular) when minItems is 1", () => {
+    render(<FieldMeta node={{ constraints: { minItems: 1 } }} />);
+    expect(screen.getByText("≥ 1 item")).toBeInTheDocument();
+  });
+
+  it("renders '≥ 2 items' (plural) when minItems is 2", () => {
+    render(<FieldMeta node={{ constraints: { minItems: 2 } }} />);
+    expect(screen.getByText("≥ 2 items")).toBeInTheDocument();
+  });
+
+  it("renders '≤ 10 items' when only maxItems is set", () => {
+    render(<FieldMeta node={{ constraints: { maxItems: 10 } }} />);
+    expect(screen.getByText("≤ 10 items")).toBeInTheDocument();
+  });
+
+  it("renders defaultBehavior text without 'Default:' prefix", () => {
+    render(<FieldMeta node={{ defaultBehavior: "128" }} />);
+    expect(screen.getByText("128")).toBeInTheDocument();
+    expect(screen.queryByText(/Default:/)).not.toBeInTheDocument();
+  });
+
+  it("renders constraints then default, middot-joined, in order", () => {
+    const { container } = render(
+      <FieldMeta node={{ constraints: { minimum: 0, maximum: 100 }, defaultBehavior: "50" }} />
+    );
+    expect(container.textContent).toMatch(/0–100.*·.*50/);
+  });
+
+  it("renders items range then default, middot-joined, in order", () => {
+    const { container } = render(
+      <FieldMeta node={{ constraints: { minItems: 1, maxItems: 5 }, defaultBehavior: "empty" }} />
+    );
+    expect(container.textContent).toMatch(/1–5 items.*·.*empty/);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/field-meta.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/field-meta.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fragment, type ComponentType } from "react";
+import { ArrowLeftRight, Equal, ListOrdered } from "lucide-react";
+import type { Constraints } from "@/types/configuration";
+
+interface FieldMetaNode {
+  defaultBehavior?: string;
+  constraints?: Constraints;
+}
+
+interface FieldMetaProps {
+  node: FieldMetaNode;
+}
+
+interface MetaItem {
+  Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  text: string;
+}
+
+function rangeItem(constraints: Constraints): MetaItem | null {
+  const hasMin = constraints.minimum !== undefined;
+  const hasMax = constraints.maximum !== undefined;
+  const hasExMin = constraints.exclusiveMinimum !== undefined;
+  const hasExMax = constraints.exclusiveMaximum !== undefined;
+
+  if (hasMin && hasMax) {
+    return { Icon: ArrowLeftRight, text: `${constraints.minimum}–${constraints.maximum}` };
+  }
+  if (!hasMin && !hasMax && hasExMin && hasExMax) {
+    return {
+      Icon: ArrowLeftRight,
+      text: `> ${constraints.exclusiveMinimum} & < ${constraints.exclusiveMaximum}`,
+    };
+  }
+  if (hasMin) {
+    return { Icon: ArrowLeftRight, text: `≥ ${constraints.minimum}` };
+  }
+  if (hasExMin) {
+    return { Icon: ArrowLeftRight, text: `> ${constraints.exclusiveMinimum}` };
+  }
+  if (hasMax) {
+    return { Icon: ArrowLeftRight, text: `≤ ${constraints.maximum}` };
+  }
+  if (hasExMax) {
+    return { Icon: ArrowLeftRight, text: `< ${constraints.exclusiveMaximum}` };
+  }
+  return null;
+}
+
+function itemsItem(constraints: Constraints): MetaItem | null {
+  const hasMin = constraints.minItems !== undefined;
+  const hasMax = constraints.maxItems !== undefined;
+  if (hasMin && hasMax) {
+    return { Icon: ListOrdered, text: `${constraints.minItems}–${constraints.maxItems} items` };
+  }
+  if (hasMin) {
+    const unit = constraints.minItems === 1 ? "item" : "items";
+    return { Icon: ListOrdered, text: `≥ ${constraints.minItems} ${unit}` };
+  }
+  if (hasMax) {
+    return { Icon: ListOrdered, text: `≤ ${constraints.maxItems} items` };
+  }
+  return null;
+}
+
+function defaultItem(node: FieldMetaNode): MetaItem | null {
+  if (node.defaultBehavior === undefined) return null;
+  return { Icon: Equal, text: node.defaultBehavior };
+}
+
+export function FieldMeta({ node }: FieldMetaProps) {
+  const items: MetaItem[] = [];
+  if (node.constraints) {
+    const r = rangeItem(node.constraints);
+    if (r) items.push(r);
+    const i = itemsItem(node.constraints);
+    if (i) items.push(i);
+  }
+  const d = defaultItem(node);
+  if (d) items.push(d);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      {items.map((item, i) => {
+        const { Icon } = item;
+        return (
+          <Fragment key={i}>
+            {i > 0 && <span aria-hidden="true">·</span>}
+            <span className="flex items-center gap-1">
+              <Icon className="h-3 w-3 text-primary" aria-hidden={true} />
+              {item.text}
+            </span>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/flag-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/flag-control.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FlagControl } from "./flag-control";
+import type { FlagNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
+
+const node: FlagNode = {
+  controlType: "flag",
+  key: "console",
+  label: "Console",
+  path: "exporter.console",
+  nullable: true,
+};
+
+describe("FlagControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
+  it("renders an off switch when value is null", () => {
+    render(<FlagControl node={node} path={node.path} value={null} onChange={vi.fn()} />);
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders an on switch when value is {}", () => {
+    render(<FlagControl node={node} path={node.path} value={{}} onChange={vi.fn()} />);
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles value from null to {} on click", () => {
+    const onChange = vi.fn();
+    render(<FlagControl node={node} path={node.path} value={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith("exporter.console", {});
+  });
+
+  it("toggles value from {} to null on click", () => {
+    const onChange = vi.fn();
+    render(<FlagControl node={node} path={node.path} value={{}} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith("exporter.console", null);
+  });
+
+  it("renders the error from state when validationErrors has this path", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<FlagControl node={node} path={node.path} value={null} onChange={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/flag-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/flag-control.tsx
@@ -13,45 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ToggleNode } from "@/types/configuration";
+import type { FlagNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
-interface ToggleControlProps {
-  node: ToggleNode;
+type FlagValue = Record<string, never> | null;
+
+interface FlagControlProps {
+  node: FlagNode;
   path: string;
-  value: boolean | null;
-  onChange: (path: string, value: boolean | null) => void;
+  value: FlagValue;
+  onChange: (path: string, value: FlagValue) => void;
 }
 
-export function ToggleControl({ node, path, value, onChange }: ToggleControlProps) {
-  const isNull = node.nullable === true && value === null;
-  const isEnabled = value ?? false;
+export function FlagControl({ node, path, value, onChange }: FlagControlProps) {
+  const isOn = value !== null;
   const { state } = useConfigurationBuilder();
   const error = state.validationErrors[path] ?? null;
 
   return (
-    <ControlWrapper
-      node={node}
-      isNull={isNull}
-      error={error}
-      onClear={() => onChange(path, null)}
-      onActivate={() => onChange(path, false)}
-    >
+    <ControlWrapper node={node} error={error}>
       <button
         type="button"
         role="switch"
-        aria-checked={isEnabled}
+        aria-checked={isOn}
         aria-label={node.label}
-        aria-required={node.required || undefined}
-        onClick={() => onChange(path, !isEnabled)}
+        onClick={() => onChange(path, isOn ? null : {})}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background ${
-          isEnabled ? "bg-primary" : "bg-border"
+          isOn ? "bg-primary" : "bg-border"
         }`}
       >
         <span
           className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${
-            isEnabled ? "translate-x-6" : "translate-x-1"
+            isOn ? "translate-x-6" : "translate-x-1"
           }`}
         />
       </button>

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { KeyValueMapControl } from "./key-value-map-control";
 import type { KeyValueMapNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: KeyValueMapNode = {
   controlType: "key_value_map",
@@ -26,9 +43,19 @@ const node: KeyValueMapNode = {
 };
 
 describe("KeyValueMapControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders existing key and value inputs", () => {
     render(
-      <KeyValueMapControl node={node} value={{ "service.name": "my-svc" }} onChange={vi.fn()} />
+      <KeyValueMapControl
+        node={node}
+        path={node.path}
+        value={{ "service.name": "my-svc" }}
+        onChange={vi.fn()}
+      />
     );
     expect(screen.getByDisplayValue("service.name")).toBeInTheDocument();
     expect(screen.getByDisplayValue("my-svc")).toBeInTheDocument();
@@ -36,7 +63,7 @@ describe("KeyValueMapControl", () => {
 
   it("adds empty entry when Add clicked", () => {
     const onChange = vi.fn();
-    render(<KeyValueMapControl node={node} value={{}} onChange={onChange} />);
+    render(<KeyValueMapControl node={node} path={node.path} value={{}} onChange={onChange} />);
     fireEvent.click(screen.getByRole("button", { name: "Add entry to Resource Attributes" }));
     expect(onChange).toHaveBeenCalledWith("resource.attributes", { "": "" });
   });
@@ -46,6 +73,7 @@ describe("KeyValueMapControl", () => {
     render(
       <KeyValueMapControl
         node={node}
+        path={node.path}
         value={{ "service.name": "my-svc", env: "prod" }}
         onChange={onChange}
       />
@@ -56,14 +84,18 @@ describe("KeyValueMapControl", () => {
 
   it("updates key on input change", () => {
     const onChange = vi.fn();
-    render(<KeyValueMapControl node={node} value={{ old: "val" }} onChange={onChange} />);
+    render(
+      <KeyValueMapControl node={node} path={node.path} value={{ old: "val" }} onChange={onChange} />
+    );
     fireEvent.change(screen.getByDisplayValue("old"), { target: { value: "new" } });
     expect(onChange).toHaveBeenCalledWith("resource.attributes", { new: "val" });
   });
 
   it("updates value on input change", () => {
     const onChange = vi.fn();
-    render(<KeyValueMapControl node={node} value={{ key: "old" }} onChange={onChange} />);
+    render(
+      <KeyValueMapControl node={node} path={node.path} value={{ key: "old" }} onChange={onChange} />
+    );
     fireEvent.change(screen.getByDisplayValue("old"), { target: { value: "new" } });
     expect(onChange).toHaveBeenCalledWith("resource.attributes", { key: "new" });
   });
@@ -71,19 +103,39 @@ describe("KeyValueMapControl", () => {
   it("does not auto-null when last entry removed on nullable node", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<KeyValueMapControl node={nullableNode} value={{ key: "val" }} onChange={onChange} />);
+    render(
+      <KeyValueMapControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={{ key: "val" }}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Remove entry 1" }));
     expect(onChange).toHaveBeenCalledWith("resource.attributes", {});
   });
 
   it("shows null state when nullable and value is null", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<KeyValueMapControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <KeyValueMapControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
   });
 
   it("shows empty state text when value is empty object", () => {
-    render(<KeyValueMapControl node={node} value={{}} onChange={vi.fn()} />);
+    render(<KeyValueMapControl node={node} path={node.path} value={{}} onChange={vi.fn()} />);
     expect(screen.getByText("No entries")).toBeInTheDocument();
+  });
+
+  it("renders the error from state when validationErrors has this path", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<KeyValueMapControl node={node} path={node.path} value={{}} onChange={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.tsx
@@ -16,10 +16,12 @@
 import { useCallback, useRef } from "react";
 import { Plus, X } from "lucide-react";
 import type { KeyValueMapNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface KeyValueMapControlProps {
   node: KeyValueMapNode;
+  path: string;
   value: Record<string, string> | null;
   onChange: (path: string, value: Record<string, string> | null) => void;
 }
@@ -37,9 +39,11 @@ function fromEntries(entries: Entry[]): Record<string, string> {
 const INPUT_CLASS =
   "rounded-lg border border-border/60 bg-background/80 px-3 py-2 text-sm backdrop-blur-sm transition-all duration-200 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function KeyValueMapControl({ node, value, onChange }: KeyValueMapControlProps) {
+export function KeyValueMapControl({ node, path, value, onChange }: KeyValueMapControlProps) {
   const entries: Entry[] = value ? toEntries(value) : [];
   const isNull = node.nullable === true && value === null;
+  const { state } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
   const listRef = useRef<HTMLUListElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
   const statusRef = useRef<HTMLSpanElement>(null);
@@ -49,7 +53,7 @@ export function KeyValueMapControl({ node, value, onChange }: KeyValueMapControl
   }, []);
 
   const emit = (next: Entry[]) => {
-    onChange(node.path, fromEntries(next));
+    onChange(path, fromEntries(next));
   };
 
   const handleAdd = () => {
@@ -80,8 +84,9 @@ export function KeyValueMapControl({ node, value, onChange }: KeyValueMapControl
     <ControlWrapper
       node={node}
       isNull={isNull}
-      onClear={() => onChange(node.path, null)}
-      onActivate={() => onChange(node.path, {})}
+      error={error}
+      onClear={() => onChange(path, null)}
+      onActivate={() => onChange(path, {})}
     >
       <div className="space-y-2">
         <span ref={statusRef} className="sr-only" aria-live="polite" />
@@ -91,14 +96,14 @@ export function KeyValueMapControl({ node, value, onChange }: KeyValueMapControl
             type="button"
             onClick={handleAdd}
             aria-label={`Add entry to ${node.label}`}
-            className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground transition-all hover:border-primary/40 hover:text-foreground"
+            className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-foreground transition-all hover:border-primary/40"
           >
-            <Plus className="h-3 w-3" aria-hidden="true" />
+            <Plus className="h-3 w-3 text-primary" aria-hidden="true" />
             Add
           </button>
         </div>
         {entries.length === 0 ? (
-          <p className="text-xs text-muted-foreground/70">No entries</p>
+          <p className="text-xs text-muted-foreground">No entries</p>
         ) : (
           <ul ref={listRef} className="space-y-2" aria-label={`${node.label} entries`}>
             {entries.map((entry, index) => (

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NumberInputControl } from "./number-input-control";
 import type { NumberInputNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: NumberInputNode = {
   controlType: "number_input",
@@ -26,38 +43,38 @@ const node: NumberInputNode = {
 };
 
 describe("NumberInputControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders input with current value", () => {
-    render(<NumberInputControl node={node} value={5000} onChange={vi.fn()} />);
+    render(<NumberInputControl node={node} path={node.path} value={5000} onChange={vi.fn()} />);
     expect(screen.getByRole("spinbutton")).toHaveValue(5000);
   });
 
   it("renders empty input when value is null", () => {
-    render(<NumberInputControl node={node} value={null} onChange={vi.fn()} />);
+    render(<NumberInputControl node={node} path={node.path} value={null} onChange={vi.fn()} />);
     expect(screen.getByRole("spinbutton")).toHaveValue(null);
   });
 
   it("calls onChange with path and parsed number", () => {
     const onChange = vi.fn();
-    render(<NumberInputControl node={node} value={0} onChange={onChange} />);
+    render(<NumberInputControl node={node} path={node.path} value={0} onChange={onChange} />);
     fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "3000" } });
     expect(onChange).toHaveBeenCalledWith("exporter.timeout", 3000);
   });
 
-  it("shows range hint when both minimum and maximum are set", () => {
-    const constrainedNode = { ...node, constraints: { minimum: 1, maximum: 60000 } };
-    render(<NumberInputControl node={constrainedNode} value={5000} onChange={vi.fn()} />);
-    expect(screen.getByText("Range: 1–60000")).toBeInTheDocument();
-  });
-
-  it("shows minimum hint when only minimum is set", () => {
-    const constrainedNode = { ...node, constraints: { minimum: 1 } };
-    render(<NumberInputControl node={constrainedNode} value={5000} onChange={vi.fn()} />);
-    expect(screen.getByText("Minimum: 1")).toBeInTheDocument();
-  });
-
   it("shows null state for nullable null value", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<NumberInputControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <NumberInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
   });
@@ -65,31 +82,109 @@ describe("NumberInputControl", () => {
   it("activates with 0 when Set value clicked", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<NumberInputControl node={nullableNode} value={null} onChange={onChange} />);
+    render(
+      <NumberInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Set value" }));
     expect(onChange).toHaveBeenCalledWith("exporter.timeout", 0);
   });
 
-  it("emits 0 when clearing nullable field instead of flipping to null state", () => {
+  it("does not commit 0 when the user clears a non-empty field", () => {
     const onChange = vi.fn();
-    const nullableNode = { ...node, nullable: true };
-    render(<NumberInputControl node={nullableNode} value={5000} onChange={onChange} />);
+    render(<NumberInputControl node={node} path={node.path} value={5000} onChange={onChange} />);
     fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
-    expect(onChange).toHaveBeenCalledWith("exporter.timeout", 0);
-  });
-
-  it("shows exclusive minimum hint as 'Greater than'", () => {
-    const constrainedNode = { ...node, constraints: { exclusiveMinimum: 0 } };
-    render(<NumberInputControl node={constrainedNode} value={5} onChange={vi.fn()} />);
-    expect(screen.getByText("Greater than 0")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("links description to input via aria-describedby", () => {
     const nodeWithDesc = { ...node, description: "Max wait time" };
-    render(<NumberInputControl node={nodeWithDesc} value={5000} onChange={vi.fn()} />);
+    render(
+      <NumberInputControl
+        node={nodeWithDesc}
+        path={nodeWithDesc.path}
+        value={5000}
+        onChange={vi.fn()}
+      />
+    );
     const input = screen.getByRole("spinbutton");
     const descId = input.getAttribute("aria-describedby");
     expect(descId).toBeTruthy();
     expect(document.getElementById(descId!)).toHaveTextContent("Max wait time");
+  });
+
+  it("calls validateField on blur and renders the error from state", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<NumberInputControl node={node} path={node.path} value={0} onChange={vi.fn()} />);
+    fireEvent.blur(screen.getByRole("spinbutton"));
+    expect(validateField).toHaveBeenCalledWith(node.path);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
+  });
+
+  it("allows typing to replace a committed zero", () => {
+    const onChange = vi.fn();
+    render(<NumberInputControl node={node} path={node.path} value={0} onChange={onChange} />);
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "7" } });
+    expect(onChange).toHaveBeenLastCalledWith("exporter.timeout", 7);
+    expect(screen.getByRole("spinbutton")).toHaveValue(7);
+  });
+
+  it("restores the committed value on blur when the draft is empty", () => {
+    const onChange = vi.fn();
+    render(<NumberInputControl node={node} path={node.path} value={42} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input).toHaveValue(null);
+    fireEvent.blur(input);
+    expect(input).toHaveValue(42);
+  });
+
+  it("syncs the draft when the external value changes", () => {
+    const { rerender } = render(
+      <NumberInputControl node={node} path={node.path} value={1} onChange={vi.fn()} />
+    );
+    expect(screen.getByRole("spinbutton")).toHaveValue(1);
+    rerender(<NumberInputControl node={node} path={node.path} value={99} onChange={vi.fn()} />);
+    expect(screen.getByRole("spinbutton")).toHaveValue(99);
+  });
+
+  it("focuses and selects the input after Set value is clicked so next keystroke replaces the 0", async () => {
+    const onChange = vi.fn();
+    const nullableNode = { ...node, nullable: true };
+    // jsdom does not support selectionStart/selectionEnd on type=number, so spy on select().
+    const selectSpy = vi.spyOn(HTMLInputElement.prototype, "select");
+    const { rerender } = render(
+      <NumberInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Set value" }));
+    expect(onChange).toHaveBeenCalledWith("exporter.timeout", 0);
+
+    // Simulate the parent re-render after onChange commits.
+    rerender(
+      <NumberInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={0}
+        onChange={onChange}
+      />
+    );
+
+    // Wait for the requestAnimationFrame callback to run.
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+    expect(selectSpy).toHaveBeenCalled();
+    selectSpy.mockRestore();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 import type { ChangeEvent } from "react";
-import { useId } from "react";
+import { useId, useRef, useState } from "react";
 import type { NumberInputNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface NumberInputControlProps {
   node: NumberInputNode;
+  path: string;
   value: number | null;
   onChange: (path: string, value: number | null) => void;
 }
@@ -27,28 +29,37 @@ interface NumberInputControlProps {
 const INPUT_CLASS =
   "w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2.5 text-sm backdrop-blur-sm transition-all duration-200 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function NumberInputControl({ node, value, onChange }: NumberInputControlProps) {
+export function NumberInputControl({ node, path, value, onChange }: NumberInputControlProps) {
   const id = useId();
   const descId = useId();
   const isNull = node.nullable === true && value === null;
+  const { state, validateField } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
   const { constraints } = node;
-  const hasExclusiveMin =
-    constraints?.exclusiveMinimum !== undefined && constraints?.minimum === undefined;
-  const hasExclusiveMax =
-    constraints?.exclusiveMaximum !== undefined && constraints?.maximum === undefined;
   const min = constraints?.minimum ?? constraints?.exclusiveMinimum;
   const max = constraints?.maximum ?? constraints?.exclusiveMaximum;
 
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState<string>(() => (value === null ? "" : String(value)));
+  const [prevValue, setPrevValue] = useState<number | null>(value);
+
+  if (prevValue !== value) {
+    setPrevValue(value);
+    const next = value === null ? "" : String(value);
+    if (draft === "" || parseFloat(draft) !== value) setDraft(next);
+  }
+
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
-    if (raw === "") {
-      onChange(node.path, 0);
-      return;
-    }
+    setDraft(raw);
+    if (raw === "") return;
     const num = parseFloat(raw);
-    if (!isNaN(num)) {
-      onChange(node.path, num);
-    }
+    if (Number.isFinite(num)) onChange(path, num);
+  };
+
+  const handleBlur = () => {
+    if (draft === "" && value !== null) setDraft(String(value));
+    validateField(path);
   };
 
   return (
@@ -57,36 +68,33 @@ export function NumberInputControl({ node, value, onChange }: NumberInputControl
       inputId={id}
       descriptionId={node.description ? descId : undefined}
       isNull={isNull}
-      onClear={() => onChange(node.path, null)}
-      onActivate={() => onChange(node.path, 0)}
+      error={error}
+      onClear={() => onChange(path, null)}
+      onActivate={() => {
+        onChange(path, 0);
+        requestAnimationFrame(() => {
+          const el = inputRef.current;
+          if (el) {
+            el.focus();
+            el.select();
+          }
+        });
+      }}
     >
-      <div className="space-y-1">
-        <input
-          id={id}
-          type="number"
-          value={value ?? ""}
-          min={min}
-          max={max}
-          placeholder={node.defaultBehavior ?? ""}
-          aria-describedby={node.description ? descId : undefined}
-          aria-required={node.required || undefined}
-          onChange={handleChange}
-          className={INPUT_CLASS}
-        />
-        {(min !== undefined || max !== undefined) && (
-          <p className="text-xs text-muted-foreground/70">
-            {min !== undefined && max !== undefined
-              ? `Range: ${hasExclusiveMin ? ">" : ""}${min}–${hasExclusiveMax ? "<" : ""}${max}`
-              : min !== undefined
-                ? hasExclusiveMin
-                  ? `Greater than ${min}`
-                  : `Minimum: ${min}`
-                : hasExclusiveMax
-                  ? `Less than ${max}`
-                  : `Maximum: ${max}`}
-          </p>
-        )}
-      </div>
+      <input
+        id={id}
+        type="number"
+        value={draft}
+        min={min}
+        max={max}
+        placeholder={node.defaultBehavior ?? ""}
+        ref={inputRef}
+        aria-describedby={node.description ? descId : undefined}
+        aria-required={node.required || undefined}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        className={INPUT_CLASS}
+      />
     </ControlWrapper>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NumberListControl } from "./number-list-control";
 import type { NumberListNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: NumberListNode = {
   controlType: "number_list",
@@ -26,57 +43,93 @@ const node: NumberListNode = {
 };
 
 describe("NumberListControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders existing items", () => {
-    render(<NumberListControl node={node} value={[4317, 4318]} onChange={vi.fn()} />);
+    render(
+      <NumberListControl node={node} path={node.path} value={[4317, 4318]} onChange={vi.fn()} />
+    );
     expect(screen.getByDisplayValue("4317")).toBeInTheDocument();
     expect(screen.getByDisplayValue("4318")).toBeInTheDocument();
   });
 
   it("adds item with value 0 when Add clicked", () => {
     const onChange = vi.fn();
-    render(<NumberListControl node={node} value={[4317]} onChange={onChange} />);
+    render(<NumberListControl node={node} path={node.path} value={[4317]} onChange={onChange} />);
     fireEvent.click(screen.getByRole("button", { name: "Add item to Ports" }));
     expect(onChange).toHaveBeenCalledWith("receiver.ports", [4317, 0]);
   });
 
   it("removes item when X clicked", () => {
     const onChange = vi.fn();
-    render(<NumberListControl node={node} value={[4317, 4318]} onChange={onChange} />);
+    render(
+      <NumberListControl node={node} path={node.path} value={[4317, 4318]} onChange={onChange} />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Remove item 1" }));
     expect(onChange).toHaveBeenCalledWith("receiver.ports", [4318]);
   });
 
   it("updates item value on input change", () => {
     const onChange = vi.fn();
-    render(<NumberListControl node={node} value={[4317]} onChange={onChange} />);
+    render(<NumberListControl node={node} path={node.path} value={[4317]} onChange={onChange} />);
     fireEvent.change(screen.getByDisplayValue("4317"), { target: { value: "8080" } });
     expect(onChange).toHaveBeenCalledWith("receiver.ports", [8080]);
   });
 
   it("emits 0 when input is cleared (allows retyping)", () => {
     const onChange = vi.fn();
-    render(<NumberListControl node={node} value={[4317]} onChange={onChange} />);
+    render(<NumberListControl node={node} path={node.path} value={[4317]} onChange={onChange} />);
     fireEvent.change(screen.getByDisplayValue("4317"), { target: { value: "" } });
     expect(onChange).toHaveBeenCalledWith("receiver.ports", [0]);
   });
 
   it("hides Add button when maxItems reached", () => {
     const constrainedNode = { ...node, constraints: { maxItems: 1 } };
-    render(<NumberListControl node={constrainedNode} value={[4317]} onChange={vi.fn()} />);
+    render(
+      <NumberListControl
+        node={constrainedNode}
+        path={constrainedNode.path}
+        value={[4317]}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.queryByRole("button", { name: "Add item to Ports" })).not.toBeInTheDocument();
   });
 
   it("does not auto-null when last item removed on nullable node", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<NumberListControl node={nullableNode} value={[4317]} onChange={onChange} />);
+    render(
+      <NumberListControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={[4317]}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Remove item 1" }));
     expect(onChange).toHaveBeenCalledWith("receiver.ports", []);
   });
 
   it("shows null state when nullable and value is null", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<NumberListControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <NumberListControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
+  });
+
+  it("renders the error from state when validationErrors has this path", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<NumberListControl node={node} path={node.path} value={[]} onChange={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.tsx
@@ -16,10 +16,12 @@
 import { useCallback, useRef } from "react";
 import { Plus, X } from "lucide-react";
 import type { NumberListNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface NumberListControlProps {
   node: NumberListNode;
+  path: string;
   value: number[] | null;
   onChange: (path: string, value: number[] | null) => void;
 }
@@ -27,9 +29,11 @@ interface NumberListControlProps {
 const INPUT_CLASS =
   "w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2 text-sm backdrop-blur-sm transition-all duration-200 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function NumberListControl({ node, value, onChange }: NumberListControlProps) {
+export function NumberListControl({ node, path, value, onChange }: NumberListControlProps) {
   const items = value ?? [];
   const isNull = node.nullable === true && value === null;
+  const { state } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
   const { constraints } = node;
   const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
@@ -42,7 +46,7 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
   }, []);
 
   const handleAdd = () => {
-    onChange(node.path, [...items, 0]);
+    onChange(path, [...items, 0]);
     requestAnimationFrame(() => {
       const inputs = listRef.current?.querySelectorAll("input");
       inputs?.item(inputs.length - 1)?.focus();
@@ -52,7 +56,7 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
 
   const handleRemove = (index: number) => {
     onChange(
-      node.path,
+      path,
       items.filter((_, i) => i !== index)
     );
     requestAnimationFrame(() => {
@@ -71,8 +75,9 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
     <ControlWrapper
       node={node}
       isNull={isNull}
-      onClear={() => onChange(node.path, null)}
-      onActivate={() => onChange(node.path, [])}
+      error={error}
+      onClear={() => onChange(path, null)}
+      onActivate={() => onChange(path, [])}
     >
       <div className="space-y-2">
         <span ref={statusRef} className="sr-only" aria-live="polite" />
@@ -83,15 +88,15 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
               type="button"
               onClick={handleAdd}
               aria-label={`Add item to ${node.label}`}
-              className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground transition-all hover:border-primary/40 hover:text-foreground"
+              className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-foreground transition-all hover:border-primary/40"
             >
-              <Plus className="h-3 w-3" aria-hidden="true" />
+              <Plus className="h-3 w-3 text-primary" aria-hidden="true" />
               Add
             </button>
           )}
         </div>
         {items.length === 0 ? (
-          <p className="text-xs text-muted-foreground/70">No items</p>
+          <p className="text-xs text-muted-foreground">No items</p>
         ) : (
           <ul ref={listRef} className="space-y-2" aria-label={`${node.label} items`}>
             {items.map((item, index) => (
@@ -105,7 +110,7 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
                     if (isNaN(num)) return;
                     const next = [...items];
                     next[index] = num;
-                    onChange(node.path, next);
+                    onChange(path, next);
                   }}
                   className={INPUT_CLASS}
                 />
@@ -123,16 +128,6 @@ export function NumberListControl({ node, value, onChange }: NumberListControlPr
             ))}
           </ul>
         )}
-        {constraints &&
-          (constraints.minItems !== undefined || constraints.maxItems !== undefined) && (
-            <p className="text-xs text-muted-foreground/70">
-              {constraints.minItems !== undefined && constraints.maxItems !== undefined
-                ? `${constraints.minItems}–${constraints.maxItems} items`
-                : constraints.minItems !== undefined
-                  ? `At least ${constraints.minItems} items`
-                  : `Up to ${constraints.maxItems} items`}
-            </p>
-          )}
       </div>
     </ControlWrapper>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/select-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/select-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { SelectControl } from "./select-control";
 import type { SelectNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: SelectNode = {
   controlType: "select",
@@ -30,49 +47,73 @@ const node: SelectNode = {
 };
 
 describe("SelectControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders all enum options", () => {
-    render(<SelectControl node={node} value="none" onChange={vi.fn()} />);
+    render(<SelectControl node={node} path={node.path} value="none" onChange={vi.fn()} />);
     expect(screen.getByRole("option", { name: "none" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "gzip" })).toBeInTheDocument();
   });
 
   it("renders with selected value", () => {
-    render(<SelectControl node={node} value="gzip" onChange={vi.fn()} />);
+    render(<SelectControl node={node} path={node.path} value="gzip" onChange={vi.fn()} />);
     expect(screen.getByRole("combobox")).toHaveValue("gzip");
   });
 
   it("calls onChange with path and selected value", () => {
     const onChange = vi.fn();
-    render(<SelectControl node={node} value="none" onChange={onChange} />);
+    render(<SelectControl node={node} path={node.path} value="none" onChange={onChange} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "gzip" } });
     expect(onChange).toHaveBeenCalledWith("exporter.compression", "gzip");
   });
 
   it("includes a default option when nullable", () => {
     const nullableNode = { ...node, nullable: true, defaultBehavior: "No compression" };
-    render(<SelectControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <SelectControl node={nullableNode} path={nullableNode.path} value={null} onChange={vi.fn()} />
+    );
     expect(screen.getByRole("option", { name: "No compression" })).toBeInTheDocument();
   });
 
   it("calls onChange with null when default option selected on nullable field", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<SelectControl node={nullableNode} value="gzip" onChange={onChange} />);
+    render(
+      <SelectControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value="gzip"
+        onChange={onChange}
+      />
+    );
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "" } });
     expect(onChange).toHaveBeenCalledWith("exporter.compression", null);
   });
 
   it("renders label from ControlWrapper", () => {
-    render(<SelectControl node={node} value="none" onChange={vi.fn()} />);
+    render(<SelectControl node={node} path={node.path} value="none" onChange={vi.fn()} />);
     expect(screen.getByText("Compression")).toBeInTheDocument();
   });
 
   it("links description to select via aria-describedby", () => {
     const nodeWithDesc = { ...node, description: "Compression algorithm" };
-    render(<SelectControl node={nodeWithDesc} value="none" onChange={vi.fn()} />);
+    render(
+      <SelectControl node={nodeWithDesc} path={nodeWithDesc.path} value="none" onChange={vi.fn()} />
+    );
     const select = screen.getByRole("combobox");
     const descId = select.getAttribute("aria-describedby");
     expect(descId).toBeTruthy();
     expect(document.getElementById(descId!)).toHaveTextContent("Compression algorithm");
+  });
+
+  it("calls validateField on blur and renders the error from state", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<SelectControl node={node} path={node.path} value="none" onChange={vi.fn()} />);
+    fireEvent.blur(screen.getByRole("combobox"));
+    expect(validateField).toHaveBeenCalledWith(node.path);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/select-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/select-control.tsx
@@ -15,10 +15,12 @@
  */
 import { useId } from "react";
 import type { SelectNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface SelectControlProps {
   node: SelectNode;
+  path: string;
   value: string | null;
   onChange: (path: string, value: string | null) => void;
 }
@@ -26,18 +28,26 @@ interface SelectControlProps {
 const SELECT_CLASS =
   "w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2.5 text-sm backdrop-blur-sm transition-all duration-200 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function SelectControl({ node, value, onChange }: SelectControlProps) {
+export function SelectControl({ node, path, value, onChange }: SelectControlProps) {
   const id = useId();
   const descId = useId();
+  const { state, validateField } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
 
   return (
-    <ControlWrapper node={node} inputId={id} descriptionId={node.description ? descId : undefined}>
+    <ControlWrapper
+      node={node}
+      inputId={id}
+      descriptionId={node.description ? descId : undefined}
+      error={error}
+    >
       <select
         id={id}
         value={value ?? ""}
         aria-describedby={node.description ? descId : undefined}
         aria-required={node.required || undefined}
-        onChange={(e) => onChange(node.path, e.target.value === "" ? null : e.target.value)}
+        onChange={(e) => onChange(path, e.target.value === "" ? null : e.target.value)}
+        onBlur={() => validateField(path)}
         className={SELECT_CLASS}
       >
         {node.nullable ? (

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { StringListControl } from "./string-list-control";
 import type { StringListNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: StringListNode = {
   controlType: "string_list",
@@ -26,9 +43,19 @@ const node: StringListNode = {
 };
 
 describe("StringListControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders existing items", () => {
     render(
-      <StringListControl node={node} value={["Authorization", "Content-Type"]} onChange={vi.fn()} />
+      <StringListControl
+        node={node}
+        path={node.path}
+        value={["Authorization", "Content-Type"]}
+        onChange={vi.fn()}
+      />
     );
     expect(screen.getByDisplayValue("Authorization")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Content-Type")).toBeInTheDocument();
@@ -36,48 +63,73 @@ describe("StringListControl", () => {
 
   it("adds an empty item when Add clicked", () => {
     const onChange = vi.fn();
-    render(<StringListControl node={node} value={["existing"]} onChange={onChange} />);
+    render(
+      <StringListControl node={node} path={node.path} value={["existing"]} onChange={onChange} />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Add item to Headers" }));
     expect(onChange).toHaveBeenCalledWith("exporter.headers", ["existing", ""]);
   });
 
   it("removes item when X clicked", () => {
     const onChange = vi.fn();
-    render(<StringListControl node={node} value={["a", "b"]} onChange={onChange} />);
+    render(
+      <StringListControl node={node} path={node.path} value={["a", "b"]} onChange={onChange} />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Remove item 1" }));
     expect(onChange).toHaveBeenCalledWith("exporter.headers", ["b"]);
   });
 
   it("updates item value on input change", () => {
     const onChange = vi.fn();
-    render(<StringListControl node={node} value={["old"]} onChange={onChange} />);
+    render(<StringListControl node={node} path={node.path} value={["old"]} onChange={onChange} />);
     fireEvent.change(screen.getByDisplayValue("old"), { target: { value: "new" } });
     expect(onChange).toHaveBeenCalledWith("exporter.headers", ["new"]);
   });
 
   it("hides Add button when maxItems reached", () => {
     const constrainedNode = { ...node, constraints: { maxItems: 2 } };
-    render(<StringListControl node={constrainedNode} value={["a", "b"]} onChange={vi.fn()} />);
+    render(
+      <StringListControl
+        node={constrainedNode}
+        path={constrainedNode.path}
+        value={["a", "b"]}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.queryByRole("button", { name: "Add item to Headers" })).not.toBeInTheDocument();
-  });
-
-  it("shows range constraint hint", () => {
-    const constrainedNode = { ...node, constraints: { minItems: 1, maxItems: 5 } };
-    render(<StringListControl node={constrainedNode} value={["a"]} onChange={vi.fn()} />);
-    expect(screen.getByText("1–5 items")).toBeInTheDocument();
   });
 
   it("does not auto-null when last item removed on nullable node", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<StringListControl node={nullableNode} value={["only"]} onChange={onChange} />);
+    render(
+      <StringListControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={["only"]}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Remove item 1" }));
     expect(onChange).toHaveBeenCalledWith("exporter.headers", []);
   });
 
   it("shows null state when nullable and value is null", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<StringListControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <StringListControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
+  });
+
+  it("renders the error from state when validationErrors has this path", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<StringListControl node={node} path={node.path} value={[]} onChange={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.tsx
@@ -16,10 +16,12 @@
 import { useCallback, useRef } from "react";
 import { Plus, X } from "lucide-react";
 import type { StringListNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface StringListControlProps {
   node: StringListNode;
+  path: string;
   value: string[] | null;
   onChange: (path: string, value: string[] | null) => void;
 }
@@ -27,9 +29,11 @@ interface StringListControlProps {
 const INPUT_CLASS =
   "w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2 text-sm backdrop-blur-sm transition-all duration-200 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function StringListControl({ node, value, onChange }: StringListControlProps) {
+export function StringListControl({ node, path, value, onChange }: StringListControlProps) {
   const items = value ?? [];
   const isNull = node.nullable === true && value === null;
+  const { state } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
   const { constraints } = node;
   const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
@@ -42,7 +46,7 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
   }, []);
 
   const handleAdd = () => {
-    onChange(node.path, [...items, ""]);
+    onChange(path, [...items, ""]);
     requestAnimationFrame(() => {
       const inputs = listRef.current?.querySelectorAll("input");
       inputs?.item(inputs.length - 1)?.focus();
@@ -52,7 +56,7 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
 
   const handleRemove = (index: number) => {
     onChange(
-      node.path,
+      path,
       items.filter((_, i) => i !== index)
     );
     requestAnimationFrame(() => {
@@ -71,8 +75,9 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
     <ControlWrapper
       node={node}
       isNull={isNull}
-      onClear={() => onChange(node.path, null)}
-      onActivate={() => onChange(node.path, [])}
+      error={error}
+      onClear={() => onChange(path, null)}
+      onActivate={() => onChange(path, [])}
     >
       <div className="space-y-2">
         <span ref={statusRef} className="sr-only" aria-live="polite" />
@@ -83,15 +88,15 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
               type="button"
               onClick={handleAdd}
               aria-label={`Add item to ${node.label}`}
-              className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground transition-all hover:border-primary/40 hover:text-foreground"
+              className="flex items-center gap-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-foreground transition-all hover:border-primary/40"
             >
-              <Plus className="h-3 w-3" aria-hidden="true" />
+              <Plus className="h-3 w-3 text-primary" aria-hidden="true" />
               Add
             </button>
           )}
         </div>
         {items.length === 0 ? (
-          <p className="text-xs text-muted-foreground/70">No items</p>
+          <p className="text-xs text-muted-foreground">No items</p>
         ) : (
           <ul ref={listRef} className="space-y-2" aria-label={`${node.label} items`}>
             {items.map((item, index) => (
@@ -103,7 +108,7 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
                   onChange={(e) => {
                     const next = [...items];
                     next[index] = e.target.value;
-                    onChange(node.path, next);
+                    onChange(path, next);
                   }}
                   className={INPUT_CLASS}
                 />
@@ -121,16 +126,6 @@ export function StringListControl({ node, value, onChange }: StringListControlPr
             ))}
           </ul>
         )}
-        {constraints &&
-          (constraints.minItems !== undefined || constraints.maxItems !== undefined) && (
-            <p className="text-xs text-muted-foreground/70">
-              {constraints.minItems !== undefined && constraints.maxItems !== undefined
-                ? `${constraints.minItems}–${constraints.maxItems} items`
-                : constraints.minItems !== undefined
-                  ? `At least ${constraints.minItems} items`
-                  : `Up to ${constraints.maxItems} items`}
-            </p>
-          )}
       </div>
     </ControlWrapper>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TextInputControl } from "./text-input-control";
 import type { TextInputNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: TextInputNode = {
   controlType: "text_input",
@@ -26,19 +43,31 @@ const node: TextInputNode = {
 };
 
 describe("TextInputControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders input with current value", () => {
-    render(<TextInputControl node={node} value="http://localhost:4317" onChange={vi.fn()} />);
+    render(
+      <TextInputControl
+        node={node}
+        path={node.path}
+        value="http://localhost:4317"
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("textbox")).toHaveValue("http://localhost:4317");
   });
 
   it("renders empty input when value is null", () => {
-    render(<TextInputControl node={node} value={null} onChange={vi.fn()} />);
+    render(<TextInputControl node={node} path={node.path} value={null} onChange={vi.fn()} />);
     expect(screen.getByRole("textbox")).toHaveValue("");
   });
 
   it("calls onChange with path and new string value", () => {
     const onChange = vi.fn();
-    render(<TextInputControl node={node} value="old" onChange={onChange} />);
+    render(<TextInputControl node={node} path={node.path} value="old" onChange={onChange} />);
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "new" } });
     expect(onChange).toHaveBeenCalledWith("exporter.endpoint", "new");
   });
@@ -46,21 +75,35 @@ describe("TextInputControl", () => {
   it("calls onChange with empty string when cleared on nullable field (null only via Clear button)", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<TextInputControl node={nullableNode} value="old" onChange={onChange} />);
+    render(
+      <TextInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value="old"
+        onChange={onChange}
+      />
+    );
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
     expect(onChange).toHaveBeenCalledWith("exporter.endpoint", "");
   });
 
   it("calls onChange with empty string when cleared on non-nullable field", () => {
     const onChange = vi.fn();
-    render(<TextInputControl node={node} value="old" onChange={onChange} />);
+    render(<TextInputControl node={node} path={node.path} value="old" onChange={onChange} />);
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
     expect(onChange).toHaveBeenCalledWith("exporter.endpoint", "");
   });
 
   it("shows null state for nullable null value", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<TextInputControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <TextInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={vi.fn()}
+      />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
@@ -68,17 +111,39 @@ describe("TextInputControl", () => {
   it("activates with empty string when Set value clicked", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<TextInputControl node={nullableNode} value={null} onChange={onChange} />);
+    render(
+      <TextInputControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Set value" }));
     expect(onChange).toHaveBeenCalledWith("exporter.endpoint", "");
   });
 
   it("links description to input via aria-describedby", () => {
     const nodeWithDesc = { ...node, description: "The collector URL" };
-    render(<TextInputControl node={nodeWithDesc} value="test" onChange={vi.fn()} />);
+    render(
+      <TextInputControl
+        node={nodeWithDesc}
+        path={nodeWithDesc.path}
+        value="test"
+        onChange={vi.fn()}
+      />
+    );
     const input = screen.getByRole("textbox");
     const descId = input.getAttribute("aria-describedby");
     expect(descId).toBeTruthy();
     expect(document.getElementById(descId!)).toHaveTextContent("The collector URL");
+  });
+
+  it("calls validateField on blur and renders the error from state", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<TextInputControl node={node} path={node.path} value="" onChange={vi.fn()} />);
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(validateField).toHaveBeenCalledWith(node.path);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.tsx
@@ -15,10 +15,12 @@
  */
 import { useId } from "react";
 import type { TextInputNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 
 interface TextInputControlProps {
   node: TextInputNode;
+  path: string;
   value: string | null;
   onChange: (path: string, value: string | null) => void;
 }
@@ -26,10 +28,12 @@ interface TextInputControlProps {
 const INPUT_CLASS =
   "w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2.5 text-sm backdrop-blur-sm transition-all duration-200 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20";
 
-export function TextInputControl({ node, value, onChange }: TextInputControlProps) {
+export function TextInputControl({ node, path, value, onChange }: TextInputControlProps) {
   const id = useId();
   const descId = useId();
   const isNull = node.nullable === true && value === null;
+  const { state, validateField } = useConfigurationBuilder();
+  const error = state.validationErrors[path] ?? null;
 
   return (
     <ControlWrapper
@@ -37,8 +41,9 @@ export function TextInputControl({ node, value, onChange }: TextInputControlProp
       inputId={id}
       descriptionId={node.description ? descId : undefined}
       isNull={isNull}
-      onClear={() => onChange(node.path, null)}
-      onActivate={() => onChange(node.path, "")}
+      error={error}
+      onClear={() => onChange(path, null)}
+      onActivate={() => onChange(path, "")}
     >
       <input
         id={id}
@@ -47,7 +52,8 @@ export function TextInputControl({ node, value, onChange }: TextInputControlProp
         placeholder={node.defaultBehavior ?? ""}
         aria-describedby={node.description ? descId : undefined}
         aria-required={node.required || undefined}
-        onChange={(e) => onChange(node.path, e.target.value)}
+        onChange={(e) => onChange(path, e.target.value)}
+        onBlur={() => validateField(path)}
         className={INPUT_CLASS}
       />
     </ControlWrapper>

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/toggle-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/toggle-control.test.tsx
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ToggleControl } from "./toggle-control";
 import type { ToggleNode } from "@/types/configuration";
+
+const validateField = vi.fn();
+let mockValidationErrors: Record<string, string> = {};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: mockValidationErrors,
+      version: "1.0.0",
+      isDirty: false,
+    },
+    validateField,
+    setValue: vi.fn(),
+  }),
+}));
 
 const node: ToggleNode = {
   controlType: "toggle",
@@ -26,33 +43,40 @@ const node: ToggleNode = {
 };
 
 describe("ToggleControl", () => {
+  beforeEach(() => {
+    validateField.mockReset();
+    mockValidationErrors = {};
+  });
+
   it("renders switch as checked when value is true", () => {
-    render(<ToggleControl node={node} value={true} onChange={vi.fn()} />);
+    render(<ToggleControl node={node} path={node.path} value={true} onChange={vi.fn()} />);
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   });
 
   it("renders switch as unchecked when value is false", () => {
-    render(<ToggleControl node={node} value={false} onChange={vi.fn()} />);
+    render(<ToggleControl node={node} path={node.path} value={false} onChange={vi.fn()} />);
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
   });
 
   it("calls onChange with path and toggled value when clicked", () => {
     const onChange = vi.fn();
-    render(<ToggleControl node={node} value={false} onChange={onChange} />);
+    render(<ToggleControl node={node} path={node.path} value={false} onChange={onChange} />);
     fireEvent.click(screen.getByRole("switch"));
     expect(onChange).toHaveBeenCalledWith("exporter.enabled", true);
   });
 
   it("calls onChange with false when toggled from true", () => {
     const onChange = vi.fn();
-    render(<ToggleControl node={node} value={true} onChange={onChange} />);
+    render(<ToggleControl node={node} path={node.path} value={true} onChange={onChange} />);
     fireEvent.click(screen.getByRole("switch"));
     expect(onChange).toHaveBeenCalledWith("exporter.enabled", false);
   });
 
   it("shows null state when nullable and value is null", () => {
     const nullableNode = { ...node, nullable: true };
-    render(<ToggleControl node={nullableNode} value={null} onChange={vi.fn()} />);
+    render(
+      <ToggleControl node={nullableNode} path={nullableNode.path} value={null} onChange={vi.fn()} />
+    );
     expect(screen.getByRole("button", { name: "Set value" })).toBeInTheDocument();
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
   });
@@ -60,7 +84,14 @@ describe("ToggleControl", () => {
   it("activates with false when Set value clicked from null state", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<ToggleControl node={nullableNode} value={null} onChange={onChange} />);
+    render(
+      <ToggleControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={null}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Set value" }));
     expect(onChange).toHaveBeenCalledWith("exporter.enabled", false);
   });
@@ -68,8 +99,21 @@ describe("ToggleControl", () => {
   it("clears to null when Clear clicked", () => {
     const onChange = vi.fn();
     const nullableNode = { ...node, nullable: true };
-    render(<ToggleControl node={nullableNode} value={false} onChange={onChange} />);
+    render(
+      <ToggleControl
+        node={nullableNode}
+        path={nullableNode.path}
+        value={false}
+        onChange={onChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: "Clear value" }));
     expect(onChange).toHaveBeenCalledWith("exporter.enabled", null);
+  });
+
+  it("renders the error from state when validationErrors has this path", () => {
+    mockValidationErrors = { [node.path]: "Required" };
+    render(<ToggleControl node={node} path={node.path} value={false} onChange={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Required");
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GroupRenderer } from "./group-renderer";
+import type { GroupNode } from "@/types/configuration";
+
+const mockState = {
+  values: {},
+  enabledSections: { resource: false },
+  validationErrors: {},
+  version: "1.0.0",
+  isDirty: false,
+};
+
+const setEnabled = vi.fn();
+const setValue = vi.fn();
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: mockState,
+    setEnabled: (...a: unknown[]) => setEnabled(...a),
+    setValue: (...a: unknown[]) => setValue(...a),
+  }),
+}));
+
+const groupNode: GroupNode = {
+  controlType: "group",
+  key: "resource",
+  label: "Resource",
+  path: "resource",
+  description: "The resource section",
+  children: [],
+};
+
+describe("GroupRenderer", () => {
+  it("at depth 0 renders a card with an enable switch", () => {
+    render(<GroupRenderer node={groupNode} depth={0} path="resource" />);
+    expect(screen.getByText("Resource")).toBeInTheDocument();
+    const sw = screen.getByRole("switch", { name: /Enable Resource/i });
+    expect(sw).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("at depth 0, flipping the switch dispatches setEnabled", () => {
+    render(<GroupRenderer node={groupNode} depth={0} path="resource" />);
+    fireEvent.click(screen.getByRole("switch", { name: /Enable Resource/i }));
+    expect(setEnabled).toHaveBeenCalledWith("resource", true);
+  });
+
+  it("at depth >= 3 renders a plain header without a collapse chevron", () => {
+    render(<GroupRenderer node={groupNode} depth={3} path="resource" />);
+    expect(screen.getByText("Resource")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /collapse/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the chevron button at depth 0 when the section is disabled", () => {
+    mockState.enabledSections.resource = false;
+    render(<GroupRenderer node={groupNode} depth={0} path="resource" />);
+    expect(screen.queryByRole("button", { name: /Expand Resource/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Collapse Resource/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a labeled chevron button at depth 0 when the section is enabled", () => {
+    mockState.enabledSections.resource = true;
+    render(<GroupRenderer node={groupNode} depth={0} path="resource" />);
+    expect(screen.getByRole("button", { name: /Collapse Resource/ })).toBeInTheDocument();
+    mockState.enabledSections.resource = false; // restore for other tests
+  });
+
+  it("auto-expands the section when enabled flips from false to true", () => {
+    mockState.enabledSections.resource = false;
+    const childNode: GroupNode = {
+      ...groupNode,
+      children: [
+        {
+          controlType: "text_input",
+          key: "schema_url",
+          label: "Schema URL",
+          path: "resource.schema_url",
+        },
+      ],
+    };
+    const { rerender } = render(<GroupRenderer node={childNode} depth={0} path="resource" />);
+    // Initially disabled and collapsed — child label should not appear.
+    expect(screen.queryByText("Schema URL")).not.toBeInTheDocument();
+
+    // Flip enabled on and re-render with the same node reference.
+    mockState.enabledSections.resource = true;
+    rerender(<GroupRenderer node={childNode} depth={0} path="resource" />);
+
+    // Child label should now appear (auto-expanded).
+    expect(screen.getByText("Schema URL")).toBeInTheDocument();
+    mockState.enabledSections.resource = false; // restore
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, type JSX } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { GroupNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SchemaRenderer } from "./schema-renderer";
+
+export interface GroupRendererProps {
+  node: GroupNode;
+  depth: number;
+  path: string;
+}
+
+export function GroupRenderer({ node, depth, path }: GroupRendererProps): JSX.Element {
+  const { state, setEnabled } = useConfigurationBuilder();
+  const isTopLevel = depth === 0;
+  const enabled = isTopLevel ? state.enabledSections[node.key] === true : true;
+  const [expanded, setExpanded] = useState(!isTopLevel || enabled);
+  const [prevEnabled, setPrevEnabled] = useState(enabled);
+  if (isTopLevel && prevEnabled !== enabled) {
+    setPrevEnabled(enabled);
+    if (enabled) setExpanded(true);
+  }
+
+  const body = enabled ? (
+    <div className={depth >= 3 ? "pl-3 border-l border-border/40 space-y-3" : "space-y-3"}>
+      {node.children.map((child) => (
+        <SchemaRenderer
+          key={child.key}
+          node={child}
+          depth={depth + 1}
+          path={path ? `${path}.${child.key}` : child.key}
+        />
+      ))}
+    </div>
+  ) : null;
+
+  if (isTopLevel) {
+    return (
+      <section className="rounded-xl border border-border/50 bg-card/40 p-5 space-y-3">
+        <header className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            {enabled && (
+              <button
+                type="button"
+                aria-expanded={expanded}
+                aria-label={expanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
+                onClick={() => setExpanded((e) => !e)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                {expanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+              </button>
+            )}
+            <h3 className="text-base font-semibold text-foreground truncate">{node.label}</h3>
+            {node.stability === "development" && (
+              <span className="rounded-full bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-500">
+                dev
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label={`Enable ${node.label}`}
+            onClick={() => setEnabled(node.key, !enabled)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ${
+              enabled ? "bg-primary" : "bg-border"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                enabled ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </header>
+        {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
+        {expanded && body}
+      </section>
+    );
+  }
+
+  if (depth <= 2) {
+    return (
+      <div className="space-y-2">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((e) => !e)}
+          className="flex items-center gap-1 text-sm font-medium text-foreground hover:text-primary"
+        >
+          {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+          {node.label}
+        </button>
+        {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
+        {expanded && body}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {node.label}
+      </h5>
+      {body}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ListRenderer } from "./list-renderer";
+import type { ListNode } from "@/types/configuration";
+
+const addListItem = vi.fn();
+const removeListItem = vi.fn();
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: { tp: { processors: [{}] } },
+      enabledSections: {},
+      validationErrors: {},
+      version: "1.0.0",
+      isDirty: false,
+    },
+    addListItem: (...a: unknown[]) => addListItem(...a),
+    removeListItem: (...a: unknown[]) => removeListItem(...a),
+    setValue: vi.fn(),
+    setEnabled: vi.fn(),
+    selectPlugin: vi.fn(),
+  }),
+}));
+
+vi.mock("./schema-renderer", () => ({
+  SchemaRenderer: ({ path }: { path: string }) => <span data-testid="child-path">{path}</span>,
+}));
+
+const listNode: ListNode = {
+  controlType: "list",
+  key: "processors",
+  label: "Processors",
+  path: "tp.processors",
+  itemSchema: {
+    controlType: "group",
+    key: "item",
+    label: "Item",
+    path: "tp.processors.item",
+    children: [],
+  },
+};
+
+describe("ListRenderer", () => {
+  it("renders an item card for each value and injects indexed path", () => {
+    render(<ListRenderer node={listNode} depth={1} path="tp.processors" />);
+    expect(screen.getByText("Item 1")).toBeInTheDocument();
+    const child = screen.getByTestId("child-path");
+    expect(child.textContent).toBe("tp.processors[0]");
+  });
+
+  it("dispatches addListItem when Add clicked", () => {
+    render(<ListRenderer node={listNode} depth={1} path="tp.processors" />);
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+    expect(addListItem).toHaveBeenCalledWith("tp.processors");
+  });
+
+  it("dispatches removeListItem with the clicked index", () => {
+    render(<ListRenderer node={listNode} depth={1} path="tp.processors" />);
+    fireEvent.click(screen.getByRole("button", { name: /remove item 1/i }));
+    expect(removeListItem).toHaveBeenCalledWith("tp.processors", 0);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
 import { Plus, X } from "lucide-react";
 import type { ListNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { SchemaRenderer } from "./schema-renderer";
 import { parsePath, getByPath } from "@/lib/config-path";
+
+let listItemIdCounter = 0;
+function nextListItemId(): string {
+  listItemIdCounter += 1;
+  return `li-${listItemIdCounter}`;
+}
 
 export interface ListRendererProps {
   node: ListNode;
@@ -34,6 +40,23 @@ export function ListRenderer({ node, depth, path }: ListRendererProps): JSX.Elem
   const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
 
+  const [ids, setIds] = useState<string[]>(() => items.map(() => nextListItemId()));
+  let renderIds = ids;
+  if (ids.length !== items.length) {
+    if (ids.length < items.length) {
+      const added = Array.from({ length: items.length - ids.length }, () => nextListItemId());
+      renderIds = [...ids, ...added];
+    } else {
+      renderIds = ids.slice(0, items.length);
+    }
+    setIds(renderIds);
+  }
+
+  const handleRemove = (i: number) => {
+    setIds((current) => current.filter((_, idx) => idx !== i));
+    removeListItem(path, i);
+  };
+
   return (
     <div className="space-y-3">
       {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
@@ -45,7 +68,7 @@ export function ListRenderer({ node, depth, path }: ListRendererProps): JSX.Elem
             const itemPath = `${path}[${i}]`;
             return (
               <li
-                key={i}
+                key={renderIds[i]}
                 className="rounded-lg border border-border/40 bg-background/30 p-4 space-y-3"
               >
                 <div className="flex items-center justify-between">
@@ -54,7 +77,7 @@ export function ListRenderer({ node, depth, path }: ListRendererProps): JSX.Elem
                     <button
                       type="button"
                       aria-label={`Remove item ${i + 1}`}
-                      onClick={() => removeListItem(path, i)}
+                      onClick={() => handleRemove(i)}
                       className="rounded-md border border-border/60 p-1 text-muted-foreground hover:border-red-500/40 hover:text-red-400"
                     >
                       <X className="h-3 w-3" aria-hidden="true" />

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { JSX } from "react";
+import { Plus, X } from "lucide-react";
+import type { ListNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SchemaRenderer } from "./schema-renderer";
+import { parsePath, getByPath } from "@/lib/config-path";
+
+export interface ListRendererProps {
+  node: ListNode;
+  depth: number;
+  path: string;
+}
+
+export function ListRenderer({ node, depth, path }: ListRendererProps): JSX.Element {
+  const { state, addListItem, removeListItem } = useConfigurationBuilder();
+  const raw = getByPath(state.values, parsePath(path));
+  const items = Array.isArray(raw) ? raw : [];
+  const { constraints } = node;
+  const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
+  const canRemove = !constraints?.minItems || items.length > constraints.minItems;
+
+  return (
+    <div className="space-y-3">
+      {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No items</p>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((_, i) => {
+            const itemPath = `${path}[${i}]`;
+            return (
+              <li
+                key={i}
+                className="rounded-lg border border-border/40 bg-background/30 p-4 space-y-3"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted-foreground">Item {i + 1}</span>
+                  {canRemove && (
+                    <button
+                      type="button"
+                      aria-label={`Remove item ${i + 1}`}
+                      onClick={() => removeListItem(path, i)}
+                      className="rounded-md border border-border/60 p-1 text-muted-foreground hover:border-red-500/40 hover:text-red-400"
+                    >
+                      <X className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  )}
+                </div>
+                <SchemaRenderer node={node.itemSchema} depth={depth + 1} path={itemPath} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {canAdd && (
+        <button
+          type="button"
+          aria-label={`Add item to ${node.label}`}
+          onClick={() => addListItem(path)}
+          className="flex items-center gap-1 rounded-md border border-border/60 px-3 py-1.5 text-xs text-foreground hover:border-primary/40"
+        >
+          <Plus className="h-3 w-3 text-primary" aria-hidden="true" />
+          Add
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PluginSelectRenderer } from "./plugin-select-renderer";
+import type { PluginSelectNode } from "@/types/configuration";
+
+const selectPlugin = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockConfigState: any = {
+  values: { exporter: { otlp_http: {} } },
+  enabledSections: {},
+  validationErrors: {},
+  version: "1.0.0",
+  isDirty: false,
+};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: mockConfigState,
+    setValue: vi.fn(),
+    setEnabled: vi.fn(),
+    selectPlugin: (...a: unknown[]) => selectPlugin(...a),
+  }),
+}));
+
+vi.mock("./schema-renderer", () => ({
+  SchemaRenderer: ({ path }: { path: string }) => <span data-testid="body-path">{path}</span>,
+}));
+
+const pluginNode: PluginSelectNode = {
+  controlType: "plugin_select",
+  key: "exporter",
+  label: "Exporter",
+  path: "exporter",
+  allowCustom: false,
+  options: [
+    {
+      controlType: "group",
+      key: "otlp_http",
+      label: "OTLP HTTP",
+      path: "exporter.otlp_http",
+      children: [],
+    },
+    {
+      controlType: "flag",
+      key: "console",
+      label: "Console",
+      path: "exporter.console",
+    },
+  ],
+};
+
+const pluginNodeWithCustom: PluginSelectNode = {
+  controlType: "plugin_select",
+  key: "exporter",
+  label: "Exporter",
+  path: "exporter",
+  allowCustom: true,
+  options: [
+    {
+      controlType: "group",
+      key: "otlp_http",
+      label: "OTLP HTTP",
+      path: "exporter.otlp_http",
+      children: [],
+    },
+    {
+      controlType: "flag",
+      key: "console",
+      label: "Console",
+      path: "exporter.console",
+    },
+  ],
+};
+
+describe("PluginSelectRenderer", () => {
+  beforeEach(() => {
+    selectPlugin.mockReset();
+    mockConfigState.values = { exporter: { otlp_http: {} } };
+  });
+
+  it("renders a select with variant labels and the body for the selected variant", () => {
+    render(<PluginSelectRenderer node={pluginNode} depth={1} path="exporter" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByText("OTLP HTTP")).toBeInTheDocument();
+    expect(screen.getByText("Console")).toBeInTheDocument();
+    expect(screen.getByTestId("body-path")).toHaveTextContent("exporter.otlp_http");
+  });
+
+  it("dispatches selectPlugin on change", () => {
+    render(<PluginSelectRenderer node={pluginNode} depth={1} path="exporter" />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "console" } });
+    expect(selectPlugin).toHaveBeenCalledWith("exporter", "console");
+  });
+
+  it("shows 'Custom: <key>' in the select when a custom plugin is committed", () => {
+    mockConfigState.values = { exporter: { "my-exporter": {} } };
+    render(<PluginSelectRenderer node={pluginNodeWithCustom} depth={1} path="exporter" />);
+    const select = screen.getByRole("combobox", { name: "Exporter variant" }) as HTMLSelectElement;
+    expect(select.value).toBe("__custom__");
+    const selectedOption = select.options[select.selectedIndex];
+    expect(selectedOption.textContent).toBe("Custom: my-exporter");
+  });
+
+  it("auto-focuses the custom-key input when the picker opens", () => {
+    mockConfigState.values = { exporter: {} };
+    render(<PluginSelectRenderer node={pluginNodeWithCustom} depth={1} path="exporter" />);
+    fireEvent.change(screen.getByRole("combobox", { name: "Exporter variant" }), {
+      target: { value: "__custom__" },
+    });
+    const input = screen.getByRole("textbox", { name: "Custom plugin key" });
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, type JSX } from "react";
+import type { PluginSelectNode, ConfigNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SchemaRenderer } from "./schema-renderer";
+import { parsePath, getByPath } from "@/lib/config-path";
+
+export interface PluginSelectRendererProps {
+  node: PluginSelectNode;
+  depth: number;
+  path: string;
+}
+
+const CUSTOM_SENTINEL = "__custom__";
+
+function resolveSelectedKey(value: unknown, options: ConfigNode[]): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) return null;
+  const match = options.find((o) => o.key === keys[0]);
+  return match ? match.key : keys[0];
+}
+
+export function PluginSelectRenderer({
+  node,
+  depth,
+  path,
+}: PluginSelectRendererProps): JSX.Element {
+  const { state, selectPlugin } = useConfigurationBuilder();
+  const current = getByPath(state.values, parsePath(path));
+  const selectedKey = resolveSelectedKey(current, node.options);
+  const knownOption = selectedKey ? node.options.find((o) => o.key === selectedKey) : undefined;
+  const isCustom = !knownOption && selectedKey !== null;
+  const selectedIsFlag = knownOption?.controlType === "flag";
+
+  const [customDraft, setCustomDraft] = useState("");
+  const [customPickerOpen, setCustomPickerOpen] = useState(false);
+
+  const selectValue = isCustom ? CUSTOM_SENTINEL : (selectedKey ?? "");
+
+  return (
+    <div className="space-y-3">
+      {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
+      <select
+        aria-label={`${node.label} variant`}
+        value={selectValue}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (!v) return;
+          if (v === CUSTOM_SENTINEL) {
+            setCustomPickerOpen(true);
+            return;
+          }
+          selectPlugin(path, v);
+        }}
+        className="w-full rounded-lg border border-border/60 bg-background/80 px-4 py-2.5 text-sm"
+      >
+        <option value="" disabled hidden>
+          Select a {node.label.toLowerCase()}
+        </option>
+        {node.options.map((opt) => (
+          <option key={opt.key} value={opt.key}>
+            {opt.label}
+          </option>
+        ))}
+        {node.allowCustom && (
+          <option value={CUSTOM_SENTINEL}>{isCustom ? `Custom: ${selectedKey}` : "Custom…"}</option>
+        )}
+      </select>
+
+      {customPickerOpen && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            autoFocus
+            aria-label="Custom plugin key"
+            placeholder="custom-plugin-key"
+            value={customDraft}
+            onChange={(e) => setCustomDraft(e.target.value)}
+            className="flex-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const k = customDraft.trim();
+              if (!k) return;
+              selectPlugin(path, k);
+              setCustomPickerOpen(false);
+              setCustomDraft("");
+            }}
+            className="rounded-md border border-border/60 bg-card px-3 py-1.5 text-xs text-foreground hover:bg-card/80"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setCustomPickerOpen(false);
+              setCustomDraft("");
+            }}
+            className="rounded-md border border-border/60 bg-card px-3 py-1.5 text-xs text-muted-foreground hover:bg-card/80"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {knownOption && !selectedIsFlag && (
+        <SchemaRenderer
+          key={knownOption.key}
+          node={knownOption}
+          depth={depth + 1}
+          path={`${path}.${knownOption.key}`}
+        />
+      )}
+
+      {isCustom && (
+        <p className="text-xs text-muted-foreground">
+          Custom plugin. Configure its body manually by importing YAML or leave it as an empty
+          block.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PreviewCard } from "./preview-card";
+import type { ConfigNode } from "@/types/configuration";
+
+const schema: ConfigNode = {
+  controlType: "group",
+  key: "root",
+  label: "Root",
+  path: "",
+  children: [],
+};
+
+const enableAllSections = vi.fn();
+const resetToDefaults = vi.fn();
+const confirmSpy = vi.fn(() => true);
+
+vi.stubGlobal("confirm", confirmSpy);
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: {},
+      version: "1.0.0",
+      isDirty: false,
+    },
+    enableAllSections: (...a: unknown[]) => enableAllSections(...a),
+    resetToDefaults: (...a: unknown[]) => resetToDefaults(...a),
+    setValue: vi.fn(),
+    setEnabled: vi.fn(),
+    selectPlugin: vi.fn(),
+    validateAll: vi.fn(),
+  }),
+}));
+
+describe("PreviewCard", () => {
+  it("renders the Output Preview title and action buttons", () => {
+    render(<PreviewCard schema={schema} />);
+    expect(screen.getByText("Output Preview")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add all/i })).toBeInTheDocument();
+  });
+
+  it("triggers enableAllSections on Add all click", () => {
+    render(<PreviewCard schema={schema} />);
+    fireEvent.click(screen.getByRole("button", { name: /add all/i }));
+    expect(enableAllSections).toHaveBeenCalledTimes(1);
+  });
+
+  it("Reset calls resetToDefaults (no confirm when state is clean)", () => {
+    render(<PreviewCard schema={schema} />);
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+    expect(resetToDefaults).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMemo, useState, type JSX } from "react";
+import { Copy, Download, RefreshCcw, ListPlus } from "lucide-react";
+import type { ConfigNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { generateYaml } from "@/lib/yaml-generator";
+
+interface PreviewCardProps {
+  schema: ConfigNode;
+}
+
+function downloadYaml(filename: string, content: string): void {
+  const blob = new Blob([content], { type: "text/yaml" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function PreviewCard({ schema }: PreviewCardProps): JSX.Element {
+  const { state, enableAllSections, resetToDefaults, validateAll } = useConfigurationBuilder();
+  const yaml = useMemo(() => generateYaml(state, schema), [state, schema]);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    validateAll();
+    try {
+      await navigator.clipboard.writeText(yaml);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = yaml;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "absolute";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      textarea.remove();
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleReset = () => {
+    if (state.isDirty) {
+      const ok = window.confirm("Reset to defaults? This will clear your changes.");
+      if (!ok) return;
+    }
+    resetToDefaults();
+  };
+
+  return (
+    <section
+      aria-label="Output Preview"
+      className="rounded-xl border border-border/50 bg-card/40 p-5 space-y-3 lg:sticky lg:top-24"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Output Preview</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-1 rounded-md border border-border/60 bg-card px-3 py-1 text-xs text-foreground hover:bg-card/80"
+          >
+            <Copy className="h-3 w-3" aria-hidden="true" />
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              validateAll();
+              downloadYaml(`otel-config-${state.version}.yaml`, yaml);
+            }}
+            className="flex items-center gap-1 rounded-md border border-border/60 bg-card px-3 py-1 text-xs text-foreground hover:bg-card/80"
+          >
+            <Download className="h-3 w-3" aria-hidden="true" />
+            Download
+          </button>
+          <span className="mx-1 h-4 w-px bg-border/60" aria-hidden="true" />
+          <button
+            type="button"
+            onClick={enableAllSections}
+            className="flex items-center gap-1 rounded-md border border-border/60 bg-card px-3 py-1 text-xs text-foreground hover:bg-card/80"
+          >
+            <ListPlus className="h-3 w-3" aria-hidden="true" />
+            Add all
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="flex items-center gap-1 rounded-md border border-border/60 bg-card px-3 py-1 text-xs text-foreground hover:bg-card/80"
+          >
+            <RefreshCcw className="h-3 w-3" aria-hidden="true" />
+            Reset
+          </button>
+        </div>
+      </header>
+      <pre className="overflow-auto max-h-[calc(100vh-8rem)] rounded-md bg-background/60 p-4 text-xs font-mono text-foreground">
+        {yaml}
+      </pre>
+    </section>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/schema-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/schema-renderer.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SchemaRenderer } from "./schema-renderer";
+import type { TextInputNode } from "@/types/configuration";
+
+vi.mock("./controls/text-input-control", () => ({
+  TextInputControl: ({ node }: { node: TextInputNode }) => <span>text:{node.key}</span>,
+}));
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: {},
+      version: "1.0.0",
+      isDirty: false,
+    },
+    setValue: vi.fn(),
+  }),
+}));
+
+describe("SchemaRenderer", () => {
+  it("dispatches leaves to their control component", () => {
+    render(
+      <SchemaRenderer
+        node={{
+          controlType: "text_input",
+          key: "endpoint",
+          label: "Endpoint",
+          path: "endpoint",
+        }}
+        depth={1}
+        path="endpoint"
+      />
+    );
+    expect(screen.getByText("text:endpoint")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/schema-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/schema-renderer.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { JSX } from "react";
+import type { ConfigNode, StringListNode, NumberListNode } from "@/types/configuration";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { parsePath, getByPath } from "@/lib/config-path";
+import type { ConfigValue } from "@/types/configuration-builder";
+import { TextInputControl } from "./controls/text-input-control";
+import { ToggleControl } from "./controls/toggle-control";
+import { NumberInputControl } from "./controls/number-input-control";
+import { SelectControl } from "./controls/select-control";
+import { StringListControl } from "./controls/string-list-control";
+import { NumberListControl } from "./controls/number-list-control";
+import { KeyValueMapControl } from "./controls/key-value-map-control";
+import { FlagControl } from "./controls/flag-control";
+import { GroupRenderer } from "./group-renderer";
+import { ListRenderer } from "./list-renderer";
+import { PluginSelectRenderer } from "./plugin-select-renderer";
+import { UnionRenderer } from "./union-renderer";
+import { CircularRefPlaceholder } from "./circular-ref-placeholder";
+
+export interface SchemaRendererProps {
+  node: ConfigNode;
+  depth: number;
+  path: string;
+}
+
+export function SchemaRenderer({ node, depth, path }: SchemaRendererProps): JSX.Element | null {
+  const { state, setValue } = useConfigurationBuilder();
+  const value = getByPath(state.values, parsePath(path));
+
+  switch (node.controlType) {
+    case "group":
+      return <GroupRenderer node={node} depth={depth} path={path} />;
+    case "list": {
+      const itemType = node.itemSchema.controlType;
+      if (itemType === "group" || itemType === "plugin_select") {
+        return <ListRenderer node={node} depth={depth} path={path} />;
+      }
+      if (itemType === "text_input") {
+        return (
+          <StringListControl
+            node={{ ...node, controlType: "string_list" } as unknown as StringListNode}
+            path={path}
+            value={Array.isArray(value) ? (value as string[]) : null}
+            onChange={(p, v) => setValue(p, v as ConfigValue)}
+          />
+        );
+      }
+      if (itemType === "number_input") {
+        return (
+          <NumberListControl
+            node={{ ...node, controlType: "number_list" } as unknown as NumberListNode}
+            path={path}
+            value={Array.isArray(value) ? (value as number[]) : null}
+            onChange={(p, v) => setValue(p, v as ConfigValue)}
+          />
+        );
+      }
+      return <p className="text-xs text-yellow-400">Unsupported list item type: {itemType}</p>;
+    }
+    case "plugin_select":
+      return <PluginSelectRenderer node={node} depth={depth} path={path} />;
+    case "union":
+      return <UnionRenderer node={node} depth={depth} path={path} />;
+    case "circular_ref":
+      return <CircularRefPlaceholder node={node} />;
+    case "text_input":
+      return (
+        <TextInputControl
+          node={node}
+          path={path}
+          value={typeof value === "string" ? value : null}
+          onChange={(p, v) => setValue(p, v)}
+        />
+      );
+    case "toggle":
+      return (
+        <ToggleControl
+          node={node}
+          path={path}
+          value={typeof value === "boolean" ? value : null}
+          onChange={(p, v) => setValue(p, v)}
+        />
+      );
+    case "number_input":
+      return (
+        <NumberInputControl
+          node={node}
+          path={path}
+          value={typeof value === "number" ? value : null}
+          onChange={(p, v) => setValue(p, v)}
+        />
+      );
+    case "select":
+      return (
+        <SelectControl
+          node={node}
+          path={path}
+          value={typeof value === "string" ? value : null}
+          onChange={(p, v) => setValue(p, v)}
+        />
+      );
+    case "string_list":
+      return (
+        <StringListControl
+          node={node}
+          path={path}
+          value={Array.isArray(value) ? (value as string[]) : null}
+          onChange={(p, v) => setValue(p, v as ConfigValue)}
+        />
+      );
+    case "number_list":
+      return (
+        <NumberListControl
+          node={node}
+          path={path}
+          value={Array.isArray(value) ? (value as number[]) : null}
+          onChange={(p, v) => setValue(p, v as ConfigValue)}
+        />
+      );
+    case "key_value_map":
+      return (
+        <KeyValueMapControl
+          node={node}
+          path={path}
+          value={
+            value && typeof value === "object" && !Array.isArray(value)
+              ? (value as Record<string, string>)
+              : null
+          }
+          onChange={(p, v) => setValue(p, v as ConfigValue)}
+        />
+      );
+    case "flag":
+      return (
+        <FlagControl
+          node={node}
+          path={path}
+          value={value === null || value === undefined ? null : {}}
+          onChange={(p, v) => setValue(p, v)}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.test.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UnionRenderer } from "./union-renderer";
+import type { UnionNode } from "@/types/configuration";
+
+const setValue = vi.fn();
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: { value: "x" },
+      enabledSections: {},
+      validationErrors: {},
+      version: "1.0.0",
+      isDirty: false,
+    },
+    setValue: (...a: unknown[]) => setValue(...a),
+    setEnabled: vi.fn(),
+    selectPlugin: vi.fn(),
+  }),
+}));
+
+vi.mock("./schema-renderer", () => ({
+  SchemaRenderer: ({ node }: { node: { key: string; hideLabel?: boolean } }) => (
+    <span data-testid="variant" data-hide-label={String(!!node.hideLabel)}>
+      {node.key}
+    </span>
+  ),
+}));
+
+const unionNode: UnionNode = {
+  controlType: "union",
+  key: "value",
+  label: "Value",
+  path: "value",
+  variants: [
+    { controlType: "text_input", key: "string", label: "String", path: "value" },
+    { controlType: "number_input", key: "int", label: "Int", path: "value" },
+  ],
+};
+
+describe("UnionRenderer", () => {
+  it("renders a radio per variant", () => {
+    render(<UnionRenderer node={unionNode} depth={1} path="value" />);
+    expect(screen.getByRole("radio", { name: "String" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Int" })).toBeInTheDocument();
+  });
+
+  it("infers the selected variant from the stored value type (string)", () => {
+    render(<UnionRenderer node={unionNode} depth={1} path="value" />);
+    expect(screen.getByTestId("variant")).toHaveTextContent("string");
+    expect(screen.getByRole("radio", { name: "String" })).toBeChecked();
+  });
+
+  it("dispatches setValue with the variant's empty value on radio change", () => {
+    render(<UnionRenderer node={unionNode} depth={1} path="value" />);
+    fireEvent.click(screen.getByRole("radio", { name: "Int" }));
+    expect(setValue).toHaveBeenCalledWith("value", 0);
+  });
+
+  it("uses the label verbatim when it is not a generic 'Variant N'", () => {
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [{ controlType: "text_input", key: "a", label: "String", path: "v" }],
+    };
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+    expect(screen.getByRole("radio", { name: "String" })).toBeInTheDocument();
+  });
+
+  it("falls back to a pretty controlType label when the schema label is 'Variant N'", () => {
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [
+        { controlType: "text_input", key: "a", label: "Variant 0", path: "v" },
+        { controlType: "toggle", key: "b", label: "Variant 1", path: "v" },
+        { controlType: "number_list", key: "c", label: "Variant 2", path: "v" },
+      ],
+    };
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+    expect(screen.getByRole("radio", { name: "Text" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Boolean" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Number list" })).toBeInTheDocument();
+  });
+
+  it("filters out empty-group variants", () => {
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [
+        { controlType: "text_input", key: "a", label: "Variant 0", path: "v" },
+        { controlType: "group", key: "b", label: "Variant 1", children: [], path: "v" },
+        { controlType: "toggle", key: "c", label: "Variant 2", path: "v" },
+      ],
+    };
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+    expect(screen.getByRole("radio", { name: "Text" })).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "Group" })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Boolean" })).toBeInTheDocument();
+  });
+
+  it("renders the first variant without a fieldset when every variant is filtered out", () => {
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [{ controlType: "group", key: "b", label: "Variant 0", children: [], path: "v" }],
+    };
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(screen.getByTestId("variant")).toHaveTextContent("b");
+  });
+
+  it("preserves the user's explicit List pick when inference is ambiguous between multiple array variants", () => {
+    // Simulate three array-shaped variants where inference cannot disambiguate.
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [
+        { controlType: "string_list", key: "a", label: "Variant 0", path: "v" },
+        {
+          controlType: "list",
+          key: "b",
+          label: "Variant 1",
+          path: "v",
+          itemSchema: { controlType: "toggle", key: "item", label: "Item", path: "v.item" },
+        },
+        { controlType: "number_list", key: "c", label: "Variant 2", path: "v" },
+      ],
+    };
+
+    // Value is "" (string) per the shared mock; start by rendering so the default selection
+    // is inferred from the string. First let's flip to "List" via a click.
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+
+    // Click the "List" radio. setValue dispatches [] which is ambiguous among all 3 array variants.
+    fireEvent.click(screen.getByRole("radio", { name: "List" }));
+
+    // After click, the "List" radio must remain checked — it must NOT snap back to "Text list".
+    expect(screen.getByRole("radio", { name: "List" })).toBeChecked();
+  });
+
+  it("renders the union's own label visibly, not only as a sr-only legend", () => {
+    render(<UnionRenderer node={unionNode} depth={1} path="value" />);
+    // There should be at least one visible (non-sr-only) element with the label text.
+    const elements = screen.getAllByText("Value");
+    const visibleElement = elements.find((el) => !el.classList.contains("sr-only"));
+    expect(visibleElement).toBeDefined();
+    // The visible label must not be a legend element.
+    expect(visibleElement!.tagName.toLowerCase()).not.toBe("legend");
+  });
+
+  it("renders the selected variant with hideLabel=true so inner ControlWrapper suppresses its own label", () => {
+    render(<UnionRenderer node={unionNode} depth={1} path="value" />);
+    const variantSpan = screen.getByTestId("variant");
+    expect(variantSpan.getAttribute("data-hide-label")).toBe("true");
+  });
+
+  it("lets unambiguous inference override a stale manualPick when the value type changes", () => {
+    const n: UnionNode = {
+      controlType: "union",
+      key: "v",
+      label: "V",
+      path: "v",
+      variants: [
+        { controlType: "text_input", key: "a", label: "String", path: "v" },
+        { controlType: "number_input", key: "b", label: "Number", path: "v" },
+      ],
+    };
+    // Shared mock stores values: { value: "x" }. Inference says text_input (String).
+    render(<UnionRenderer node={n} depth={1} path="v" />);
+    expect(screen.getByRole("radio", { name: "String" })).toBeChecked();
+
+    // User clicks Number -> setValue dispatches 0 -> inference is unambiguous (number_input wins).
+    fireEvent.click(screen.getByRole("radio", { name: "Number" }));
+    // We can't directly observe state post-click because our mock is static, but the click's
+    // setValue call should have been emitted with 0:
+    expect(setValue).toHaveBeenLastCalledWith("v", 0);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState } from "react";
+import type { JSX } from "react";
+import type { ConfigNode, UnionNode } from "@/types/configuration";
+import type { ConfigValue } from "@/types/configuration-builder";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SchemaRenderer } from "./schema-renderer";
+import { parsePath, getByPath } from "@/lib/config-path";
+
+export interface UnionRendererProps {
+  node: UnionNode;
+  depth: number;
+  path: string;
+}
+
+function variantMatches(v: ConfigNode, value: unknown): boolean {
+  switch (v.controlType) {
+    case "text_input":
+    case "select":
+      return typeof value === "string";
+    case "number_input":
+      return typeof value === "number";
+    case "toggle":
+    case "flag":
+      return typeof value === "boolean";
+    case "string_list":
+    case "number_list":
+    case "list":
+      return Array.isArray(value);
+    case "group":
+    case "plugin_select":
+    case "key_value_map":
+      return value !== null && typeof value === "object" && !Array.isArray(value);
+    default:
+      return false;
+  }
+}
+
+function inferVariantKey(value: unknown, variants: ConfigNode[]): string | null {
+  const matches = variants.filter((v) => variantMatches(v, value));
+  return matches.length === 1 ? matches[0].key : null;
+}
+
+function emptyValueFor(variant: ConfigNode): ConfigValue {
+  switch (variant.controlType) {
+    case "text_input":
+    case "select":
+      return "";
+    case "number_input":
+      return 0;
+    case "toggle":
+    case "flag":
+      return false;
+    case "string_list":
+    case "number_list":
+    case "list":
+      return [];
+    case "group":
+    case "plugin_select":
+    case "key_value_map":
+      return {};
+    default:
+      return null;
+  }
+}
+
+const CONTROL_TYPE_DISPLAY: Record<ConfigNode["controlType"], string> = {
+  text_input: "Text",
+  number_input: "Number",
+  toggle: "Boolean",
+  select: "Choice",
+  flag: "Flag",
+  string_list: "Text list",
+  number_list: "Number list",
+  list: "List",
+  key_value_map: "Map",
+  group: "Group",
+  union: "Variant",
+  plugin_select: "Plugin",
+  circular_ref: "Reference",
+};
+
+function displayLabel(variant: ConfigNode): string {
+  if (variant.label && !/^Variant \d+$/.test(variant.label)) return variant.label;
+  return CONTROL_TYPE_DISPLAY[variant.controlType] ?? variant.controlType;
+}
+
+function isRenderable(variant: ConfigNode): boolean {
+  if (variant.controlType === "group" && variant.children.length === 0) return false;
+  return true;
+}
+
+export function UnionRenderer({ node, depth, path }: UnionRendererProps): JSX.Element {
+  const { state, setValue } = useConfigurationBuilder();
+  const current = getByPath(state.values, parsePath(path));
+
+  const renderable = node.variants.filter(isRenderable);
+  const effectiveVariants = renderable.length > 0 ? renderable : node.variants.slice(0, 1);
+
+  const [manualPick, setManualPick] = useState<string | null>(null);
+  const inferred = inferVariantKey(current, effectiveVariants);
+  const selectedKey = inferred ?? manualPick ?? effectiveVariants[0]?.key ?? "";
+  const selectedVariant = effectiveVariants.find((v) => v.key === selectedKey);
+  const showChooser = renderable.length > 0;
+
+  const handleChange = (nextKey: string) => {
+    if (nextKey === selectedKey) return;
+    const nextVariant = effectiveVariants.find((v) => v.key === nextKey);
+    if (!nextVariant) return;
+    setManualPick(nextKey);
+    setValue(path, emptyValueFor(nextVariant));
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-foreground">{node.label}</p>
+      {node.description && <p className="text-xs text-muted-foreground">{node.description}</p>}
+      {showChooser && (
+        <fieldset>
+          <legend className="sr-only">{node.label}</legend>
+          <div className="flex flex-wrap gap-2">
+            {effectiveVariants.map((v) => (
+              <label key={v.key} className="flex items-center gap-2 text-xs text-muted-foreground">
+                <input
+                  type="radio"
+                  name={`${path}-variant`}
+                  value={v.key}
+                  checked={selectedKey === v.key}
+                  onChange={() => handleChange(v.key)}
+                />
+                {displayLabel(v)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      )}
+      {selectedVariant && (
+        <SchemaRenderer
+          key={selectedVariant.key}
+          node={{ ...selectedVariant, hideLabel: true } as ConfigNode}
+          depth={depth + 1}
+          path={path}
+        />
+      )}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -13,99 +13,112 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useMemo, useState } from "react";
 import { BackButton } from "@/components/ui/back-button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { VersionSelector } from "@/features/java-agent/components/version-selector";
+import {
+  useConfigVersions,
+  useConfigSchema,
+  useConfigStarter,
+} from "@/hooks/use-configuration-data";
+import { ConfigurationBuilderProvider } from "@/hooks/configuration-builder-provider";
+import type { GroupNode } from "@/types/configuration";
+import { SchemaRenderer } from "./components/schema-renderer";
+import { PreviewCard } from "./components/preview-card";
+
+function SdkTab({ version }: { version: string }) {
+  const schema = useConfigSchema(version);
+  const starter = useConfigStarter(version);
+
+  if (schema.loading || starter.loading) {
+    return <p className="mt-4 text-sm text-muted-foreground">Loading schema…</p>;
+  }
+  if (schema.error || !schema.data) {
+    return <p className="mt-4 text-sm text-red-400">Failed to load schema.</p>;
+  }
+  if (starter.error) {
+    return <p className="mt-4 text-sm text-red-400">Failed to load starter template.</p>;
+  }
+
+  const root = schema.data as GroupNode;
+  const visibleChildren = root.children.filter((c) => c.key !== "file_format");
+  const groupChildren = visibleChildren.filter((c) => c.controlType === "group");
+  const leafChildren = visibleChildren.filter((c) => c.controlType !== "group");
+
+  return (
+    <ConfigurationBuilderProvider
+      key={version}
+      schema={schema.data}
+      version={version}
+      starter={starter.data}
+    >
+      <div className="mt-4 grid gap-6 md:grid-cols-2">
+        <div className="space-y-4">
+          {leafChildren.length > 0 && (
+            <section className="rounded-xl border border-border/50 bg-card/40 p-5 space-y-3">
+              <h3 className="text-base font-semibold text-foreground">General</h3>
+              {leafChildren.map((child) => (
+                <SchemaRenderer key={child.key} node={child} depth={1} path={child.key} />
+              ))}
+            </section>
+          )}
+          {groupChildren.map((child) => (
+            <SchemaRenderer key={child.key} node={child} depth={0} path={child.key} />
+          ))}
+        </div>
+        <PreviewCard schema={schema.data} />
+      </div>
+    </ConfigurationBuilderProvider>
+  );
+}
 
 export function ConfigurationBuilderPage() {
+  const versions = useConfigVersions();
+  const latest = useMemo(
+    () =>
+      versions.data?.versions.find((v) => v.is_latest)?.version ??
+      versions.data?.versions[0]?.version ??
+      "",
+    [versions.data]
+  );
+  const [currentVersion, setCurrentVersion] = useState<string>("");
+  const version = currentVersion || latest;
+
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
       <div className="space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex items-center">
           <BackButton />
-          {/* Version Dropdown - not hooked up yet */}
-          <div className="flex items-center gap-2">
-            <label htmlFor="java-agent-version" className="text-sm text-foreground">
-              Version
-            </label>
-            <select
-              id="java-agent-version"
-              className="rounded-md border border-border/50 bg-card/80 px-3 py-2 text-sm text-foreground"
-            >
-              <option>2.25.0 (latest)</option>
-            </select>
-          </div>
         </div>
-
         <div>
           <h1 className="text-3xl font-bold text-foreground mb-2">Configuration Builder</h1>
           <p className="text-muted-foreground">
             Build and customize your OpenTelemetry Java Agent configuration
           </p>
         </div>
-
-        {/* Tabs */}
         <Tabs defaultValue="sdk">
           <TabsList>
             <TabsTrigger value="sdk">SDK</TabsTrigger>
             <TabsTrigger value="instrumentation">Instrumentation</TabsTrigger>
           </TabsList>
-
           <TabsContent value="sdk">
-            <div className="mt-4 grid grid-cols-2 gap-6">
-              {/* Left Column - Controls */}
-              <div className="rounded-lg border border-border/50 bg-card/50 p-6 min-h-96">
-                <p className="text-muted-foreground text-sm">SDK controls will appear here</p>
-              </div>
-
-              {/* Right Column - Output Preview */}
-              <div className="rounded-lg border border-border/50 bg-card/50 p-6 min-h-96">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-medium text-foreground">Output Preview</h3>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      className="rounded-md border border-border/50 bg-card px-3 py-1 text-sm text-foreground hover:bg-card/80"
-                    >
-                      Copy
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-md border border-border/50 bg-card px-3 py-1 text-sm text-foreground hover:bg-card/80"
-                    >
-                      Download
-                    </button>
-                  </div>
-                </div>
-                <p className="text-muted-foreground text-sm">YAML output will appear here</p>
-              </div>
+            <div className="mt-4 flex items-center justify-end">
+              {versions.data && version ? (
+                <VersionSelector
+                  versions={versions.data.versions}
+                  currentVersion={version}
+                  onVersionChange={setCurrentVersion}
+                  label="Schema version"
+                  id="config-schema-version"
+                />
+              ) : null}
             </div>
+            {version ? <SdkTab version={version} /> : null}
           </TabsContent>
-
           <TabsContent value="instrumentation">
-            <div className="mt-4 grid grid-cols-2 gap-6">
-              {/* Left Column */}
-              <div className="rounded-lg border border-border/50 bg-card/50 p-6 min-h-96">
-                <p className="text-muted-foreground text-sm">
-                  Instrumentation controls will appear here
-                </p>
-              </div>
-
-              {/* Right Column */}
-              <div className="rounded-lg border border-border/50 bg-card/50 p-6 min-h-96">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-medium text-foreground">Output Preview</h3>
-                  <div className="flex gap-2">
-                    <button className="rounded-md border border-border/50 bg-card px-3 py-1 text-sm text-foreground hover:bg-card/80">
-                      Copy
-                    </button>
-                    <button className="rounded-md border border-border/50 bg-card px-3 py-1 text-sm text-foreground hover:bg-card/80">
-                      Download
-                    </button>
-                  </div>
-                </div>
-                <p className="text-muted-foreground text-sm">YAML output will appear here</p>
-              </div>
+            <div className="mt-4 rounded-xl border border-border/40 bg-card/30 p-8 text-center text-sm text-muted-foreground">
+              Instrumentation browser is coming in a follow-up PR (#250).
             </div>
           </TabsContent>
         </Tabs>

--- a/ecosystem-explorer/src/features/java-agent/configuration/starter-template.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/configuration/starter-template.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  ConfigNode,
+  GroupNode,
+  ListNode,
+  PluginSelectNode,
+  ConfigStarter,
+} from "@/types/configuration";
+import type { ConfigValue, ConfigValues } from "@/types/configuration-builder";
+import { findNodeByPath } from "@/lib/schema-defaults";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadJson<T>(relPath: string): T {
+  const abs = resolve(__dirname, "../../../../public/data/configuration", relPath);
+  return JSON.parse(readFileSync(abs, "utf-8")) as T;
+}
+
+function walk(
+  value: ConfigValue,
+  pathSegments: (string | number)[],
+  schema: ConfigNode,
+  errors: string[]
+): void {
+  const currentSchemaNode = findNodeByPath(schema, pathSegments);
+  if (
+    Array.isArray(value) &&
+    currentSchemaNode?.controlType === "list" &&
+    (currentSchemaNode as ListNode).itemSchema.controlType === "plugin_select"
+  ) {
+    const pluginSchema = (currentSchemaNode as ListNode).itemSchema as PluginSelectNode;
+    const validKeys = new Set(pluginSchema.options.map((o) => o.key));
+    value.forEach((item, i) => {
+      if (item === null || typeof item !== "object" || Array.isArray(item)) {
+        errors.push(
+          `list item is not an object at ${[...pathSegments, i].join(".")} (itemSchema is plugin_select, expected single-key object)`
+        );
+        return;
+      }
+      const keys = Object.keys(item as ConfigValues);
+      if (keys.length !== 1) {
+        errors.push(
+          `plugin_select list item must have exactly one key at ${[...pathSegments, i].join(".")} (got ${keys.length})`
+        );
+        return;
+      }
+      if (!pluginSchema.allowCustom && !validKeys.has(keys[0])) {
+        errors.push(`unknown plugin key "${keys[0]}" at ${[...pathSegments, i].join(".")}`);
+      }
+    });
+  }
+
+  if (value === null || typeof value !== "object") return;
+
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => walk(item, [...pathSegments, i], schema, errors));
+    return;
+  }
+  for (const [k, v] of Object.entries(value as ConfigValues)) {
+    const segs = [...pathSegments, k];
+    const resolved = findNodeByPath(schema, segs);
+    if (!resolved) {
+      errors.push(`path not resolvable in schema: ${segs.join(".")}`);
+      continue;
+    }
+    walk(v, segs, schema, errors);
+  }
+}
+
+describe("1.0.0.starter.json shape", () => {
+  const schema = loadJson<ConfigNode>("versions/1.0.0.json");
+  const starter = loadJson<ConfigStarter>("versions/1.0.0.starter.json");
+
+  it("every enabledSections key is a top-level group in the schema", () => {
+    expect(schema.controlType).toBe("group");
+    const topKeys = (schema as GroupNode).children.reduce<Record<string, string>>((acc, c) => {
+      acc[c.key] = c.controlType;
+      return acc;
+    }, {});
+    for (const [key, on] of Object.entries(starter.enabledSections)) {
+      expect(on).toBe(true);
+      expect(topKeys[key]).toBe("group");
+    }
+  });
+
+  it("every values path resolves in the schema and list items match their itemSchema", () => {
+    const errors: string[] = [];
+    walk(starter.values, [], schema, errors);
+    expect(errors).toEqual([]);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
@@ -36,7 +36,10 @@ function renderPage(initialPath = "/java-agent/instrumentation/2.0.0") {
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
-        <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
+        <Route
+          path="/java-agent/instrumentation/:version"
+          element={<JavaInstrumentationListPage />}
+        />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/hooks/configuration-builder-provider.tsx
+++ b/ecosystem-explorer/src/hooks/configuration-builder-provider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useMemo, type ReactNode } from "react";
-import type { ConfigNode } from "@/types/configuration";
+import type { ConfigNode, ConfigStarter } from "@/types/configuration";
 import {
   useConfigurationBuilderState,
   ConfigStateContext,
@@ -24,28 +24,22 @@ import {
 interface ConfigurationBuilderProviderProps {
   schema: ConfigNode;
   version: string;
+  starter: ConfigStarter | null;
   children: ReactNode;
 }
 
 export function ConfigurationBuilderProvider({
   schema,
   version,
+  starter,
   children,
 }: ConfigurationBuilderProviderProps) {
-  const { state, ...actions } = useConfigurationBuilderState(schema, version);
-
+  const { state, actions } = useConfigurationBuilderState(schema, version, starter);
   const stateValue = useMemo(() => ({ state }), [state]);
-  const actionsValue = useMemo(
-    () => actions,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
 
   return (
     <ConfigStateContext.Provider value={stateValue}>
-      <ConfigDispatchContext.Provider value={actionsValue}>
-        {children}
-      </ConfigDispatchContext.Provider>
+      <ConfigDispatchContext.Provider value={actions}>{children}</ConfigDispatchContext.Provider>
     </ConfigStateContext.Provider>
   );
 }

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
@@ -261,4 +261,64 @@ describe("configurationBuilderReducer", () => {
       expect(result.validationErrors).toEqual({ other: "Error" });
     });
   });
+
+  describe("SET_ENABLED null-leftover predicate", () => {
+    it("populates defaults when the section value is null", () => {
+      const initial: ConfigurationBuilderState = {
+        version: "1.0.0",
+        values: { resource: null },
+        enabledSections: {},
+        validationErrors: {},
+        isDirty: false,
+      };
+      const next = configurationBuilderReducer(initial, {
+        type: "SET_ENABLED",
+        section: "resource",
+        enabled: true,
+        defaults: { attributes: [] },
+      });
+      expect(next.values.resource).toEqual({ attributes: [] });
+      expect(next.enabledSections.resource).toBe(true);
+    });
+  });
+
+  describe("ENABLE_ALL_SECTIONS", () => {
+    it("enables every section and populates defaults for empty ones", () => {
+      const initial: ConfigurationBuilderState = {
+        version: "1.0.0",
+        values: { resource: { attributes: [{ name: "service.name", value: "svc" }] } },
+        enabledSections: { resource: true },
+        validationErrors: {},
+        isDirty: false,
+      };
+      const next = configurationBuilderReducer(initial, {
+        type: "ENABLE_ALL_SECTIONS",
+        defaultsBySection: {
+          resource: { attributes: [] },
+          tracer_provider: { processors: [] },
+        },
+      });
+      expect(next.enabledSections).toEqual({ resource: true, tracer_provider: true });
+      expect(next.values.resource).toEqual({
+        attributes: [{ name: "service.name", value: "svc" }],
+      });
+      expect(next.values.tracer_provider).toEqual({ processors: [] });
+      expect(next.isDirty).toBe(true);
+    });
+
+    it("leaves isDirty false when no section changed", () => {
+      const initial: ConfigurationBuilderState = {
+        version: "1.0.0",
+        values: { resource: {}, tracer_provider: {} },
+        enabledSections: { resource: true, tracer_provider: true },
+        validationErrors: {},
+        isDirty: false,
+      };
+      const next = configurationBuilderReducer(initial, {
+        type: "ENABLE_ALL_SECTIONS",
+        defaultsBySection: { resource: {}, tracer_provider: {} },
+      });
+      expect(next.isDirty).toBe(false);
+    });
+  });
 });

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
@@ -20,6 +20,7 @@ import type {
   ConfigValue,
 } from "@/types/configuration-builder";
 import { getByPath, setByPath, serializePath } from "@/lib/config-path";
+import { hasUserValues } from "@/lib/state-hydrate";
 
 export const INITIAL_STATE: ConfigurationBuilderState = {
   version: "",
@@ -47,7 +48,7 @@ export function configurationBuilderReducer(
     }
 
     case "SET_ENABLED": {
-      const hasExistingValues = state.values[action.section] !== undefined;
+      const hasExistingValues = hasUserValues(state.values[action.section]);
       const newValues =
         action.enabled && !hasExistingValues && action.defaults
           ? { ...state.values, [action.section]: action.defaults }
@@ -135,6 +136,24 @@ export function configurationBuilderReducer(
         ...state,
         validationErrors: { ...state.validationErrors, [action.path]: action.error },
       };
+    }
+
+    case "ENABLE_ALL_SECTIONS": {
+      const newEnabled: Record<string, boolean> = { ...state.enabledSections };
+      const newValues: ConfigValues = { ...state.values };
+      let changed = false;
+      for (const [key, defaults] of Object.entries(action.defaultsBySection)) {
+        if (newEnabled[key] !== true) {
+          newEnabled[key] = true;
+          changed = true;
+        }
+        if (!hasUserValues(newValues[key])) {
+          newValues[key] = defaults;
+          changed = true;
+        }
+      }
+      if (!changed) return state;
+      return { ...state, values: newValues, enabledSections: newEnabled, isDirty: true };
     }
 
     default:

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
@@ -16,7 +16,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useConfigurationBuilderState } from "./use-configuration-builder";
-import type { GroupNode, NumberInputNode, TextInputNode } from "@/types/configuration";
+import type {
+  ConfigNode,
+  ConfigStarter,
+  GroupNode,
+  NumberInputNode,
+  TextInputNode,
+} from "@/types/configuration";
 
 const STORAGE_KEY = "otel-config-builder-state-v1";
 
@@ -63,13 +69,13 @@ afterEach(() => {
 
 describe("useConfigurationBuilderState", () => {
   it("should initialize with empty state", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     expect(result.current.state.values).toEqual({});
     expect(result.current.state.isDirty).toBe(false);
   });
 
   it("should set a value", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.setValue("file_format", "1.0");
     });
@@ -78,7 +84,7 @@ describe("useConfigurationBuilderState", () => {
   });
 
   it("should enable a section with defaults", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.setEnabled("attribute_limits", true);
     });
@@ -87,7 +93,7 @@ describe("useConfigurationBuilderState", () => {
   });
 
   it("should reset to defaults", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.setValue("file_format", "1.0");
       result.current.resetToDefaults();
@@ -97,20 +103,20 @@ describe("useConfigurationBuilderState", () => {
   });
 
   it("should validate a field", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     const error = result.current.validateField("file_format");
     expect(error).toBe("Required");
   });
 
   it("should validate all fields", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     const validation = result.current.validateAll();
     expect(validation.valid).toBe(false);
     expect(validation.errors.file_format).toBe("Required");
   });
 
   it("should auto-clear validation error on setValue", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.validateAll();
     });
@@ -122,7 +128,7 @@ describe("useConfigurationBuilderState", () => {
   });
 
   it("should clear validation error explicitly", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.validateAll();
     });
@@ -134,7 +140,7 @@ describe("useConfigurationBuilderState", () => {
   });
 
   it("should leave other errors untouched when clearing one", () => {
-    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {
       result.current.setEnabled("attribute_limits", true);
     });
@@ -157,47 +163,9 @@ describe("useConfigurationBuilderState", () => {
     ).toBeUndefined();
   });
 
-  it("should reset state when version changes", () => {
-    const { result, rerender } = renderHook(
-      ({ version }) => useConfigurationBuilderState(mockSchema, version),
-      { initialProps: { version: "1.0.0" } }
-    );
-
-    act(() => {
-      result.current.setValue("file_format", "1.0");
-    });
-    expect(result.current.state.values.file_format).toBe("1.0");
-
-    rerender({ version: "2.0.0" });
-
-    expect(result.current.state.values).toEqual({});
-    expect(result.current.state.version).toBe("2.0.0");
-  });
-
-  it("should not persist stale state under new version key after switch", () => {
-    const { result, rerender } = renderHook(
-      ({ version }) => useConfigurationBuilderState(mockSchema, version),
-      { initialProps: { version: "1.0.0" } }
-    );
-
-    act(() => {
-      result.current.setValue("file_format", "1.0");
-    });
-    rerender({ version: "2.0.0" });
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const saved = JSON.parse(raw);
-      expect(saved.state.values).toEqual({});
-    }
-  });
-
   describe("loadFromYaml", () => {
     it("should populate state from valid YAML", async () => {
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       vi.useRealTimers();
       await act(async () => {
         await result.current.loadFromYaml(
@@ -209,7 +177,7 @@ describe("useConfigurationBuilderState", () => {
     });
 
     it("should throw a controlled error on invalid YAML", async () => {
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       vi.useRealTimers();
       await expect(result.current.loadFromYaml("key: value\n  bad indent: x")).rejects.toThrow(
         /Failed to parse YAML/
@@ -217,7 +185,7 @@ describe("useConfigurationBuilderState", () => {
     });
 
     it("should ignore non-object YAML", async () => {
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       vi.useRealTimers();
       await act(async () => {
         await result.current.loadFromYaml("just a string");
@@ -228,7 +196,7 @@ describe("useConfigurationBuilderState", () => {
 
   describe("localStorage persistence", () => {
     it("should save to localStorage after debounce", () => {
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       act(() => {
         result.current.setValue("file_format", "1.0");
       });
@@ -254,7 +222,7 @@ describe("useConfigurationBuilderState", () => {
           },
         })
       );
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       expect(result.current.state.values.file_format).toBe("1.0");
     });
 
@@ -272,8 +240,117 @@ describe("useConfigurationBuilderState", () => {
           },
         })
       );
-      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0"));
+      const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
       expect(result.current.state.values).toEqual({});
     });
+  });
+
+  it("resetToDefaults with starter hydrates from starter", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "resource",
+          label: "Resource",
+          path: "resource",
+          children: [],
+        },
+      ],
+    };
+    const starter: ConfigStarter = {
+      enabledSections: { resource: true },
+      values: { resource: { attributes: [] } },
+    };
+    const { result } = renderHook(() => useConfigurationBuilderState(schema, "1.0.0", starter));
+    act(() => result.current.setEnabled("resource", false));
+    expect(result.current.state.enabledSections.resource).toBe(false);
+    act(() => result.current.resetToDefaults());
+    expect(result.current.state.enabledSections.resource).toBe(true);
+    expect(result.current.state.values.resource).toEqual({ attributes: [] });
+  });
+
+  it("enableAllSections enables every top-level group child", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "resource",
+          label: "Resource",
+          path: "resource",
+          children: [],
+        },
+        {
+          controlType: "group",
+          key: "tracer_provider",
+          label: "TracerProvider",
+          path: "tracer_provider",
+          children: [],
+        },
+        {
+          controlType: "text_input",
+          key: "file_format",
+          label: "File Format",
+          path: "file_format",
+        },
+      ],
+    };
+    const { result } = renderHook(() => useConfigurationBuilderState(schema, "1.0.0", null));
+    act(() => result.current.enableAllSections());
+    expect(result.current.state.enabledSections.resource).toBe(true);
+    expect(result.current.state.enabledSections.tracer_provider).toBe(true);
+    expect(result.current.state.enabledSections.file_format).toBeUndefined();
+  });
+
+  it("selectPlugin works for a plugin_select inside a list item", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "list",
+          key: "processors",
+          label: "Processors",
+          path: "processors",
+          itemSchema: {
+            controlType: "plugin_select",
+            key: "item",
+            label: "Item",
+            path: "processors.item",
+            allowCustom: false,
+            options: [
+              {
+                controlType: "group",
+                key: "batch",
+                label: "Batch",
+                path: "processors.item.batch",
+                children: [],
+              },
+              {
+                controlType: "group",
+                key: "simple",
+                label: "Simple",
+                path: "processors.item.simple",
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const { result } = renderHook(() => useConfigurationBuilderState(schema, "1.0.0", null));
+    act(() => result.current.addListItem("processors"));
+    expect(result.current.state.values.processors).toEqual([{ batch: {} }]);
+    act(() => result.current.selectPlugin("processors[0]", "simple"));
+    expect((result.current.state.values.processors as unknown[])[0]).toEqual({ simple: {} });
   });
 });

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.ts
@@ -13,15 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useReducer, useEffect, useCallback, useRef, createContext, useContext } from "react";
-import type { ConfigNode, ListNode, PluginSelectNode } from "@/types/configuration";
+import {
+  useReducer,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+  createContext,
+  useContext,
+} from "react";
+import type {
+  ConfigNode,
+  ConfigStarter,
+  GroupNode,
+  ListNode,
+  PluginSelectNode,
+} from "@/types/configuration";
 import type {
   ConfigValue,
   ConfigValues,
   ConfigurationBuilderState,
   ValidationResult,
 } from "@/types/configuration-builder";
-import { configurationBuilderReducer, INITIAL_STATE } from "./configuration-builder-reducer";
+import { configurationBuilderReducer } from "./configuration-builder-reducer";
 import { parsePath, serializePath, getByPath } from "@/lib/config-path";
 import {
   buildDefaults,
@@ -29,6 +43,7 @@ import {
   buildPluginDefaults,
   findNodeByPath,
 } from "@/lib/schema-defaults";
+import { hydrateStarterState } from "@/lib/state-hydrate";
 import {
   validateField as validateFieldNode,
   validateAll as validateAllNodes,
@@ -49,6 +64,7 @@ export interface ConfigurationBuilderActionsContextValue {
   setMapEntry: (path: string, key: string, value: string) => void;
   removeMapEntry: (path: string, key: string) => void;
   resetToDefaults: () => void;
+  enableAllSections: () => void;
   loadFromYaml: (yaml: string) => Promise<void>;
   validateField: (path: string) => string | null;
   validateAll: () => ValidationResult;
@@ -86,34 +102,28 @@ function saveToStorage(version: string, state: ConfigurationBuilderState): void 
   }
 }
 
-export function useConfigurationBuilderState(schema: ConfigNode, version: string) {
+export function useConfigurationBuilderState(
+  schema: ConfigNode,
+  version: string,
+  starter: ConfigStarter | null
+) {
   const [state, dispatch] = useReducer(
     configurationBuilderReducer,
     version,
-    (v) => loadFromStorage(v) ?? { ...INITIAL_STATE, version: v }
+    (v) => loadFromStorage(v) ?? hydrateStarterState(v, starter)
   );
   const stateRef = useRef(state);
   const schemaRef = useRef(schema);
   const versionRef = useRef(version);
-  const loadedVersionRef = useRef(version);
+  const starterRef = useRef(starter);
 
   // Keep refs in sync so callbacks always have access to the latest values
   useEffect(() => {
     stateRef.current = state;
     schemaRef.current = schema;
     versionRef.current = version;
-  }, [state, schema, version]);
-
-  // Reload state when version changes
-  useEffect(() => {
-    if (loadedVersionRef.current === version) return;
-    loadedVersionRef.current = version;
-    const saved = loadFromStorage(version);
-    dispatch({
-      type: "LOAD_STATE",
-      state: saved ?? { ...INITIAL_STATE, version },
-    });
-  }, [version]);
+    starterRef.current = starter;
+  }, [state, schema, version, starter]);
 
   // Debounced localStorage save
   useEffect(() => {
@@ -154,10 +164,7 @@ export function useConfigurationBuilderState(schema: ConfigNode, version: string
 
   const selectPlugin = useCallback((path: string, pluginKey: string) => {
     const segments = parsePath(path);
-    const node = findNodeByPath(
-      schemaRef.current,
-      segments.filter((s) => typeof s === "string")
-    );
+    const node = findNodeByPath(schemaRef.current, segments);
     if (node && node.controlType === "plugin_select") {
       const defaults = buildPluginDefaults(node as PluginSelectNode, pluginKey);
       dispatch({ type: "SELECT_PLUGIN", path: segments, pluginKey, defaults });
@@ -166,10 +173,7 @@ export function useConfigurationBuilderState(schema: ConfigNode, version: string
 
   const addListItem = useCallback((path: string) => {
     const segments = parsePath(path);
-    const node = findNodeByPath(
-      schemaRef.current,
-      segments.filter((s) => typeof s === "string")
-    );
+    const node = findNodeByPath(schemaRef.current, segments);
     if (
       node &&
       (node.controlType === "list" ||
@@ -194,8 +198,25 @@ export function useConfigurationBuilderState(schema: ConfigNode, version: string
   }, []);
 
   const resetToDefaults = useCallback(() => {
-    dispatch({ type: "RESET_TO_DEFAULTS" });
+    dispatch({
+      type: "LOAD_STATE",
+      state: hydrateStarterState(versionRef.current, starterRef.current),
+    });
     localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  const enableAllSections = useCallback(() => {
+    const schema = schemaRef.current;
+    if (!schema || schema.controlType !== "group") return;
+    const defaultsBySection: Record<string, ConfigValues> = {};
+    for (const child of (schema as GroupNode).children) {
+      if (child.controlType !== "group") continue;
+      const built = buildDefaults(child);
+      if (typeof built === "object" && built !== null && !Array.isArray(built)) {
+        defaultsBySection[child.key] = built as ConfigValues;
+      }
+    }
+    dispatch({ type: "ENABLE_ALL_SECTIONS", defaultsBySection });
   }, []);
 
   const loadFromYaml = useCallback(async (yaml: string) => {
@@ -231,10 +252,7 @@ export function useConfigurationBuilderState(schema: ConfigNode, version: string
 
   const validateFieldAction = useCallback((path: string): string | null => {
     const segments = parsePath(path);
-    const node = findNodeByPath(
-      schemaRef.current,
-      segments.filter((s) => typeof s === "string")
-    );
+    const node = findNodeByPath(schemaRef.current, segments);
     if (!node) return null;
     const value = getByPath(stateRef.current.values, segments);
     const error = validateFieldNode(node, value);
@@ -258,21 +276,28 @@ export function useConfigurationBuilderState(schema: ConfigNode, version: string
     dispatch({ type: "SET_FIELD_ERROR", path: pathKey, error: null });
   }, []);
 
-  return {
-    state,
-    setValue,
-    setEnabled,
-    selectPlugin,
-    addListItem,
-    removeListItem,
-    setMapEntry,
-    removeMapEntry,
-    resetToDefaults,
-    loadFromYaml,
-    validateField: validateFieldAction,
-    validateAll: validateAllAction,
-    clearValidationError,
-  };
+  const actions = useMemo(
+    () => ({
+      setValue,
+      setEnabled,
+      selectPlugin,
+      addListItem,
+      removeListItem,
+      setMapEntry,
+      removeMapEntry,
+      resetToDefaults,
+      enableAllSections,
+      loadFromYaml,
+      validateField: validateFieldAction,
+      validateAll: validateAllAction,
+      clearValidationError,
+    }),
+    // all callbacks are stable; resetToDefaults reads starter via ref
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return { state, ...actions, actions };
 }
 
 export function useConfigurationBuilder() {

--- a/ecosystem-explorer/src/hooks/use-configuration-data.test.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-data.test.ts
@@ -15,12 +15,13 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { useConfigVersions, useConfigSchema } from "./use-configuration-data";
+import { useConfigVersions, useConfigSchema, useConfigStarter } from "./use-configuration-data";
 import type { ConfigVersionsIndex, GroupNode } from "@/types/configuration";
 
 vi.mock("@/lib/api/configuration-data", () => ({
   loadConfigVersions: vi.fn(),
   loadConfigSchema: vi.fn(),
+  loadConfigStarter: vi.fn(),
 }));
 
 import * as configData from "@/lib/api/configuration-data";
@@ -178,5 +179,29 @@ describe("useConfigSchema", () => {
 
     expect(result.current.data).toBeNull();
     expect(result.current.error).toEqual(new Error("Schema not found"));
+  });
+});
+
+describe("useConfigStarter", () => {
+  it("resolves to the parsed starter", async () => {
+    vi.mocked(configData.loadConfigStarter).mockResolvedValue({
+      enabledSections: { resource: true },
+      values: { resource: {} },
+    });
+    const { result } = renderHook(() => useConfigStarter("1.0.0"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual({
+      enabledSections: { resource: true },
+      values: { resource: {} },
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resolves to null when the loader resolves null (404)", async () => {
+    vi.mocked(configData.loadConfigStarter).mockResolvedValue(null);
+    const { result } = renderHook(() => useConfigStarter("1.0.0"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
   });
 });

--- a/ecosystem-explorer/src/hooks/use-configuration-data.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-data.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useState, useEffect } from "react";
-import type { ConfigVersionsIndex, ConfigNode } from "@/types/configuration";
+import type { ConfigVersionsIndex, ConfigNode, ConfigStarter } from "@/types/configuration";
 import type { DataState } from "./data-state";
 import * as configData from "@/lib/api/configuration-data";
 
@@ -91,6 +91,43 @@ export function useConfigSchema(version: string): DataState<ConfigNode> {
 
     loadData();
 
+    return () => {
+      cancelled = true;
+    };
+  }, [version]);
+
+  return state;
+}
+
+export function useConfigStarter(version: string): DataState<ConfigStarter | null> {
+  const [state, setState] = useState<DataState<ConfigStarter | null>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadData() {
+      if (!version) {
+        setState({ data: null, loading: false, error: null });
+        return;
+      }
+      setState({ data: null, loading: true, error: null });
+      try {
+        const data = await configData.loadConfigStarter(version);
+        if (!cancelled) setState({ data, loading: false, error: null });
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            data: null,
+            loading: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+        }
+      }
+    }
+    loadData();
     return () => {
       cancelled = true;
     };

--- a/ecosystem-explorer/src/lib/api/configuration-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/configuration-data.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "fake-indexeddb/auto";
 import * as configData from "./configuration-data";
+import { loadConfigStarter } from "./configuration-data";
 import * as idbCache from "./idb-cache";
 import type { ConfigVersionsIndex, GroupNode } from "@/types/configuration";
 
@@ -134,6 +135,45 @@ describe("configuration-data", () => {
       await expect(configData.loadConfigSchema("1.0.0")).rejects.toThrow(
         "Failed to load config-schema-1.0.0: 500 Internal Server Error"
       );
+    });
+  });
+
+  describe("loadConfigStarter", () => {
+    beforeEach(async () => {
+      idbCache.closeDB();
+      await new Promise<void>((resolve) => {
+        const deleteRequest = indexedDB.deleteDatabase("otel-explorer-cache");
+        deleteRequest.onsuccess = () => resolve();
+        deleteRequest.onerror = () => resolve();
+      });
+    });
+
+    it("returns parsed starter on 200", async () => {
+      const body = { enabledSections: { resource: true }, values: { resource: {} } };
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify(body), { status: 200 })
+        ) as unknown as typeof fetch;
+      const result = await loadConfigStarter("1.0.0");
+      expect(result).toEqual(body);
+    });
+
+    it("returns null on 404", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response("nope", { status: 404, statusText: "Not Found" })
+        ) as unknown as typeof fetch;
+      const result = await loadConfigStarter("9.9.9");
+      expect(result).toBeNull();
+    });
+
+    it("throws on 500", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response("boom", { status: 500 })) as unknown as typeof fetch;
+      await expect(loadConfigStarter("1.0.0")).rejects.toThrow(/500/);
     });
   });
 });

--- a/ecosystem-explorer/src/lib/api/configuration-data.ts
+++ b/ecosystem-explorer/src/lib/api/configuration-data.ts
@@ -13,24 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ConfigVersionsIndex, ConfigNode } from "@/types/configuration";
+import type { ConfigVersionsIndex, ConfigNode, ConfigStarter } from "@/types/configuration";
 import { STORES } from "./idb-cache";
 import { fetchWithCache } from "./fetch-with-cache";
 
 const BASE_PATH = "/data/configuration";
 
 export async function loadConfigVersions(): Promise<ConfigVersionsIndex> {
-  return fetchWithCache<ConfigVersionsIndex>(
+  const data = await fetchWithCache<ConfigVersionsIndex>(
     "config-versions-index",
     `${BASE_PATH}/versions-index.json`,
     STORES.CONFIGURATION
   );
+  if (!data) throw new Error("Versions index returned null unexpectedly");
+  return data;
 }
 
 export async function loadConfigSchema(version: string): Promise<ConfigNode> {
-  return fetchWithCache<ConfigNode>(
+  const data = await fetchWithCache<ConfigNode>(
     `config-schema-${version}`,
     `${BASE_PATH}/versions/${version}.json`,
     STORES.CONFIGURATION
+  );
+  if (!data) throw new Error(`Schema for version ${version} returned null unexpectedly`);
+  return data;
+}
+
+export async function loadConfigStarter(version: string): Promise<ConfigStarter | null> {
+  return fetchWithCache<ConfigStarter>(
+    `config-starter-${version}`,
+    `${BASE_PATH}/versions/${version}.starter.json`,
+    STORES.CONFIGURATION,
+    { allow404: true }
   );
 }

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { fetchWithCache } from "./fetch-with-cache";
 import * as idbCache from "./idb-cache";
+import { STORES } from "./idb-cache";
 
 declare const global: typeof globalThis;
 
@@ -115,5 +116,39 @@ describe("fetchWithCache", () => {
 
     expect(result).toEqual(data);
     expect(global.fetch).toHaveBeenCalledWith("/url");
+  });
+
+  it("returns null when allow404 is true and response is 404", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("not found", { status: 404, statusText: "Not Found" })
+      ) as unknown as typeof fetch;
+    const result = await fetchWithCache("test-404-soft", "/missing.json", STORES.CONFIGURATION, {
+      allow404: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("throws on 404 when allow404 is not set", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("not found", { status: 404, statusText: "Not Found" })
+      ) as unknown as typeof fetch;
+    await expect(
+      fetchWithCache("test-404-hard", "/missing.json", STORES.CONFIGURATION)
+    ).rejects.toThrow(/404/);
+  });
+
+  it("throws on 500 even when allow404 is true", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("boom", { status: 500, statusText: "Internal Server Error" })
+      ) as unknown as typeof fetch;
+    await expect(
+      fetchWithCache("test-500-soft", "/broken.json", STORES.CONFIGURATION, { allow404: true })
+    ).rejects.toThrow(/500/);
   });
 });

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
@@ -36,7 +36,6 @@ export async function fetchWithCache<T>(
       if (isIDBAvailable()) {
         const cachedData = await getCached<T>(cacheKey, storeType);
         if (cachedData !== null) {
-          inflightRequests.delete(cacheKey);
           return cachedData;
         }
       }
@@ -44,7 +43,6 @@ export async function fetchWithCache<T>(
       const response = await fetch(url);
       if (!response.ok) {
         if (response.status === 404 && options?.allow404) {
-          inflightRequests.delete(cacheKey);
           return null;
         }
         throw new Error(`Failed to load ${cacheKey}: ${response.status} ${response.statusText}`);
@@ -60,11 +58,9 @@ export async function fetchWithCache<T>(
         }
       }
 
-      inflightRequests.delete(cacheKey);
       return data;
-    } catch (error) {
+    } finally {
       inflightRequests.delete(cacheKey);
-      throw error;
     }
   })();
 

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
@@ -17,13 +17,18 @@ import { getCached, setCached, isIDBAvailable, type StoreName } from "./idb-cach
 
 const inflightRequests = new Map<string, Promise<unknown>>();
 
+export interface FetchWithCacheOptions {
+  allow404?: boolean;
+}
+
 export async function fetchWithCache<T>(
   cacheKey: string,
   url: string,
-  storeType: StoreName
-): Promise<T> {
+  storeType: StoreName,
+  options?: FetchWithCacheOptions
+): Promise<T | null> {
   if (inflightRequests.has(cacheKey)) {
-    return inflightRequests.get(cacheKey) as Promise<T>;
+    return inflightRequests.get(cacheKey) as Promise<T | null>;
   }
 
   const request = (async () => {
@@ -38,6 +43,10 @@ export async function fetchWithCache<T>(
 
       const response = await fetch(url);
       if (!response.ok) {
+        if (response.status === 404 && options?.allow404) {
+          inflightRequests.delete(cacheKey);
+          return null;
+        }
         throw new Error(`Failed to load ${cacheKey}: ${response.status} ${response.statusText}`);
       }
 

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -20,19 +20,23 @@ import { fetchWithCache } from "./fetch-with-cache";
 const BASE_PATH = "/data/javaagent";
 
 export async function loadVersions(): Promise<VersionsIndex> {
-  return fetchWithCache<VersionsIndex>(
+  const data = await fetchWithCache<VersionsIndex>(
     "versions-index",
     `${BASE_PATH}/versions-index.json`,
     STORES.METADATA
   );
+  if (!data) throw new Error("Versions index returned null unexpectedly");
+  return data;
 }
 
 export async function loadVersionManifest(version: string): Promise<VersionManifest> {
-  return fetchWithCache<VersionManifest>(
+  const data = await fetchWithCache<VersionManifest>(
     `manifest-${version}`,
     `${BASE_PATH}/versions/${version}-index.json`,
     STORES.METADATA
   );
+  if (!data) throw new Error(`Manifest for version ${version} returned null unexpectedly`);
+  return data;
 }
 
 export async function loadInstrumentation(
@@ -48,11 +52,13 @@ export async function loadInstrumentation(
   }
 
   const filename = `${id}-${hash}.json`;
-  return fetchWithCache<InstrumentationData>(
+  const data = await fetchWithCache<InstrumentationData>(
     `instrumentation-${hash}`,
     `${BASE_PATH}/instrumentations/${id}/${filename}`,
     STORES.INSTRUMENTATIONS
   );
+  if (!data) throw new Error(`Instrumentation "${id}" returned null unexpectedly`);
+  return data;
 }
 
 export async function loadAllInstrumentations(version: string): Promise<InstrumentationData[]> {

--- a/ecosystem-explorer/src/lib/schema-defaults.test.ts
+++ b/ecosystem-explorer/src/lib/schema-defaults.test.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { buildDefaults, findNodeByPath } from "./schema-defaults";
+import { buildDefaults, buildPluginDefaults, findNodeByPath } from "./schema-defaults";
 import type {
+  ConfigNode,
   GroupNode,
   NumberInputNode,
+  PluginSelectNode,
   ToggleNode,
   CircularRefNode,
 } from "@/types/configuration";
@@ -76,6 +78,38 @@ describe("buildDefaults", () => {
   });
 });
 
+describe("buildPluginDefaults", () => {
+  const pluginNode: PluginSelectNode = {
+    controlType: "plugin_select",
+    key: "propagator",
+    label: "Item",
+    path: "propagator.composite.item",
+    allowCustom: true,
+    options: [
+      {
+        controlType: "group",
+        key: "tracecontext",
+        label: "Tracecontext",
+        path: "propagator.composite.item.tracecontext",
+        children: [],
+      },
+    ],
+  };
+
+  it("emits the known plugin key with its built defaults", () => {
+    expect(buildPluginDefaults(pluginNode, "tracecontext")).toEqual({ tracecontext: {} });
+  });
+
+  it("emits an empty-body entry for a custom plugin key when allowCustom is true", () => {
+    expect(buildPluginDefaults(pluginNode, "xray")).toEqual({ xray: {} });
+  });
+
+  it("returns an empty object for an unknown key when allowCustom is false", () => {
+    const strict: PluginSelectNode = { ...pluginNode, allowCustom: false };
+    expect(buildPluginDefaults(strict, "xray")).toEqual({});
+  });
+});
+
 describe("findNodeByPath", () => {
   const rootSchema: GroupNode = {
     controlType: "group",
@@ -92,5 +126,28 @@ describe("findNodeByPath", () => {
 
   it("should return undefined for missing path", () => {
     expect(findNodeByPath(rootSchema, ["nonexistent"])).toBeUndefined();
+  });
+
+  it("descends into union variants by key", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "union",
+          key: "value",
+          label: "Value",
+          path: "value",
+          variants: [
+            { controlType: "text_input", key: "string", label: "String", path: "value.string" },
+            { controlType: "number_input", key: "int", label: "Int", path: "value.int" },
+          ],
+        },
+      ],
+    };
+    const node = findNodeByPath(schema, ["value", "string"]);
+    expect(node?.controlType).toBe("text_input");
   });
 });

--- a/ecosystem-explorer/src/lib/schema-defaults.ts
+++ b/ecosystem-explorer/src/lib/schema-defaults.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ConfigNode, GroupNode, ListNode, PluginSelectNode } from "@/types/configuration";
+import type {
+  ConfigNode,
+  GroupNode,
+  ListNode,
+  PluginSelectNode,
+  UnionNode,
+} from "@/types/configuration";
 import type { ConfigValue, ConfigValues } from "@/types/configuration-builder";
 
 export function buildDefaults(node: ConfigNode): ConfigValue {
@@ -77,7 +83,9 @@ export function buildPluginDefaults(
   pluginKey: string
 ): ConfigValues {
   const option = pluginSelectNode.options.find((o) => o.key === pluginKey);
-  if (!option) return {};
+  if (!option) {
+    return pluginSelectNode.allowCustom ? { [pluginKey]: {} } : {};
+  }
   const defaults = buildDefaults(option);
   return { [pluginKey]: defaults };
 }
@@ -94,7 +102,12 @@ export function findNodeByPath(
 
   for (const segment of segments) {
     if (!current) return undefined;
-    if (typeof segment === "number") continue;
+    if (typeof segment === "number") {
+      if (current.controlType === "list") {
+        current = (current as ListNode).itemSchema;
+      }
+      continue;
+    }
 
     if (current.controlType === "group") {
       current = (current as GroupNode).children.find((c) => c.key === segment);
@@ -109,6 +122,8 @@ export function findNodeByPath(
       } else {
         current = undefined;
       }
+    } else if (current.controlType === "union") {
+      current = (current as UnionNode).variants.find((v) => v.key === segment);
     } else {
       current = undefined;
     }

--- a/ecosystem-explorer/src/lib/state-hydrate.test.ts
+++ b/ecosystem-explorer/src/lib/state-hydrate.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { hasUserValues, hydrateStarterState } from "./state-hydrate";
+import type { ConfigStarter } from "@/types/configuration";
+
+describe("hasUserValues", () => {
+  it("returns false for undefined and null", () => {
+    expect(hasUserValues(undefined)).toBe(false);
+    expect(hasUserValues(null)).toBe(false);
+  });
+  it("returns true for strings, numbers, booleans, objects, arrays", () => {
+    expect(hasUserValues("")).toBe(true);
+    expect(hasUserValues("x")).toBe(true);
+    expect(hasUserValues(0)).toBe(true);
+    expect(hasUserValues(false)).toBe(true);
+    expect(hasUserValues({})).toBe(true);
+    expect(hasUserValues([])).toBe(true);
+  });
+});
+
+describe("hydrateStarterState", () => {
+  it("returns empty state when starter is null", () => {
+    const s = hydrateStarterState("1.0.0", null);
+    expect(s).toEqual({
+      version: "1.0.0",
+      values: {},
+      enabledSections: {},
+      validationErrors: {},
+      isDirty: false,
+    });
+  });
+  it("copies starter values and enabledSections into the state", () => {
+    const starter: ConfigStarter = {
+      enabledSections: { resource: true },
+      values: { resource: { attributes: [] } },
+    };
+    const s = hydrateStarterState("1.0.0", starter);
+    expect(s.version).toBe("1.0.0");
+    expect(s.enabledSections).toEqual({ resource: true });
+    expect(s.values).toEqual({ resource: { attributes: [] } });
+    expect(s.isDirty).toBe(false);
+    expect(s.validationErrors).toEqual({});
+  });
+});

--- a/ecosystem-explorer/src/lib/state-hydrate.ts
+++ b/ecosystem-explorer/src/lib/state-hydrate.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ConfigStarter } from "@/types/configuration";
+import type { ConfigValue, ConfigurationBuilderState } from "@/types/configuration-builder";
+
+export function hasUserValues(current: ConfigValue | undefined): boolean {
+  return current !== undefined && current !== null;
+}
+
+export function hydrateStarterState(
+  version: string,
+  starter: ConfigStarter | null
+): ConfigurationBuilderState {
+  return {
+    version,
+    values: starter?.values ?? {},
+    enabledSections: starter?.enabledSections ?? {},
+    validationErrors: {},
+    isDirty: false,
+  };
+}

--- a/ecosystem-explorer/src/lib/yaml-generator.test.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.test.ts
@@ -126,7 +126,7 @@ describe("generateYaml", () => {
     expect(output).not.toContain("legacy_thing");
   });
 
-  it("emits enabled groups with values, omits enabled groups that strip to empty", () => {
+  it("emits enabled groups with values, emits empty object for enabled groups that strip to empty", () => {
     const schema: ConfigNode = {
       controlType: "group",
       key: "root",
@@ -168,7 +168,7 @@ describe("generateYaml", () => {
 
     expect(output).toContain("filled_section:");
     expect(output).toContain("setting: value");
-    expect(output).not.toContain("empty_section:");
+    expect(output).toMatch(/^empty_section: \{\}$/m);
   });
 
   it("omits groups with enabledSections[key] !== true", () => {
@@ -282,7 +282,7 @@ describe("generateYaml", () => {
     expect(output).not.toMatch(/\bd:/);
   });
 
-  it("preserves plugin_select discriminator inside list, omits empty group at top level", () => {
+  it("preserves plugin_select discriminator inside list, emits empty object for empty group at top level", () => {
     const schema: ConfigNode = {
       controlType: "group",
       key: "root",
@@ -328,7 +328,7 @@ describe("generateYaml", () => {
     expect(output).toContain("processors:");
     expect(output).toMatch(/- batch:\s*\{\s*\}/);
 
-    expect(output).not.toContain("empty_provider:");
+    expect(output).toMatch(/^empty_provider: \{\}$/m);
   });
 
   it("preserves standalone plugin_select discriminator with null value", () => {
@@ -439,5 +439,76 @@ describe("generateYaml", () => {
     expect(output).toMatch(/always_on:\s*(null|~)?/);
     expect(output).toMatch(/- tracecontext:\s*(null|~)?/);
     expect(output).toMatch(/- baggage:\s*(null|~)?/);
+  });
+
+  it("emits empty object for enabled top-level group with stripped body", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "text_input",
+          key: "file_format",
+          label: "File Format",
+          path: "file_format",
+          required: true,
+        },
+        {
+          controlType: "group",
+          key: "resource",
+          label: "Resource",
+          path: "resource",
+          children: [
+            {
+              controlType: "text_input",
+              key: "name",
+              label: "Name",
+              path: "resource.name",
+              nullable: true,
+            },
+          ],
+        },
+      ],
+    };
+    const state: ConfigurationBuilderState = {
+      version: "1.0.0",
+      values: { resource: { name: null } },
+      enabledSections: { resource: true },
+      validationErrors: {},
+      isDirty: false,
+    };
+    const out = generateYaml(state, schema);
+    expect(out).toMatch(/^resource: \{\}$/m);
+  });
+
+  it("skips disabled top-level group even if it has values", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "resource",
+          label: "Resource",
+          path: "resource",
+          children: [
+            { controlType: "text_input", key: "name", label: "Name", path: "resource.name" },
+          ],
+        },
+      ],
+    };
+    const state: ConfigurationBuilderState = {
+      version: "1.0.0",
+      values: { resource: { name: "svc" } },
+      enabledSections: { resource: false },
+      validationErrors: {},
+      isDirty: false,
+    };
+    const out = generateYaml(state, schema);
+    expect(out).not.toMatch(/resource:/);
   });
 });

--- a/ecosystem-explorer/src/lib/yaml-generator.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.ts
@@ -135,6 +135,21 @@ export function generateYaml(
   for (const child of others) {
     if (child.controlType === "group") {
       if (state.enabledSections[child.key] !== true) continue;
+      const raw = state.values[child.key];
+      let stripped: StrippedResult = raw === undefined ? EMPTY : stripEmpties(raw);
+      // Unwrap the plugin_select short-circuit at the section-body root: a
+      // single-entry object with null value at the top level represents an
+      // unset leaf, not a bare discriminator.
+      if (stripped !== EMPTY && isPlainObject(stripped)) {
+        const entries = Object.entries(stripped);
+        if (entries.length === 1 && entries[0][1] === null) {
+          stripped = EMPTY;
+        }
+      }
+      const body = stripped === EMPTY ? {} : (stripped as ConfigValue);
+      const block = sectionComment(child, child.key) + dumpYaml({ [child.key]: body });
+      sectionBlocks.push(block);
+      continue;
     }
     const raw = state.values[child.key];
     if (raw === undefined) continue;

--- a/ecosystem-explorer/src/test/integration/configuration-builder-actions.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-actions.integration.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { render, screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
+import { ConfigurationBuilderPage } from "@/features/java-agent/configuration/configuration-builder-page";
+
+const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+beforeAll(() => {
+  installFetchInterceptor();
+  // jsdom's navigator.clipboard is either undefined or read-only; force-install
+  // a mock via defineProperty (it IS configurable in jsdom-latest when defined).
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    writable: true,
+    value: { writeText: clipboardWrite },
+  });
+});
+afterAll(() => {
+  uninstallFetchInterceptor();
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  cleanup();
+  clipboardWrite.mockClear();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/java-agent/configuration/builder"]}>
+      <Routes>
+        <Route path="/java-agent/configuration/builder" element={<ConfigurationBuilderPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ConfigurationBuilderPage — actions", () => {
+  it("Copy writes current YAML to clipboard", async () => {
+    renderPage();
+
+    await screen.findByText("Output Preview", undefined, { timeout: 10_000 });
+    const copyBtn = screen.getByRole("button", { name: /^copy$/i });
+    fireEvent.click(copyBtn);
+
+    await waitFor(() => {
+      expect(clipboardWrite).toHaveBeenCalled();
+    });
+    const firstCall = clipboardWrite.mock.calls[0];
+    expect(firstCall[0]).toMatch(/file_format:/);
+  });
+
+  it("Add all makes every top-level section appear in the YAML preview", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await screen.findByText("Output Preview", undefined, { timeout: 10_000 });
+    await user.click(screen.getByRole("button", { name: /add all/i }));
+
+    await waitFor(() => {
+      const pre = screen.getByText(/OpenTelemetry SDK Configuration/).closest("pre");
+      const text = pre?.textContent ?? "";
+      expect(text).toMatch(/^resource:/m);
+      expect(text).toMatch(/^attribute_limits:/m);
+    });
+  });
+});

--- a/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
+import { ConfigurationBuilderPage } from "@/features/java-agent/configuration/configuration-builder-page";
+
+beforeAll(() => installFetchInterceptor());
+afterAll(() => uninstallFetchInterceptor());
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/java-agent/configuration/builder"]}>
+      <Routes>
+        <Route path="/java-agent/configuration/builder" element={<ConfigurationBuilderPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ConfigurationBuilderPage — basic", () => {
+  it("renders the SDK tab with starter-preloaded sections", async () => {
+    renderPage();
+    const resourceToggle = await screen.findByRole(
+      "switch",
+      { name: /Enable Resource/i },
+      { timeout: 10_000 }
+    );
+    expect(resourceToggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("YAML preview updates when a section is toggled off", async () => {
+    renderPage();
+    const user = userEvent.setup();
+    const resourceToggle = await screen.findByRole(
+      "switch",
+      { name: /Enable Resource/i },
+      { timeout: 10_000 }
+    );
+    expect(resourceToggle).toHaveAttribute("aria-checked", "true");
+    await user.click(resourceToggle);
+    await waitFor(() => {
+      expect(resourceToggle).toHaveAttribute("aria-checked", "false");
+    });
+    const pre = screen.getByText(/OpenTelemetry SDK Configuration/).closest("pre");
+    expect(pre?.textContent).not.toMatch(/^resource:/m);
+  });
+});

--- a/ecosystem-explorer/src/test/integration/configuration-builder-lists.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-lists.integration.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
+import { ConfigurationBuilderPage } from "@/features/java-agent/configuration/configuration-builder-page";
+
+beforeAll(() => installFetchInterceptor());
+afterAll(() => uninstallFetchInterceptor());
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/java-agent/configuration/builder"]}>
+      <Routes>
+        <Route path="/java-agent/configuration/builder" element={<ConfigurationBuilderPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ConfigurationBuilderPage — lists + plugin select", () => {
+  it("adds a processor item to logger_provider.processors", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    // Wait for top-level cards to render.
+    await screen.findByRole("switch", { name: /Enable Logger Provider/i }, { timeout: 10_000 });
+
+    // The Processors list lives inside the Logger Provider card.
+    // Locate its Add button by accessible name.
+    const addButtons = await screen.findAllByRole("button", {
+      name: /Add item to Processors/i,
+    });
+    expect(addButtons.length).toBeGreaterThan(0);
+
+    const before = screen.getAllByText(/^Item \d+$/).length;
+    await user.click(addButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/^Item \d+$/).length).toBeGreaterThan(before);
+    });
+  });
+});

--- a/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
@@ -34,7 +34,10 @@ function renderPage() {
   return render(
     <MemoryRouter initialEntries={[`/java-agent/instrumentation/${latestVersion}`]}>
       <Routes>
-        <Route path="/java-agent/instrumentation/:version" element={<JavaInstrumentationListPage />} />
+        <Route
+          path="/java-agent/instrumentation/:version"
+          element={<JavaInstrumentationListPage />}
+        />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/types/configuration-builder.ts
+++ b/ecosystem-explorer/src/types/configuration-builder.ts
@@ -47,4 +47,5 @@ export type ConfigurationBuilderAction =
   | { type: "RESET_TO_DEFAULTS" }
   | { type: "LOAD_STATE"; state: ConfigurationBuilderState }
   | { type: "SET_VALIDATION_ERRORS"; errors: Record<string, string> }
-  | { type: "SET_FIELD_ERROR"; path: string; error: string | null };
+  | { type: "SET_FIELD_ERROR"; path: string; error: string | null }
+  | { type: "ENABLE_ALL_SECTIONS"; defaultsBySection: Record<string, ConfigValues> };

--- a/ecosystem-explorer/src/types/configuration.ts
+++ b/ecosystem-explorer/src/types/configuration.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ConfigValues } from "./configuration-builder";
+
 export interface ConfigVersionsIndex {
   versions: ConfigVersionInfo[];
 }
@@ -143,8 +145,6 @@ export type ConfigNode =
   | ToggleNode
   | FlagNode
   | KeyValueMapNode;
-
-import type { ConfigValues } from "./configuration-builder";
 
 export interface ConfigStarter {
   enabledSections: Record<string, boolean>;

--- a/ecosystem-explorer/src/types/configuration.ts
+++ b/ecosystem-explorer/src/types/configuration.ts
@@ -62,6 +62,7 @@ export interface ConfigNodeBase {
   required?: boolean;
   stability?: "development";
   nullBehavior?: string;
+  hideLabel?: boolean;
 }
 
 export interface GroupNode extends ConfigNodeBase {
@@ -142,3 +143,10 @@ export type ConfigNode =
   | ToggleNode
   | FlagNode
   | KeyValueMapNode;
+
+import type { ConfigValues } from "./configuration-builder";
+
+export interface ConfigStarter {
+  enabledSections: Record<string, boolean>;
+  values: ConfigValues;
+}


### PR DESCRIPTION
Closes #249.

Renders the OpenTelemetry SDK configuration schema as an interactive form. Recursive renderer that dispatches on controlType (Group, List, Union, PluginSelect, CircularRef, and the leaf controls). Top-level groups toggle on/off, lists respect minItems/maxItems, plugin selects allow custom keys, unions keep the manual pick when inference is ambiguous. State managed by a reducer-backed hook with starter-template hydration and per-field validation on blur. PreviewCard shows the generated YAML with Copy, Download, Reset, and Add all.

Opening for review, the bulk of the work should be done. Follow-up #264: automate the per-version starter file generation in the Python pipeline.