### PR TITLE
fix: add missing event types to screenshot workflow trigger

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -3,6 +3,7 @@ name: PR Screenshots
 on:
   pull_request:
     branches: [main]
+    types: [labeled, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds back `types: [labeled, synchronize]` to the screenshot workflow's `pull_request` trigger
- The `types` line was accidentally dropped when `branches: [main]` was added during PR #247 review
- Without explicit types, GitHub defaults to `[opened, synchronize, reopened]` which does not include `labeled` — so adding the `add-screenshots` label never triggered the workflow

Fixes the issue reported in https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/pull/247#issuecomment-4276328000

## Test plan
- [x] Tested on fork ([Vjc5h3nt/opentelemetry-ecosystem-explorer#2](https://github.com/Vjc5h3nt/opentelemetry-ecosystem-explorer/pull/2))
- [x] `labeled` event: removing and re-adding label triggers workflow successfully
- [x] `synchronize` event: pushing commits with label present triggers workflow automatically
- [x] All screenshot workflow runs completed successfully
- [x] Python lint (`ruff check`) passes
- [x] Python format (`ruff format`) passes
- [x] Markdown lint passes
- [x] Copyright headers valid
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 366 JS tests pass
- [x] All Python tests pass (collector-watcher: 96, java-instrumentation-watcher: 54, configuration-watcher: 36)