### PR TITLE
fix: use pull_request event ref for screenshot workflow checkout

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Setup Bun


### PR DESCRIPTION
## Summary
- Update the checkout `ref` from `github.head_ref` to `github.event.pull_request.head.ref` to fix branch resolution for fork-based pull requests
- Tested in fork with same-repo PR: https://github.com/Vjc5h3nt/opentelemetry-ecosystem-explorer/pull/3