### PR TITLE
DB builder - Support java agent file version 0.5

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
@@ -53,7 +53,9 @@ def transform_instrumentation_format(inventory_data: dict[str, Any]) -> dict[str
         logger.debug("File format 0.1 detected, transforming to 0.2")
         bump_to_0_2 = _transform_0_1_to_0_2(inventory_data)
         logger.debug("Now transforming from 0.2 to 0.3")
-        return _transform_0_3_to_0_5(_transform_0_2_to_0_3(bump_to_0_2))
+        bump_to_0_3 = _transform_0_2_to_0_3(bump_to_0_2)
+        logger.debug("Now transforming from 0.3 to 0.5")
+        return _transform_0_3_to_0_5(bump_to_0_3)
     else:
         raise ValueError(f"Unsupported file format: {file_format}")
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
@@ -40,17 +40,20 @@ def transform_instrumentation_format(inventory_data: dict[str, Any]) -> dict[str
 
     file_format = inventory_data["file_format"]
 
-    if file_format == 0.3:
-        logger.debug("File format 0.3 detected, no transformation needed")
+    if file_format == 0.5:
+        logger.debug("File format 0.5 detected, no transformation needed")
         return inventory_data
+    if file_format == 0.3:
+        logger.debug("File format 0.3 detected, transforming to 0.5")
+        return _transform_0_3_to_0_5(inventory_data)
     if file_format == 0.2:
         logger.debug("File format 0.2 detected, transforming to 0.3")
-        return _transform_0_2_to_0_3(inventory_data)
+        return _transform_0_3_to_0_5(_transform_0_2_to_0_3(inventory_data))
     elif file_format == 0.1:
         logger.debug("File format 0.1 detected, transforming to 0.2")
         bump_to_0_2 = _transform_0_1_to_0_2(inventory_data)
         logger.debug("Now transforming from 0.2 to 0.3")
-        return _transform_0_2_to_0_3(bump_to_0_2)
+        return _transform_0_3_to_0_5(_transform_0_2_to_0_3(bump_to_0_2))
     else:
         raise ValueError(f"Unsupported file format: {file_format}")
 
@@ -147,4 +150,26 @@ def _transform_0_2_to_0_3(inventory_data: dict[str, Any]) -> dict[str, Any]:
     transformed_data["file_format"] = 0.3
     logger.info("Transformed inventory from format 0.2 to 0.3")
 
+    return transformed_data
+
+
+def _transform_0_3_to_0_5(inventory_data: dict[str, Any]) -> dict[str, Any]:
+    """Transform file_format 0.3 to 0.5.
+
+    0.5 introduces new optional fields:
+    - ``has_javaagent`` at the library level
+    - ``declarative_name`` and ``examples`` in each configuration entry
+
+    No structural changes are needed; missing values are populated later by the
+    metadata backfiller using data from versions that do have the new fields.
+
+    Args:
+        inventory_data: Inventory data in format 0.3
+
+    Returns:
+        Inventory data tagged as format 0.5
+    """
+    transformed_data = inventory_data.copy()
+    transformed_data["file_format"] = 0.5
+    logger.info("Transformed inventory from format 0.3 to 0.5")
     return transformed_data

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/metadata_backfiller.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/metadata_backfiller.py
@@ -223,7 +223,7 @@ def _needs_backfill(item: dict[str, Any], field: str) -> bool:
     return not _has_value(item, field)
 
 
-def _find_backfill_value(item_name: str, field: str, current_version: Version, timeline: dict) -> Any:
+def _find_backfill_value(item_name: str, field: str, current_version: Version, timeline: dict) -> Any | None:
     """Find the appropriate backfill value for a field.
 
     Searches forward in time to find the next available value for the field.

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/metadata_backfiller.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/metadata_backfiller.py
@@ -22,7 +22,10 @@ from semantic_version import Version
 
 logger = logging.getLogger(__name__)
 
-BACKFILLABLE_FIELDS = ["display_name", "description", "library_link"]
+BACKFILLABLE_FIELDS = ["display_name", "description", "library_link", "has_javaagent"]
+NESTED_BACKFILLABLE_FIELDS: dict[str, list[str]] = {
+    "configurations": ["declarative_name", "examples"],
+}
 
 
 def backfill_metadata(
@@ -36,10 +39,9 @@ def backfill_metadata(
     If versions 1.1-1.3 lack a display_name but 1.4 has it, backfill 1.4's
     value to 1.1-1.3. If 1.5 updates it, use the new value for 1.5+.
 
-    The backfilling happens in three phases:
-    1. Collect Timeline: Load all versions and track first appearance of each field
-    2. Apply Backfill: Process versions chronologically, backfill missing fields
-    3. Return: Provide backfilled inventories ready for processing
+    Also backfills nested fields declared in ``NESTED_BACKFILLABLE_FIELDS``
+    (e.g. per-configuration ``declarative_name`` and ``examples``) across
+    versions, matching nested items by their ``name``.
 
     Args:
         versions: List of versions (unordered)
@@ -57,8 +59,8 @@ def backfill_metadata(
 
     logger.info(f"Backfilling metadata across {len(versions)} versions")
 
-    inventories = {}
-    metadata_timeline = _build_metadata_timeline(versions, load_inventory_fn, item_key, inventories)
+    inventories: dict[Version, dict[str, Any]] = {}
+    metadata_timeline, nested_timelines = _build_timelines(versions, load_inventory_fn, item_key, inventories)
 
     backfilled_inventories = {}
     for version in versions:
@@ -79,11 +81,16 @@ def backfill_metadata(
                     backfilled_value = _find_backfill_value(item_name, field, version, metadata_timeline)
                     if backfilled_value is not None:
                         backfilled_item[field] = backfilled_value
-                        logger.debug(
-                            f"Backfilled {field} for {item_name} in {version} with value: {backfilled_value[:50]}..."
-                            if len(backfilled_value) > 50
-                            else f"Backfilled {field} for {item_name} in {version} with value: {backfilled_value}"
-                        )
+                        logger.debug(f"Backfilled {field} for {item_name} in {version}")
+
+            for nested_key, nested_fields in NESTED_BACKFILLABLE_FIELDS.items():
+                nested_items = backfilled_item.get(nested_key)
+                if not nested_items:
+                    continue
+                per_item_timeline = nested_timelines[nested_key].get(item_name, {})
+                backfilled_item[nested_key] = _backfill_nested_items(
+                    nested_items, nested_fields, version, per_item_timeline, item_name, nested_key
+                )
 
             backfilled_items.append(backfilled_item)
 
@@ -95,13 +102,57 @@ def backfill_metadata(
     return backfilled_inventories
 
 
-def _build_metadata_timeline(
+def _backfill_nested_items(
+    nested_items: list[Any],
+    nested_fields: list[str],
+    version: Version,
+    per_item_timeline: dict,
+    parent_name: str,
+    nested_key: str,
+) -> list[Any]:
+    """Backfill fields on a list of nested items (e.g. configurations).
+
+    Args:
+        nested_items: The nested items for the current version
+        nested_fields: Field names to backfill
+        version: Version being processed
+        per_item_timeline: Timeline scoped to the parent item,
+            shape {nested_name: {field: {version: value}}}
+        parent_name: Name of the parent item (for logging)
+        nested_key: Name of the nested collection (for logging)
+
+    Returns:
+        New list with backfilled nested items
+    """
+    result = []
+    for nested_item in nested_items:
+        if not isinstance(nested_item, dict):
+            result.append(nested_item)
+            continue
+
+        nested_name = nested_item.get("name")
+        if not nested_name:
+            result.append(nested_item)
+            continue
+
+        backfilled = nested_item.copy()
+        for field in nested_fields:
+            if _needs_backfill(nested_item, field):
+                backfilled_value = _find_backfill_value(nested_name, field, version, per_item_timeline)
+                if backfilled_value is not None:
+                    backfilled[field] = backfilled_value
+                    logger.debug(f"Backfilled {nested_key}.{field} for {parent_name}/{nested_name} in {version}")
+        result.append(backfilled)
+    return result
+
+
+def _build_timelines(
     versions: list[Version],
     load_inventory_fn: Callable[[Version], dict[str, Any]],
     item_key: str,
     inventories: dict[Version, dict[str, Any]],
-) -> dict[str, dict[str, dict[Version, str]]]:
-    """Build timeline of metadata changes for all items.
+) -> tuple[dict, dict]:
+    """Build timelines of metadata changes.
 
     Args:
         versions: List of versions in any order
@@ -110,9 +161,15 @@ def _build_metadata_timeline(
         inventories: Dict to populate with loaded inventories
 
     Returns:
-        Nested dict: {item_name: {field_name: {version: value}}}
+        Tuple of:
+        - metadata_timeline: {item_name: {field: {version: value}}}
+        - nested_timelines: {nested_key: {item_name: {nested_name: {field: {version: value}}}}}
     """
-    metadata_timeline = defaultdict(lambda: defaultdict(dict))
+    metadata_timeline: dict = defaultdict(lambda: defaultdict(dict))
+    nested_timelines: dict[str, dict] = {
+        nested_key: defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+        for nested_key in NESTED_BACKFILLABLE_FIELDS
+    }
 
     for version in versions:
         inventory = load_inventory_fn(version)
@@ -125,28 +182,48 @@ def _build_metadata_timeline(
                 continue
 
             for field in BACKFILLABLE_FIELDS:
-                if field in item and item[field]:
+                if _has_value(item, field):
                     metadata_timeline[item_name][field][version] = item[field]
 
-    return metadata_timeline
+            for nested_key, fields in NESTED_BACKFILLABLE_FIELDS.items():
+                nested_items = item.get(nested_key) or []
+                for nested_item in nested_items:
+                    if not isinstance(nested_item, dict):
+                        continue
+                    nested_name = nested_item.get("name")
+                    if not nested_name:
+                        continue
+                    for field in fields:
+                        if _has_value(nested_item, field):
+                            nested_timelines[nested_key][item_name][nested_name][field][version] = nested_item[field]
+
+    return metadata_timeline, nested_timelines
+
+
+def _has_value(item: dict[str, Any], field: str) -> bool:
+    """Check if an item has a meaningful (non-empty) value for a field.
+
+    Treats missing keys, None, empty strings, and empty lists as absent.
+    Boolean ``False`` is a meaningful value.
+    """
+    if field not in item:
+        return False
+    value = item[field]
+    if value is None:
+        return False
+    if isinstance(value, str) and value == "":
+        return False
+    if isinstance(value, list) and not value:
+        return False
+    return True
 
 
 def _needs_backfill(item: dict[str, Any], field: str) -> bool:
-    """Check if a field needs backfilling.
-
-    A field needs backfilling if it's missing or empty string.
-
-    Args:
-        item: The item to check
-        field: The field name
-
-    Returns:
-        True if the field needs backfilling, False otherwise
-    """
-    return field not in item or not item[field]
+    """Check if a field needs backfilling."""
+    return not _has_value(item, field)
 
 
-def _find_backfill_value(item_name: str, field: str, current_version: Version, metadata_timeline: dict) -> str | None:
+def _find_backfill_value(item_name: str, field: str, current_version: Version, timeline: dict) -> Any:
     """Find the appropriate backfill value for a field.
 
     Searches forward in time to find the next available value for the field.
@@ -155,22 +232,21 @@ def _find_backfill_value(item_name: str, field: str, current_version: Version, m
         item_name: Name of the item
         field: Field name to backfill
         current_version: Version being processed
-        metadata_timeline: Timeline of metadata changes
+        timeline: Timeline shape {item_name: {field: {version: value}}}
 
     Returns:
         The backfill value, or None if no value found
     """
-    if item_name not in metadata_timeline:
+    if item_name not in timeline:
         return None
 
-    if field not in metadata_timeline[item_name]:
+    if field not in timeline[item_name]:
         return None
 
-    field_timeline = metadata_timeline[item_name][field]
+    field_timeline = timeline[item_name][field]
     if not field_timeline:
         return None
 
-    # Find the first value at or after the current version
     sorted_versions = sorted(field_timeline.keys())
 
     for version in sorted_versions:

--- a/ecosystem-automation/explorer-db-builder/tests/test_instrumentation_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_instrumentation_transformer.py
@@ -22,15 +22,24 @@ from explorer_db_builder.instrumentation_transformer import (
 
 
 class TestTransformInstrumentationFormat:
-    def test_format_0_3_no_transformation(self):
-        """Format 0.3 data is returned unchanged."""
+    def test_format_0_5_no_transformation(self):
+        """Format 0.5 data is returned unchanged."""
         data = {
-            "file_format": 0.3,
+            "file_format": 0.5,
             "libraries": [
                 {
                     "name": "test-lib",
                     "javaagent_target_versions": ["com.test:lib:[1.0,)"],
                     "has_standalone_library": True,
+                    "has_javaagent": True,
+                    "configurations": [
+                        {
+                            "name": "otel.test.option",
+                            "declarative_name": "java.test.option",
+                            "type": "boolean",
+                            "examples": ["true", "false"],
+                        }
+                    ],
                 }
             ],
         }
@@ -38,10 +47,30 @@ class TestTransformInstrumentationFormat:
         result = transform_instrumentation_format(data)
 
         assert result == data
-        assert result["file_format"] == 0.3
+        assert result["file_format"] == 0.5
 
-    def test_format_0_2_transforms_to_0_3(self):
-        """Format 0.2 data is transformed to 0.3."""
+    def test_format_0_3_transforms_to_0_5(self):
+        """Format 0.3 data is transformed to 0.5 (version bump, structure preserved)."""
+        data = {
+            "file_format": 0.3,
+            "libraries": [
+                {
+                    "name": "test-lib",
+                    "javaagent_target_versions": ["com.test:lib:[1.0,)"],
+                    "has_standalone_library": True,
+                    "configurations": [{"name": "otel.test.option", "type": "boolean"}],
+                }
+            ],
+        }
+
+        result = transform_instrumentation_format(data)
+
+        assert result["file_format"] == 0.5
+        assert result["libraries"][0]["name"] == "test-lib"
+        assert result["libraries"][0]["configurations"][0]["name"] == "otel.test.option"
+
+    def test_format_0_2_transforms_to_0_5(self):
+        """Format 0.2 data is transformed to 0.5."""
         data = {
             "file_format": 0.2,
             "libraries": [
@@ -75,7 +104,7 @@ class TestTransformInstrumentationFormat:
 
         result = transform_instrumentation_format(data)
 
-        assert result["file_format"] == 0.3
+        assert result["file_format"] == 0.5
         # Verify the type field was renamed to data_type in the metric
         metric = result["libraries"][0]["telemetry"][0]["metrics"][0]
         assert metric["data_type"] == "HISTOGRAM"
@@ -86,8 +115,8 @@ class TestTransformInstrumentationFormat:
         assert result["libraries"][0]["display_name"] == "ActiveJ"
         assert result["libraries"][0]["javaagent_target_versions"] == ["io.activej:activej-http:[6.0,)"]
 
-    def test_format_0_1_transforms_to_0_3(self):
-        """Format 0.1 data is transformed through 0.2 to 0.3."""
+    def test_format_0_1_transforms_to_0_5(self):
+        """Format 0.1 data is transformed through 0.2 and 0.3 to 0.5."""
         data = {
             "file_format": 0.1,
             "libraries": [
@@ -103,7 +132,7 @@ class TestTransformInstrumentationFormat:
 
         result = transform_instrumentation_format(data)
 
-        assert result["file_format"] == 0.3
+        assert result["file_format"] == 0.5
         assert result["libraries"][0]["javaagent_target_versions"] == ["com.test:lib:[1.0,)"]
         assert result["libraries"][0]["has_standalone_library"] is True
         assert "target_versions" not in result["libraries"][0]
@@ -117,9 +146,9 @@ class TestTransformInstrumentationFormat:
 
     def test_unsupported_file_format_raises_error(self):
         """Unsupported file format raises ValueError."""
-        data = {"file_format": 0.4, "libraries": []}
+        data = {"file_format": 0.9, "libraries": []}
 
-        with pytest.raises(ValueError, match="Unsupported file format: 0.4"):
+        with pytest.raises(ValueError, match="Unsupported file format: 0.9"):
             transform_instrumentation_format(data)
 
 

--- a/ecosystem-automation/explorer-db-builder/tests/test_metadata_backfiller.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_metadata_backfiller.py
@@ -238,3 +238,163 @@ class TestBackfillMetadata:
 
         assert result[Version("1.1.0")]["libraries"][0]["display_name"] == "Test Library"
         assert result[Version("1.2.0")]["libraries"][0]["display_name"] == "Test Library"
+
+    def test_backfill_has_javaagent_boolean(self):
+        """Backfills the has_javaagent boolean (including False) from later versions."""
+        versions = [Version("1.1.0"), Version("1.2.0"), Version("1.3.0")]
+
+        inventories = {
+            Version("1.1.0"): {
+                "file_format": 0.3,
+                "libraries": [
+                    {"name": "agent-lib"},
+                    {"name": "library-only"},
+                ],
+            },
+            Version("1.2.0"): {
+                "file_format": 0.3,
+                "libraries": [
+                    {"name": "agent-lib"},
+                    {"name": "library-only"},
+                ],
+            },
+            Version("1.3.0"): {
+                "file_format": 0.5,
+                "libraries": [
+                    {"name": "agent-lib", "has_javaagent": True},
+                    {"name": "library-only", "has_javaagent": False},
+                ],
+            },
+        }
+
+        def load_fn(version):
+            return inventories[version]
+
+        result = backfill_metadata(versions, load_fn)
+
+        assert result[Version("1.1.0")]["libraries"][0]["has_javaagent"] is True
+        assert result[Version("1.1.0")]["libraries"][1]["has_javaagent"] is False
+        assert result[Version("1.2.0")]["libraries"][0]["has_javaagent"] is True
+        assert result[Version("1.2.0")]["libraries"][1]["has_javaagent"] is False
+        assert result[Version("1.3.0")]["libraries"][0]["has_javaagent"] is True
+        assert result[Version("1.3.0")]["libraries"][1]["has_javaagent"] is False
+
+    def test_backfill_nested_configuration_fields(self):
+        """Backfills declarative_name and examples within configurations across versions."""
+        versions = [Version("1.1.0"), Version("1.2.0")]
+
+        inventories = {
+            Version("1.1.0"): {
+                "file_format": 0.3,
+                "libraries": [
+                    {
+                        "name": "http-lib",
+                        "configurations": [
+                            {"name": "otel.http.known-methods", "type": "list"},
+                            {"name": "otel.http.capture-headers", "type": "list"},
+                        ],
+                    }
+                ],
+            },
+            Version("1.2.0"): {
+                "file_format": 0.5,
+                "libraries": [
+                    {
+                        "name": "http-lib",
+                        "configurations": [
+                            {
+                                "name": "otel.http.known-methods",
+                                "declarative_name": "java.common.http.known_methods",
+                                "type": "list",
+                                "examples": ["GET,POST", "CONNECT,OPTIONS"],
+                            },
+                            {
+                                "name": "otel.http.capture-headers",
+                                "declarative_name": "java.common.http.capture_headers",
+                                "type": "list",
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+
+        def load_fn(version):
+            return inventories[version]
+
+        result = backfill_metadata(versions, load_fn)
+
+        old_configs = result[Version("1.1.0")]["libraries"][0]["configurations"]
+        assert old_configs[0]["declarative_name"] == "java.common.http.known_methods"
+        assert old_configs[0]["examples"] == ["GET,POST", "CONNECT,OPTIONS"]
+        assert old_configs[1]["declarative_name"] == "java.common.http.capture_headers"
+        assert "examples" not in old_configs[1]
+
+    def test_nested_backfill_isolates_per_library(self):
+        """A configuration named the same in different libraries is not cross-contaminated."""
+        versions = [Version("1.1.0"), Version("1.2.0")]
+
+        inventories = {
+            Version("1.1.0"): {
+                "file_format": 0.3,
+                "libraries": [
+                    {"name": "lib-a", "configurations": [{"name": "shared.option"}]},
+                    {"name": "lib-b", "configurations": [{"name": "shared.option"}]},
+                ],
+            },
+            Version("1.2.0"): {
+                "file_format": 0.5,
+                "libraries": [
+                    {
+                        "name": "lib-a",
+                        "configurations": [{"name": "shared.option", "declarative_name": "a.shared"}],
+                    },
+                    {
+                        "name": "lib-b",
+                        "configurations": [{"name": "shared.option", "declarative_name": "b.shared"}],
+                    },
+                ],
+            },
+        }
+
+        def load_fn(version):
+            return inventories[version]
+
+        result = backfill_metadata(versions, load_fn)
+
+        a_config = result[Version("1.1.0")]["libraries"][0]["configurations"][0]
+        b_config = result[Version("1.1.0")]["libraries"][1]["configurations"][0]
+        assert a_config["declarative_name"] == "a.shared"
+        assert b_config["declarative_name"] == "b.shared"
+
+    def test_empty_examples_list_is_backfilled(self):
+        """An empty examples list is treated as missing and backfilled."""
+        versions = [Version("1.1.0"), Version("1.2.0")]
+
+        inventories = {
+            Version("1.1.0"): {
+                "file_format": 0.5,
+                "libraries": [
+                    {
+                        "name": "lib-a",
+                        "configurations": [{"name": "opt", "examples": []}],
+                    }
+                ],
+            },
+            Version("1.2.0"): {
+                "file_format": 0.5,
+                "libraries": [
+                    {
+                        "name": "lib-a",
+                        "configurations": [{"name": "opt", "examples": ["one", "two"]}],
+                    }
+                ],
+            },
+        }
+
+        def load_fn(version):
+            return inventories[version]
+
+        result = backfill_metadata(versions, load_fn)
+
+        assert result[Version("1.1.0")]["libraries"][0]["configurations"][0]["examples"] == ["one", "two"]


### PR DESCRIPTION
Related to #257

#271 added support for the `java-instrumentation-watcher` to ingest the new 0.5 file format into the registry, this PR updates our database builder tool to convert that new file format into the database used in the explorer web app.

After this is merged, I will run the `Build Explorer Database` github action with the `clean` flag, and it will generate a PR with a completely rebuilt [database](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/tree/main/ecosystem-explorer/public/data/javaagent). 

I have tested the new database locally with the website and all is working.

The `metadata_backfiller` aspect of this allows us to take immutable parts of the metadata that might have been populated in a staggered manner, and ensure that all versions are backfilled with it. For example, we just added `declarative_name` to config metadata, so we want to backfill that to previous versions