### PR TITLE
Collapse empty YAML values and hide Instrumentation from SDK tab

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -27,6 +27,8 @@ import type { GroupNode } from "@/types/configuration";
 import { SchemaRenderer } from "./components/schema-renderer";
 import { PreviewCard } from "./components/preview-card";
 
+const HIDDEN_SDK_KEYS = new Set(["file_format", "instrumentation/development"]);
+
 function SdkTab({ version }: { version: string }) {
   const schema = useConfigSchema(version);
   const starter = useConfigStarter(version);
@@ -42,7 +44,7 @@ function SdkTab({ version }: { version: string }) {
   }
 
   const root = schema.data as GroupNode;
-  const visibleChildren = root.children.filter((c) => c.key !== "file_format");
+  const visibleChildren = root.children.filter((c) => !HIDDEN_SDK_KEYS.has(c.key));
   const groupChildren = visibleChildren.filter((c) => c.controlType === "group");
   const leafChildren = visibleChildren.filter((c) => c.controlType !== "group");
 

--- a/ecosystem-explorer/src/lib/yaml-generator.test.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.test.ts
@@ -168,7 +168,7 @@ describe("generateYaml", () => {
 
     expect(output).toContain("filled_section:");
     expect(output).toContain("setting: value");
-    expect(output).toMatch(/^empty_section: \{\}$/m);
+    expect(output).toMatch(/^empty_section:$/m);
   });
 
   it("omits groups with enabledSections[key] !== true", () => {
@@ -326,9 +326,9 @@ describe("generateYaml", () => {
 
     expect(output).toContain("tracer_provider:");
     expect(output).toContain("processors:");
-    expect(output).toMatch(/- batch:\s*\{\s*\}/);
+    expect(output).toMatch(/^ {4}- batch:$/m);
 
-    expect(output).toMatch(/^empty_provider: \{\}$/m);
+    expect(output).toMatch(/^empty_provider:$/m);
   });
 
   it("preserves standalone plugin_select discriminator with null value", () => {
@@ -359,7 +359,7 @@ describe("generateYaml", () => {
     const output = generateYaml(state, schema, { header: "" });
 
     expect(output).toContain("sampler:");
-    expect(output).toMatch(/always_on:\s*(null|~)?/);
+    expect(output).toMatch(/^ {4}always_on:$/m);
   });
 
   it("preserves standalone plugin_select discriminator with empty object", () => {
@@ -436,9 +436,9 @@ describe("generateYaml", () => {
 
     expect(output).toContain("parent_based:");
     expect(output).toContain("root:");
-    expect(output).toMatch(/always_on:\s*(null|~)?/);
-    expect(output).toMatch(/- tracecontext:\s*(null|~)?/);
-    expect(output).toMatch(/- baggage:\s*(null|~)?/);
+    expect(output).toMatch(/^ {8}always_on:$/m);
+    expect(output).toMatch(/^ {4}- tracecontext:$/m);
+    expect(output).toMatch(/^ {4}- baggage:$/m);
   });
 
   it("emits empty object for enabled top-level group with stripped body", () => {
@@ -480,7 +480,7 @@ describe("generateYaml", () => {
       isDirty: false,
     };
     const out = generateYaml(state, schema);
-    expect(out).toMatch(/^resource: \{\}$/m);
+    expect(out).toMatch(/^resource:$/m);
   });
 
   it("skips disabled top-level group even if it has values", () => {
@@ -510,5 +510,95 @@ describe("generateYaml", () => {
     };
     const out = generateYaml(state, schema);
     expect(out).not.toMatch(/resource:/);
+  });
+
+  it("collapses empty object values at list-item position", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "tracer_provider",
+          label: "Tracer Provider",
+          path: "tracer_provider",
+          children: [],
+        },
+      ],
+    };
+
+    const state: ConfigurationBuilderState = {
+      version: "1.0.0",
+      values: { tracer_provider: { processors: [{ batch: {} }] } },
+      enabledSections: { tracer_provider: true },
+      validationErrors: {},
+      isDirty: false,
+    };
+
+    const output = generateYaml(state, schema, { header: "" });
+    expect(output).toMatch(/^ {4}- batch:$/m);
+    expect(output).not.toMatch(/- batch: \{\}/);
+  });
+
+  it("collapses null values at nested discriminator position", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "tracer_provider",
+          label: "Tracer Provider",
+          path: "tracer_provider",
+          children: [],
+        },
+      ],
+    };
+
+    const state: ConfigurationBuilderState = {
+      version: "1.0.0",
+      values: { tracer_provider: { sampler: { always_on: null } } },
+      enabledSections: { tracer_provider: true },
+      validationErrors: {},
+      isDirty: false,
+    };
+
+    const output = generateYaml(state, schema, { header: "" });
+    expect(output).toMatch(/^ {4}always_on:$/m);
+    expect(output).not.toMatch(/always_on: null/);
+  });
+
+  it("does not collapse non-empty scalar values on the same line", () => {
+    const schema: ConfigNode = {
+      controlType: "group",
+      key: "root",
+      label: "Root",
+      path: "",
+      children: [
+        {
+          controlType: "group",
+          key: "resource",
+          label: "Resource",
+          path: "resource",
+          children: [],
+        },
+      ],
+    };
+
+    const state: ConfigurationBuilderState = {
+      version: "1.0.0",
+      values: { resource: { service_name: "demo", endpoint: "http://localhost:4318" } },
+      enabledSections: { resource: true },
+      validationErrors: {},
+      isDirty: false,
+    };
+
+    const output = generateYaml(state, schema, { header: "" });
+    expect(output).toContain("service_name: demo");
+    expect(output).toContain("endpoint: http://localhost:4318");
   });
 });

--- a/ecosystem-explorer/src/lib/yaml-generator.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.ts
@@ -39,13 +39,26 @@ function defaultHeader(version: string): string {
   ].join("\n");
 }
 
+function emptiesToNull(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(emptiesToNull);
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return null;
+    return Object.fromEntries(entries.map(([k, v]) => [k, emptiesToNull(v)]));
+  }
+  return value;
+}
+
 function dumpYaml(obj: unknown): string {
-  return dump(obj, {
+  const yaml = dump(emptiesToNull(obj), {
     sortKeys: true,
     lineWidth: -1,
     noRefs: true,
     quotingType: '"',
+    styles: { "!!null": "empty" },
   });
+  // js-yaml leaves a trailing space after the empty-style null representation.
+  return yaml.replace(/: $/gm, ":");
 }
 
 function sectionComment(node: ConfigNode | undefined, fallbackKey: string): string {

--- a/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
@@ -60,4 +60,13 @@ describe("ConfigurationBuilderPage — basic", () => {
     const pre = screen.getByText(/OpenTelemetry SDK Configuration/).closest("pre");
     expect(pre?.textContent).not.toMatch(/^resource:/m);
   });
+
+  it("does not render the instrumentation/development section in the SDK tab", async () => {
+    renderPage();
+
+    await screen.findByRole("switch", { name: /Enable Resource/i }, { timeout: 10_000 });
+
+    expect(screen.queryByRole("switch", { name: /Enable Instrumentation/i })).toBeNull();
+    expect(screen.queryByRole("heading", { name: /^Instrumentation$/i, level: 3 })).toBeNull();
+  });
 });


### PR DESCRIPTION
Addresses items 6 and 8 from #269.

**Item 6**: `js-yaml` was emitting `otlp_http: {}` and `always_on: null` for plugin-select discriminators and empty enabled groups. Added an `emptiesToNull` walker that converts empty objects to null before dumping, combined with `styles: { "!!null": "empty" }` so both cases render as `otlp_http:`. Matches the canonical form in the OTel configuration spec examples.

**Item 8**: Hid `instrumentation/development` from the SDK tab form. The filter now uses a named `HIDDEN_SDK_KEYS` set alongside the existing `file_format` exclusion. That content will surface in the Instrumentation tab once #250 lands.
