### PR TITLE
fix: replace lucide-react GitHub icon with inline SVG

### DIFF
--- a/ecosystem-explorer/bun.lock
+++ b/ecosystem-explorer/bun.lock
@@ -8,7 +8,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "idb": "^8.0.3",
         "js-yaml": "^4.1.1",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.0",
@@ -539,7 +539,7 @@
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
-    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "idb": "^8.0.3",
     "js-yaml": "^4.1.1",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.0"

--- a/ecosystem-explorer/src/components/icons/github-icon.tsx
+++ b/ecosystem-explorer/src/components/icons/github-icon.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from "react";
+import type { SVGProps } from "react";
 
-export function GitHubIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+export function GitHubIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
     <svg
       viewBox="0 0 24 24"

--- a/ecosystem-explorer/src/components/icons/github-icon.tsx
+++ b/ecosystem-explorer/src/components/icons/github-icon.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-label="GitHub"
+      role="img"
+      fill="currentColor"
+    >
+      <path
+        d="M12 0C5.373 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.562 21.8 24 17.302 24 12 24 5.373 18.627 0 12 0z"
+      />
+    </svg>
+  );
+}

--- a/ecosystem-explorer/src/components/icons/github-icon.tsx
+++ b/ecosystem-explorer/src/components/icons/github-icon.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export function GithubIcon({ className }: { className?: string }) {
+import React from "react";
+
+export function GitHubIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       viewBox="0 0 24 24"
@@ -21,6 +23,7 @@ export function GithubIcon({ className }: { className?: string }) {
       aria-label="GitHub"
       role="img"
       fill="currentColor"
+      {...props}
     >
       <path
         d="M12 0C5.373 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.562 21.8 24 17.302 24 12 24 5.373 18.627 0 12 0z"

--- a/ecosystem-explorer/src/components/layout/footer.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.tsx
@@ -15,7 +15,7 @@
  */
 import { Map } from "lucide-react";
 import { Link } from "react-router-dom";
-import { GithubIcon } from "@/components/icons/github-icon";
+import { GitHubIcon } from "@/components/icons/github-icon";
 import { OtelLogo } from "@/components/icons/otel-logo";
 
 export function Footer() {
@@ -42,7 +42,7 @@ export function Footer() {
               className="hover:text-foreground transition-colors flex items-center gap-1"
               aria-label="GitHub repository"
             >
-              <GithubIcon className="h-4 w-4" aria-hidden="true" />
+              <GitHubIcon className="h-4 w-4" aria-hidden="true" />
               GitHub
             </a>
             <a

--- a/ecosystem-explorer/src/components/layout/footer.tsx
+++ b/ecosystem-explorer/src/components/layout/footer.tsx
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Github, Map } from "lucide-react";
+import { Map } from "lucide-react";
 import { Link } from "react-router-dom";
+import { GithubIcon } from "@/components/icons/github-icon";
 import { OtelLogo } from "@/components/icons/otel-logo";
 
 export function Footer() {
@@ -41,7 +42,7 @@ export function Footer() {
               className="hover:text-foreground transition-colors flex items-center gap-1"
               aria-label="GitHub repository"
             >
-              <Github className="h-4 w-4" aria-hidden="true" />
+              <GithubIcon className="h-4 w-4" aria-hidden="true" />
               GitHub
             </a>
             <a

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Github, BookOpen, Bug, MessageSquare } from "lucide-react";
+import { BookOpen, Bug, MessageSquare } from "lucide-react";
+import { GithubIcon } from "@/components/icons/github-icon";
 
 const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
 
@@ -62,7 +63,7 @@ export function AboutPage() {
             rel="noopener noreferrer"
             className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
           >
-            <Github className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
+            <GithubIcon className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
             <div className="space-y-1">
               <h3 className="text-sm font-medium text-foreground">Source Code</h3>
               <p className="text-xs text-muted-foreground">

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { BookOpen, Bug, MessageSquare } from "lucide-react";
-import { GithubIcon } from "@/components/icons/github-icon";
+import { GitHubIcon } from "@/components/icons/github-icon";
 
 const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
 
@@ -63,7 +63,7 @@ export function AboutPage() {
             rel="noopener noreferrer"
             className="flex items-start gap-4 rounded-lg border border-border/50 bg-card/50 p-5 hover:bg-card transition-colors"
           >
-            <GithubIcon className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
+            <GitHubIcon className="h-5 w-5 mt-0.5 flex-shrink-0 text-primary" aria-hidden="true" />
             <div className="space-y-1">
               <h3 className="text-sm font-medium text-foreground">Source Code</h3>
               <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes #281

## Changes

- Upgraded `lucide-react` to `1.0.0`
- Created a custom `GithubIcon` React component (`github-icon.tsx`) with an inline SVG to avoid the dependency issue
- Replaced the `lucide-react` GitHub icon usage with the new `GithubIcon` component

## Why

`lucide-react` removed the `Github` icon in a recent version, causing a runtime error. Instead of relying on the dependency for a single icon, this PR introduces a lightweight inline SVG component as a stable replacement.

## Screenshots
About page:
<img width="908" height="291" alt="Screenshot 2026-04-23 at 15 57 29" src="https://github.com/user-attachments/assets/395f468c-468a-4c4c-beb2-08b96edacff7" />

Footer:
<img width="338" height="94" alt="Screenshot 2026-04-23 at 15 49 39" src="https://github.com/user-attachments/assets/05f9f2c9-4f3d-4190-ac48-31145dbde9f9" />

Footer hover state:
<img width="324" height="73" alt="Screenshot 2026-04-23 at 15 50 37" src="https://github.com/user-attachments/assets/2b7a6e64-2d46-4e71-8566-fc46a94d71e1" />
