### PR TITLE
Add cache expiration and bump schema version

### DIFF
--- a/ecosystem-explorer/src/lib/api/idb-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.test.ts
@@ -37,7 +37,7 @@ describe("idb-cache", () => {
       const db = await initDB();
 
       expect(db.name).toBe("otel-explorer-cache");
-      expect(db.version).toBe(2);
+      expect(db.version).toBe(4);
 
       const storeNames = Array.from(db.objectStoreNames);
       expect(storeNames).toContain("metadata");

--- a/ecosystem-explorer/src/lib/api/idb-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.test.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { initDB, getCached, setCached, clearAllCached, closeDB, STORES } from "./idb-cache";
 
 describe("idb-cache", () => {
   beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
     closeDB();
 
     await new Promise<void>((resolve) => {
@@ -29,6 +30,7 @@ describe("idb-cache", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     closeDB();
   });
 
@@ -85,6 +87,34 @@ describe("idb-cache", () => {
       const result = await getCached<typeof data>(key, STORES.CONFIGURATION);
 
       expect(result).toEqual(data);
+    });
+
+    it("should return data cached within 24 hours", async () => {
+      const key = "fresh-key";
+      const data = { value: "fresh" };
+      const now = Date.now();
+
+      await setCached(key, data, STORES.METADATA);
+      vi.setSystemTime(now + 23 * 60 * 60 * 1000); // 23 hours later
+      const result = await getCached<typeof data>(key, STORES.METADATA);
+
+      expect(result).toEqual(data);
+    });
+
+    it("should return null and delete entries older than 24 hours", async () => {
+      const key = "stale-key";
+      const data = { value: "stale" };
+      const now = Date.now();
+
+      await setCached(key, data, STORES.METADATA);
+      vi.setSystemTime(now + 25 * 60 * 60 * 1000); // 25 hours later
+      const result = await getCached<typeof data>(key, STORES.METADATA);
+
+      expect(result).toBeNull();
+      // Confirm it was deleted from the store
+      const db = await initDB();
+      const raw = await db.get(STORES.METADATA, key);
+      expect(raw).toBeUndefined();
     });
 
     it("should return null for non-existent keys", async () => {

--- a/ecosystem-explorer/src/lib/api/idb-cache.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.ts
@@ -16,7 +16,8 @@
 import { openDB, type IDBPDatabase } from "idb";
 
 const DB_NAME = "otel-explorer-cache";
-const DB_VERSION = 2;
+const DB_VERSION = 4;
+const CACHE_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 export const STORES = {
   METADATA: "metadata",
@@ -29,12 +30,16 @@ export type StoreName = (typeof STORES)[keyof typeof STORES];
 interface CacheEntry<T> {
   key: string;
   data: T;
-  cachedAt: number; // unused for now, will use in future for cache eviction policies
+  cachedAt: number;
 }
 
 let dbInstance: IDBPDatabase | null = null;
 let dbInitPromise: Promise<IDBPDatabase> | null = null;
 let dbInitFailed = false;
+
+function isExpired(cachedAt: number): boolean {
+  return Date.now() - cachedAt > CACHE_EXPIRATION_MS;
+}
 
 export async function initDB(): Promise<IDBPDatabase> {
   if (!isIDBAvailable()) {
@@ -57,17 +62,19 @@ export async function initDB(): Promise<IDBPDatabase> {
     try {
       const db = await openDB(DB_NAME, DB_VERSION, {
         upgrade(db) {
-          if (!db.objectStoreNames.contains(STORES.METADATA)) {
-            db.createObjectStore(STORES.METADATA, { keyPath: "key" });
+          if (db.objectStoreNames.contains(STORES.METADATA)) {
+            db.deleteObjectStore(STORES.METADATA);
+          }
+          if (db.objectStoreNames.contains(STORES.INSTRUMENTATIONS)) {
+            db.deleteObjectStore(STORES.INSTRUMENTATIONS);
+          }
+          if (db.objectStoreNames.contains(STORES.CONFIGURATION)) {
+            db.deleteObjectStore(STORES.CONFIGURATION);
           }
 
-          if (!db.objectStoreNames.contains(STORES.INSTRUMENTATIONS)) {
-            db.createObjectStore(STORES.INSTRUMENTATIONS, { keyPath: "key" });
-          }
-
-          if (!db.objectStoreNames.contains(STORES.CONFIGURATION)) {
-            db.createObjectStore(STORES.CONFIGURATION, { keyPath: "key" });
-          }
+          db.createObjectStore(STORES.METADATA, { keyPath: "key" });
+          db.createObjectStore(STORES.INSTRUMENTATIONS, { keyPath: "key" });
+          db.createObjectStore(STORES.CONFIGURATION, { keyPath: "key" });
         },
       });
 
@@ -94,7 +101,13 @@ export async function getCached<T>(key: string, store: StoreName): Promise<T | n
       return null;
     }
 
-    return (entry as CacheEntry<T>).data;
+    const cacheEntry = entry as CacheEntry<T>;
+    if (isExpired(cacheEntry.cachedAt)) {
+      await db.delete(store, key);
+      return null;
+    }
+
+    return cacheEntry.data;
   } catch (error) {
     console.error(`Failed to get cached data for %s:`, key, error);
     return null;

--- a/ecosystem-explorer/src/lib/api/idb-cache.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.ts
@@ -38,7 +38,11 @@ let dbInitPromise: Promise<IDBPDatabase> | null = null;
 let dbInitFailed = false;
 
 function isExpired(cachedAt: number): boolean {
-  return Date.now() - cachedAt > CACHE_EXPIRATION_MS;
+  const now = Date.now();
+  if (cachedAt > now) {
+    return true;
+  }
+  return now - cachedAt > CACHE_EXPIRATION_MS;
 }
 
 export async function initDB(): Promise<IDBPDatabase> {


### PR DESCRIPTION
We recently rebuilt the database in #283 so we need to bump the cache schema version to invalidate the previous cache.

Also added a 24 hour expiry so things get cleaned up