### PR TITLE
SDK config browser: emit file_format as major.minor, rename custom plugin input

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
@@ -116,13 +116,13 @@ describe("PluginSelectRenderer", () => {
     expect(selectedOption.textContent).toBe("Custom: my-exporter");
   });
 
-  it("auto-focuses the custom-key input when the picker opens", () => {
+  it("auto-focuses the custom-name input when the picker opens", () => {
     mockConfigState.values = { exporter: {} };
     render(<PluginSelectRenderer node={pluginNodeWithCustom} depth={1} path="exporter" />);
     fireEvent.change(screen.getByRole("combobox", { name: "Exporter variant" }), {
       target: { value: "__custom__" },
     });
-    const input = screen.getByRole("textbox", { name: "Custom plugin key" });
+    const input = screen.getByRole("textbox", { name: "Custom plugin name" });
     expect(document.activeElement).toBe(input);
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.tsx
@@ -87,8 +87,8 @@ export function PluginSelectRenderer({
           <input
             type="text"
             autoFocus
-            aria-label="Custom plugin key"
-            placeholder="custom-plugin-key"
+            aria-label="Custom plugin name"
+            placeholder="custom-plugin-name"
             value={customDraft}
             onChange={(e) => setCustomDraft(e.target.value)}
             className="flex-1 rounded-md border border-border/60 bg-background/80 px-3 py-1.5 text-sm"

--- a/ecosystem-explorer/src/lib/yaml-generator.test.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.test.ts
@@ -107,7 +107,8 @@ describe("generateYaml", () => {
 
     const output = generateYaml(state, fixtureSchema, { header: "" });
 
-    expect(output).toContain("file_format: 1.0.1");
+    expect(output).toContain('file_format: "1.0"');
+    expect(output).not.toContain("file_format: 1.0.1");
 
     const fileFormatIdx = output.indexOf("file_format:");
     const loggerIdx = output.indexOf("logger_provider:");

--- a/ecosystem-explorer/src/lib/yaml-generator.ts
+++ b/ecosystem-explorer/src/lib/yaml-generator.ts
@@ -39,6 +39,11 @@ function defaultHeader(version: string): string {
   ].join("\n");
 }
 
+function toFileFormatVersion(version: string): string {
+  const m = version.match(/^(\d+)\.(\d+)/);
+  return m ? `${m[1]}.${m[2]}` : version;
+}
+
 function emptiesToNull(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(emptiesToNull);
   if (value !== null && typeof value === "object") {
@@ -138,7 +143,8 @@ export function generateYaml(
 
   const fileFormatNode = children.find((c) => c.key === "file_format");
   const fileFormatBlock =
-    sectionComment(fileFormatNode, "file_format") + dumpYaml({ file_format: state.version });
+    sectionComment(fileFormatNode, "file_format") +
+    dumpYaml({ file_format: toFileFormatVersion(state.version) });
 
   const others = children
     .filter((c) => c.key !== "file_format")


### PR DESCRIPTION
Addresses items 4 and 5 from #269.

**Item 4**: `file_format` is now emitted as major.minor (`"1.0"` instead of `"1.0.0"`), matching the spec's `otel-sdk-config.yaml` example. Added a file-local `toFileFormatVersion` helper in `yaml-generator.ts`. `state.version` stays full semver for schema lookup, downloaded filename, and the `# Schema version:` header comment.

**Item 5**: Renamed the custom plugin input's placeholder (`custom-plugin-key` → `custom-plugin-name`) and aria-label (`Custom plugin key` → `Custom plugin name`), plus the one matching test query.