### PR TITLE
SDK config browser: hide distribution section

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -28,7 +28,7 @@ import type { GroupNode } from "@/types/configuration";
 import { SchemaRenderer } from "./components/schema-renderer";
 import { PreviewCard } from "./components/preview-card";
 
-const HIDDEN_SDK_KEYS = new Set(["file_format", "instrumentation/development"]);
+const HIDDEN_SDK_KEYS = new Set(["file_format", "instrumentation/development", "distribution"]);
 
 function SdkTab({ version }: { version: string }) {
   const schema = useConfigSchema(version);

--- a/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-basic.integration.test.tsx
@@ -69,4 +69,12 @@ describe("ConfigurationBuilderPage — basic", () => {
     expect(screen.queryByRole("switch", { name: /Enable Instrumentation/i })).toBeNull();
     expect(screen.queryByRole("heading", { name: /^Instrumentation$/i, level: 3 })).toBeNull();
   });
+
+  it("does not render the distribution section in the SDK tab", async () => {
+    renderPage();
+
+    await screen.findByRole("switch", { name: /Enable Resource/i }, { timeout: 10_000 });
+
+    expect(screen.queryByText("Distribution", { exact: true })).toBeNull();
+  });
 });


### PR DESCRIPTION
Addresses item 1 from #269.

Adds `"distribution"` to `HIDDEN_SDK_KEYS` in `configuration-builder-page.tsx` alongside the existing `file_format` and `instrumentation/development` entries, plus one integration test mirroring the existing `instrumentation/development` exclusion assertion.

Follow-up #289 tracks the long-term decision (hide entirely, free-form YAML block, or per-distribution schemas).