### PR TITLE
Reduce size of all components in theme

### DIFF
--- a/ecosystem-explorer/src/components/layout/header.tsx
+++ b/ecosystem-explorer/src/components/layout/header.tsx
@@ -19,7 +19,7 @@ import { OtelLogo } from "@/components/icons/otel-logo";
 export function Header() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/30 bg-background/95 backdrop-blur-xl h-16">
-      <div className="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
+      <div className="max-w-screen-2xl mx-auto px-6 h-full flex items-center justify-between">
         <Link to="/" className="flex items-center gap-3">
           <OtelLogo className="h-6 w-6 text-primary" />
           <span className="font-semibold text-foreground">OTel Explorer</span>

--- a/ecosystem-explorer/src/components/layout/page-container.tsx
+++ b/ecosystem-explorer/src/components/layout/page-container.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface PageContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function PageContainer({ children, className }: PageContainerProps) {
+  const classes = ["max-w-screen-2xl mx-auto px-6 py-4", className].filter(Boolean).join(" ");
+  return <div className={classes}>{children}</div>;
+}

--- a/ecosystem-explorer/src/components/layout/page-container.tsx
+++ b/ecosystem-explorer/src/components/layout/page-container.tsx
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ReactNode } from "react";
+
 interface PageContainerProps {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }
 

--- a/ecosystem-explorer/src/features/collector/collector-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 import { isEnabled } from "@/lib/feature-flags";
+import { PageContainer } from "@/components/layout/page-container";
 
 export function CollectorPage() {
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
+    <PageContainer>
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold text-foreground mb-2">OpenTelemetry Collector</h1>
@@ -36,6 +37,6 @@ export function CollectorPage() {
           </div>
         )}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -15,6 +15,7 @@
  */
 import { useMemo, useState } from "react";
 import { BackButton } from "@/components/ui/back-button";
+import { PageContainer } from "@/components/layout/page-container";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { SegmentedTabList } from "@/components/ui/segmented-tabs";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
@@ -90,7 +91,7 @@ export function ConfigurationBuilderPage() {
   const [activeTab, setActiveTab] = useState("sdk");
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
+    <PageContainer>
       <div className="space-y-6">
         <div className="flex items-center">
           <BackButton />
@@ -130,6 +131,6 @@ export function ConfigurationBuilderPage() {
           </TabsContent>
         </Tabs>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -40,6 +40,7 @@ import {
 import { TelemetrySection } from "./components/telemetry-section";
 import { TelemetryComparisonSection } from "./components/telemetry-comparison/telemetry-comparison-section";
 import { VersionSelector } from "./components/version-selector";
+import { PageContainer } from "@/components/layout/page-container";
 
 function buildSourceUrl(sourcePath: string): string {
   try {
@@ -87,7 +88,7 @@ export function InstrumentationDetailPage() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-7xl px-6 py-12">
+      <PageContainer>
         <div className="flex min-h-[400px] items-center justify-center">
           <div className="text-center">
             <div
@@ -104,15 +105,15 @@ export function InstrumentationDetailPage() {
             </div>
           </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (error || !instrumentation) {
     return (
-      <div className="mx-auto max-w-7xl px-6 py-12">
+      <PageContainer>
         <BackButton />
-        <div className="mt-6">
+        <div className="mt-3">
           <DetailCard className="border-red-500/50 bg-red-500/5">
             <div className="flex gap-4">
               <AlertCircle
@@ -130,7 +131,7 @@ export function InstrumentationDetailPage() {
             </div>
           </DetailCard>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -139,10 +140,10 @@ export function InstrumentationDetailPage() {
     instrumentation.display_name && instrumentation.display_name !== instrumentation.name;
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
+    <PageContainer>
       <BackButton />
 
-      <div className="mt-6 space-y-6">
+      <div className="mt-3 space-y-6">
         <header className="relative overflow-hidden rounded-lg border border-border/60 bg-card/80 p-8">
           {/* Ambient radial gradient background */}
           <div
@@ -577,6 +578,6 @@ export function InstrumentationDetailPage() {
           </Tabs>
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/java-agent-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-agent-page.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 import { AgentExploreLanding } from "@/features/java-agent/components/agent-explore-landing.tsx";
+import { PageContainer } from "@/components/layout/page-container";
 
 export function JavaAgentPage() {
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
+    <PageContainer>
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold text-foreground mb-2">OpenTelemetry Java Agent</h1>
@@ -28,6 +29,6 @@ export function JavaAgentPage() {
         </div>
         <AgentExploreLanding />
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/java-configuration-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-configuration-list-page.tsx
@@ -17,10 +17,11 @@ import { ConfigurationIcon } from "@/components/icons/configuration-icon";
 import { BackButton } from "@/components/ui/back-button";
 import { NavigationCard } from "@/components/ui/navigation-card";
 import { isEnabled } from "@/lib/feature-flags";
+import { PageContainer } from "@/components/layout/page-container";
 
 export function JavaConfigurationListPage() {
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
+    <PageContainer>
       <div className="space-y-6">
         <BackButton />
         <div>
@@ -41,6 +42,6 @@ export function JavaConfigurationListPage() {
           </div>
         )}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -25,6 +25,7 @@ import { InstrumentationGroupCard } from "@/features/java-agent/components/instr
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import { getInstrumentationDisplayName } from "./utils/format";
 import { groupInstrumentationsByDisplayName } from "./utils/group-instrumentations";
+import { PageContainer } from "@/components/layout/page-container";
 
 export function JavaInstrumentationListPage() {
   const { version: versionParam } = useParams<{ version?: string }>();
@@ -111,41 +112,41 @@ export function JavaInstrumentationListPage() {
 
   if (versionsLoading || instrumentationsLoading) {
     return (
-      <div className="max-w-7xl mx-auto px-6 py-12">
+      <PageContainer>
         <div className="flex items-center justify-center min-h-[400px]">
           <div className="text-center space-y-2">
             <div className="text-lg font-medium">Loading instrumentations...</div>
             <div className="text-sm text-muted-foreground">This may take a moment</div>
           </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (error) {
     return (
-      <div className="max-w-7xl mx-auto px-6 py-12">
+      <PageContainer>
         <div className="p-6 border border-red-500/50 rounded-lg bg-red-500/10 text-red-600 dark:text-red-400">
           <h3 className="font-semibold mb-2">Error loading instrumentations</h3>
           <p className="text-sm">{error.message}</p>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (!resolvedVersion) {
     return (
-      <div className="max-w-7xl mx-auto px-6 py-12">
+      <PageContainer>
         <div className="p-6 border border-yellow-500/50 rounded-lg bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
           <h3 className="font-semibold mb-2">No version available</h3>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-6 py-12">
-      <div className="space-y-8">
+    <PageContainer>
+      <div className="space-y-4">
         <BackButton />
 
         {/* Header Section */}
@@ -203,6 +204,6 @@ export function JavaInstrumentationListPage() {
           </div>
         )}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/features/not-found/not-found-page.tsx
+++ b/ecosystem-explorer/src/features/not-found/not-found-page.tsx
@@ -15,10 +15,11 @@
  */
 import { Link } from "react-router-dom";
 import { Compass } from "@/components/icons/compass";
+import { PageContainer } from "@/components/layout/page-container";
 
 export function NotFoundPage() {
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12 flex flex-col items-center justify-center min-h-[60vh]">
+    <PageContainer className="flex flex-col items-center justify-center min-h-[60vh]">
       <Compass className="w-32 h-32 mb-8 opacity-50" />
 
       <h1 className="text-4xl font-bold text-foreground mb-4">404 - Page Not Found</h1>
@@ -34,6 +35,6 @@ export function NotFoundPage() {
       >
         Return to Home
       </Link>
-    </div>
+    </PageContainer>
   );
 }

--- a/ecosystem-explorer/src/index.css
+++ b/ecosystem-explorer/src/index.css
@@ -66,5 +66,5 @@ body {
 
 html {
   /* Root font size affects overall rem calculations for all components. */
-  font-size: 13px;
+  font-size: 14px;
 }

--- a/ecosystem-explorer/src/index.css
+++ b/ecosystem-explorer/src/index.css
@@ -63,3 +63,8 @@ body {
 [role="tab"][data-state="active"] {
   border-top-color: hsl(var(--primary-hsl)) !important;
 }
+
+html {
+  /* Root font size affects overall rem calculations for all components. */
+  font-size: 14px;
+}

--- a/ecosystem-explorer/src/index.css
+++ b/ecosystem-explorer/src/index.css
@@ -66,5 +66,5 @@ body {
 
 html {
   /* Root font size affects overall rem calculations for all components. */
-  font-size: 14px;
+  font-size: 13px;
 }


### PR DESCRIPTION
I found the existing sizing of things to be a bit bloated, so I wanted to slim things down a bit.

In tailwind the root font size affects the REM calculation used in all other components, so this reduces the font size which results in all components / padding / margin etc to be reduced a bit.

I also added a new page container and made it wider so we take advantage of more of the horizontal real estate.

Before:

<img width="1496" height="817" alt="image" src="https://github.com/user-attachments/assets/8ff10e30-f87e-4085-b0be-f4f1323eae47" />

After:

<img width="1496" height="818" alt="image" src="https://github.com/user-attachments/assets/66e0fce8-213f-4060-8fe5-1c5ee7f997c2" />

