### PR TITLE
Auto-increment DB_VERSION on database rebuild

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -85,6 +85,18 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Increment DB cache schema version
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          FILE="ecosystem-explorer/src/lib/api/idb-cache.ts"
+          CURRENT=$(grep -oP 'const DB_VERSION = \K[0-9]+' "$FILE")
+          if [ -z "$CURRENT" ]; then
+            echo "Could not find DB_VERSION in $FILE"
+            exit 1
+          fi
+          NEW=$((CURRENT + 1))
+          sed -i "s/const DB_VERSION = ${CURRENT};/const DB_VERSION = ${NEW};/" "$FILE"
+
       - name: Commit and push changes
         if: steps.check_changes.outputs.has_changes == 'true'
         env:
@@ -92,7 +104,7 @@ jobs:
         run: |
           BRANCH="otelbot/automated-explorer-database-update"
 
-          git add ecosystem-explorer/public/data/
+          git add ecosystem-explorer/public/data/ ecosystem-explorer/src/lib/api/idb-cache.ts
 
           git commit -m "Update explorer database"
 


### PR DESCRIPTION
Closes #285,

### Description

When the `explorer-db-builder` runs and produces changes to `ecosystem-explorer/public/data/`, the `DB_VERSION` in `idb-cache.ts` should be incremented so that users' browsers automatically clear their stale IndexedDB cache and fetch the updated data.

### Changes

- Added a new step `Increment DB cache schema version` in `build-explorer-database.yml` that reads the current `DB_VERSION` value from `idb-cache.ts` and increments it by 1
- Updated `git add` in the commit step to also stage `idb-cache.ts` alongside the data files
- The step only runs when `has_changes == 'true'`, so no-op builds do not trigger a version bump