### PR TITLE
Remove cache version assertion

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -224,7 +224,8 @@ export function JavaInstrumentationListPage() {
                     Custom Instrumentations
                   </h2>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Non-library instrumentations such as methods, JMX metrics, and external annotations.
+                    Non-library instrumentations such as methods, JMX metrics, and external
+                    annotations.
                   </p>
                 </div>
                 <div className="grid gap-6 md:grid-cols-2">

--- a/ecosystem-explorer/src/lib/api/idb-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.test.ts
@@ -39,7 +39,6 @@ describe("idb-cache", () => {
       const db = await initDB();
 
       expect(db.name).toBe("otel-explorer-cache");
-      expect(db.version).toBe(4);
 
       const storeNames = Array.from(db.objectStoreNames);
       expect(storeNames).toContain("metadata");

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -45,7 +45,7 @@ export async function loadInstrumentation(
   manifest?: VersionManifest
 ): Promise<InstrumentationData> {
   const resolvedManifest = manifest ?? (await loadVersionManifest(version));
-  
+
   const libraryHash = resolvedManifest.instrumentations[id];
   const customHash = resolvedManifest.custom_instrumentations?.[id];
   const hash = libraryHash || customHash;
@@ -62,7 +62,7 @@ export async function loadInstrumentation(
     STORES.INSTRUMENTATIONS
   );
   if (!data) throw new Error(`Instrumentation "${id}" returned null unexpectedly`);
-  
+
   return { ...data, _is_custom: isCustom };
 }
 
@@ -70,7 +70,7 @@ export async function loadAllInstrumentations(version: string): Promise<Instrume
   const manifest = await loadVersionManifest(version);
   const libraryIds = Object.keys(manifest.instrumentations || {});
   const customIds = Object.keys(manifest.custom_instrumentations || {});
-  
+
   const allIds = [...libraryIds, ...customIds];
 
   return Promise.all(


### PR DESCRIPTION
We now have automation that automatically increments the cache version, so having an assertion on the version is problematic, and not really valuable.