### PR TITLE
configuration-builder: FieldSection layout and markdown descriptions

### DIFF
--- a/ecosystem-explorer/bun.lock
+++ b/ecosystem-explorer/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "ecosystem-explorer",
       "dependencies": {
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "idb": "^8.0.3",
@@ -12,7 +13,9 @@
         "lucide-react": "^1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
+        "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -179,6 +182,8 @@
 
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
 
+    "@radix-ui/react-hover-card": ["@radix-ui/react-hover-card@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg=="],
+
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
@@ -323,21 +328,33 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
 
@@ -358,6 +375,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w=="],
 
@@ -393,6 +412,8 @@
 
     "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
@@ -405,7 +426,19 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001790", "", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -425,11 +458,15 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
@@ -465,11 +502,15 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
@@ -501,11 +542,17 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
@@ -515,9 +562,21 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -571,6 +630,8 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
@@ -579,7 +640,95 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -600,6 +749,8 @@
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
@@ -629,6 +780,8 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -637,11 +790,21 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
 
     "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -663,11 +826,19 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
@@ -691,6 +862,10 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -705,9 +880,25 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
@@ -739,6 +930,8 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -762,6 +955,10 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -23,6 +23,7 @@
     "test:integration:watch": "vitest --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "idb": "^8.0.3",
@@ -30,7 +31,9 @@
     "lucide-react": "^1.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.0"
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.13.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/ecosystem-explorer/src/components/ui/info-tooltip.test.tsx
+++ b/ecosystem-explorer/src/components/ui/info-tooltip.test.tsx
@@ -14,56 +14,46 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { InfoTooltip } from "./info-tooltip";
 
 describe("InfoTooltip", () => {
-  it("renders the tooltip element with the description text in the DOM", () => {
-    render(<InfoTooltip text="Helpful description." />);
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveTextContent("Helpful description.");
+  it("renders nothing when text is empty", () => {
+    const { container } = render(<InfoTooltip text="" />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it("uses the supplied describedById on the tooltip element", () => {
+  it("renders nothing when text is only whitespace", () => {
+    const { container } = render(<InfoTooltip text={"  \n  "} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a trigger button labelled Description", () => {
+    render(<InfoTooltip text="Helpful description." />);
+    expect(screen.getByRole("button", { name: "Description" })).toBeInTheDocument();
+  });
+
+  it("renders the description text in an accessible element so screen readers reach it via aria-describedby", () => {
+    render(<InfoTooltip text="Helpful description." />);
+    const description = screen.getByText("Helpful description.");
+    expect(description).toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: "Description" });
+    expect(trigger.getAttribute("aria-describedby")).toBe(description.id);
+  });
+
+  it("uses the supplied describedById on the description element", () => {
     render(<InfoTooltip text="X" describedById="my-desc" />);
-    expect(screen.getByRole("tooltip").id).toBe("my-desc");
+    expect(screen.getByText("X").id).toBe("my-desc");
   });
 
   it("auto-generates an id when describedById is not provided", () => {
     render(<InfoTooltip text="X" />);
-    expect(screen.getByRole("tooltip").id.length).toBeGreaterThan(0);
+    expect(screen.getByText("X").id.length).toBeGreaterThan(0);
   });
 
-  it("makes the tooltip visible on trigger focus and hides it on blur", () => {
+  it("starts with the hover card closed", () => {
     render(<InfoTooltip text="X" />);
-    const trigger = screen.getByRole("button", { name: /description/i });
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "false");
-    fireEvent.focus(trigger);
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "true");
-    fireEvent.blur(trigger);
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "false");
-  });
-
-  it("makes the tooltip visible while the wrapper is hovered", () => {
-    const { container } = render(<InfoTooltip text="X" />);
-    const wrapper = container.querySelector("span") as HTMLElement;
-    fireEvent.mouseEnter(wrapper);
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "true");
-    fireEvent.mouseLeave(wrapper);
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "false");
-  });
-
-  it("closes on Escape", () => {
-    render(<InfoTooltip text="X" />);
-    const trigger = screen.getByRole("button", { name: /description/i });
-    fireEvent.focus(trigger);
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "true");
-    fireEvent.keyDown(trigger, { key: "Escape" });
-    expect(screen.getByRole("tooltip")).toHaveAttribute("data-open", "false");
-  });
-
-  it("renders nothing when text is empty", () => {
-    const { container } = render(<InfoTooltip text="" />);
-    expect(container.firstChild).toBeNull();
+    const trigger = screen.getByRole("button", { name: "Description" });
+    expect(trigger).toHaveAttribute("data-state", "closed");
   });
 });

--- a/ecosystem-explorer/src/components/ui/info-tooltip.test.tsx
+++ b/ecosystem-explorer/src/components/ui/info-tooltip.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { InfoTooltip } from "./info-tooltip";
 
 describe("InfoTooltip", () => {
@@ -54,6 +54,21 @@ describe("InfoTooltip", () => {
   it("starts with the hover card closed", () => {
     render(<InfoTooltip text="X" />);
     const trigger = screen.getByRole("button", { name: "Description" });
+    expect(trigger).toHaveAttribute("data-state", "closed");
+  });
+
+  it("opens the popup on focus so sighted keyboard users see it", () => {
+    render(<InfoTooltip text="Keyboard visible description." />);
+    const trigger = screen.getByRole("button", { name: "Description" });
+    fireEvent.focus(trigger);
+    expect(trigger).toHaveAttribute("data-state", "open");
+  });
+
+  it("closes the popup on blur", () => {
+    render(<InfoTooltip text="Keyboard visible description." />);
+    const trigger = screen.getByRole("button", { name: "Description" });
+    fireEvent.focus(trigger);
+    fireEvent.blur(trigger);
     expect(trigger).toHaveAttribute("data-state", "closed");
   });
 });

--- a/ecosystem-explorer/src/components/ui/info-tooltip.tsx
+++ b/ecosystem-explorer/src/components/ui/info-tooltip.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useId, type JSX } from "react";
+import { useId, useState, type JSX } from "react";
 import { Info } from "lucide-react";
 import * as HoverCard from "@radix-ui/react-hover-card";
 import { MarkdownDescription } from "./markdown-description";
@@ -36,16 +36,19 @@ export function InfoTooltip({
 }: InfoTooltipProps): JSX.Element | null {
   const autoId = useId();
   const id = describedById ?? autoId;
+  const [open, setOpen] = useState(false);
   if (text.trim() === "") return null;
 
   return (
     <span className={`relative inline-flex ${className ?? ""}`}>
-      <HoverCard.Root openDelay={100} closeDelay={150}>
+      <HoverCard.Root open={open} onOpenChange={setOpen} openDelay={100} closeDelay={150}>
         <HoverCard.Trigger asChild>
           <button
             type="button"
             aria-label="Description"
             aria-describedby={id}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
             className="text-muted-foreground hover:text-foreground focus-visible:ring-primary/40 inline-flex h-4 w-4 items-center justify-center rounded-full focus:outline-none focus-visible:ring-2"
           >
             <Info className="h-3 w-3" aria-hidden="true" />

--- a/ecosystem-explorer/src/components/ui/info-tooltip.tsx
+++ b/ecosystem-explorer/src/components/ui/info-tooltip.tsx
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useId, useState, type JSX } from "react";
+import { useId, type JSX } from "react";
 import { Info } from "lucide-react";
+import * as HoverCard from "@radix-ui/react-hover-card";
+import { MarkdownDescription } from "./markdown-description";
 
 export interface InfoTooltipProps {
   text: string;
   /**
-   * Stable id for the tooltip's content element. When provided, consumers can
-   * point an input's `aria-describedby` at it. When omitted, an auto-generated
-   * id is used.
+   * Stable id for the screen-reader description element. When provided,
+   * consumers can point an input's `aria-describedby` at it. When omitted,
+   * an auto-generated id is used.
    */
   describedById?: string;
   className?: string;
@@ -34,40 +36,39 @@ export function InfoTooltip({
 }: InfoTooltipProps): JSX.Element | null {
   const autoId = useId();
   const id = describedById ?? autoId;
-  const [open, setOpen] = useState(false);
   if (text.trim() === "") return null;
 
   return (
-    <span
-      className={`relative inline-flex ${className ?? ""}`}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-    >
-      <button
-        type="button"
-        aria-label="Description"
-        aria-describedby={id}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") setOpen(false);
-        }}
-        className="text-muted-foreground hover:text-foreground focus-visible:ring-primary/40 inline-flex h-4 w-4 items-center justify-center rounded-full focus:outline-none focus-visible:ring-2"
-      >
-        <Info className="h-3 w-3" aria-hidden="true" />
-      </button>
-      <span
-        role="tooltip"
-        id={id}
-        data-open={open}
-        className={[
-          "border-border/60 bg-card text-foreground pointer-events-none absolute top-full left-0 z-20 mt-1 w-max max-w-xs rounded-md border px-2 py-1 text-xs shadow-lg",
-          open ? "opacity-100" : "opacity-0",
-          "transition-opacity",
-        ].join(" ")}
-      >
-        {text}
-      </span>
+    <span className={`relative inline-flex ${className ?? ""}`}>
+      <HoverCard.Root openDelay={100} closeDelay={150}>
+        <HoverCard.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Description"
+            aria-describedby={id}
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-primary/40 inline-flex h-4 w-4 items-center justify-center rounded-full focus:outline-none focus-visible:ring-2"
+          >
+            <Info className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </HoverCard.Trigger>
+        <span id={id} className="sr-only">
+          {text}
+        </span>
+        <HoverCard.Portal>
+          <HoverCard.Content
+            side="bottom"
+            align="start"
+            sideOffset={4}
+            collisionPadding={8}
+            className={[
+              "border-border/60 bg-card text-foreground z-20 w-max max-w-xs rounded-md border px-2 py-1 text-xs shadow-lg",
+              "[&_li]:my-0 [&_p]:my-0.5 [&_ul]:my-0.5 [&_ul]:list-disc [&_ul]:pl-4",
+            ].join(" ")}
+          >
+            <MarkdownDescription text={text} />
+          </HoverCard.Content>
+        </HoverCard.Portal>
+      </HoverCard.Root>
     </span>
   );
 }

--- a/ecosystem-explorer/src/components/ui/markdown-description.test.tsx
+++ b/ecosystem-explorer/src/components/ui/markdown-description.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MarkdownDescription } from "./markdown-description";
+
+describe("MarkdownDescription", () => {
+  it("renders nothing when text is empty", () => {
+    const { container } = render(<MarkdownDescription text="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when text is only whitespace", () => {
+    const { container } = render(<MarkdownDescription text={"   \n  "} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single paragraph as one <p>", () => {
+    const { container } = render(<MarkdownDescription text="Hello world." />);
+    const ps = container.querySelectorAll("p");
+    expect(ps.length).toBe(1);
+    expect(ps[0]).toHaveTextContent("Hello world.");
+  });
+
+  it("renders blank-line-separated paragraphs as multiple <p>", () => {
+    const { container } = render(
+      <MarkdownDescription text={"First paragraph.\n\nSecond paragraph."} />
+    );
+    const ps = container.querySelectorAll("p");
+    expect(ps.length).toBe(2);
+    expect(ps[0]).toHaveTextContent("First paragraph.");
+    expect(ps[1]).toHaveTextContent("Second paragraph.");
+  });
+
+  it("renders a single-newline break inside a paragraph as a soft break", () => {
+    const { container } = render(<MarkdownDescription text={"Line one.\nLine two."} />);
+    const ps = container.querySelectorAll("p");
+    expect(ps.length).toBe(1);
+    expect(ps[0]).toHaveTextContent("Line one.");
+    expect(ps[0]).toHaveTextContent("Line two.");
+  });
+
+  it("renders dash bullets as a <ul> with <li> children", () => {
+    const { container } = render(<MarkdownDescription text={"- first\n- second\n- third"} />);
+    const ul = container.querySelector("ul");
+    expect(ul).not.toBeNull();
+    const items = ul!.querySelectorAll("li");
+    expect(items.length).toBe(3);
+    expect(items[0]).toHaveTextContent("first");
+    expect(items[2]).toHaveTextContent("third");
+  });
+
+  it("renders asterisk bullets as a <ul> with <li> children", () => {
+    const { container } = render(<MarkdownDescription text={"* one\n* two"} />);
+    const items = container.querySelectorAll("ul li");
+    expect(items.length).toBe(2);
+  });
+
+  it("autolinks bare http URLs with safe rel and target", () => {
+    render(<MarkdownDescription text="See https://example.com/spec for details." />);
+    const link = screen.getByRole("link", { name: "https://example.com/spec" });
+    expect(link).toHaveAttribute("href", "https://example.com/spec");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not render raw HTML tags as elements", () => {
+    const { container } = render(
+      <MarkdownDescription text={"Hello <script>alert(1)</script> world"} />
+    );
+    expect(container.querySelector("script")).toBeNull();
+  });
+
+  it("strips disallowed markdown elements (headings, tables, blockquotes)", () => {
+    const { container } = render(
+      <MarkdownDescription text={"# Heading\n\n> quote\n\n| a | b |\n|---|---|\n| 1 | 2 |"} />
+    );
+    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("renders inline code, strong, and em when present", () => {
+    const { container } = render(
+      <MarkdownDescription text={"a **bold** and _italic_ and `code` token"} />
+    );
+    expect(container.querySelector("strong")).not.toBeNull();
+    expect(container.querySelector("em")).not.toBeNull();
+    expect(container.querySelector("code")).not.toBeNull();
+  });
+
+  it("applies the supplied className to the wrapper element", () => {
+    const { container } = render(<MarkdownDescription text="Hello." className="custom-cls" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("custom-cls");
+  });
+});

--- a/ecosystem-explorer/src/components/ui/markdown-description.tsx
+++ b/ecosystem-explorer/src/components/ui/markdown-description.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ComponentProps, JSX } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface MarkdownDescriptionProps {
+  text: string;
+  className?: string;
+}
+
+const ALLOWED = ["p", "ul", "ol", "li", "a", "strong", "em", "code"];
+
+function Anchor({ href, children, ...rest }: ComponentProps<"a">): JSX.Element {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary [overflow-wrap:anywhere] underline-offset-2 hover:underline"
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}
+
+export function MarkdownDescription({
+  text,
+  className,
+}: MarkdownDescriptionProps): JSX.Element | null {
+  if (text.trim() === "") return null;
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        allowedElements={ALLOWED}
+        unwrapDisallowed
+        components={{ a: Anchor }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/components/ui/markdown-description.tsx
+++ b/ecosystem-explorer/src/components/ui/markdown-description.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 import type { ComponentProps, JSX } from "react";
+import { Fragment } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface MarkdownDescriptionProps {
   text: string;
   className?: string;
+  /** When true, do not wrap output in a `<div>` and unwrap the top-level `<p>`
+   *  so the rendered nodes flow inline with surrounding text. */
+  inline?: boolean;
 }
 
 const ALLOWED = ["p", "ul", "ol", "li", "a", "strong", "em", "code"];
@@ -41,8 +45,21 @@ function Anchor({ href, children, ...rest }: ComponentProps<"a">): JSX.Element {
 export function MarkdownDescription({
   text,
   className,
+  inline,
 }: MarkdownDescriptionProps): JSX.Element | null {
   if (text.trim() === "") return null;
+  if (inline) {
+    return (
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        allowedElements={ALLOWED}
+        unwrapDisallowed
+        components={{ a: Anchor, p: Fragment }}
+      >
+        {text}
+      </ReactMarkdown>
+    );
+  }
   return (
     <div className={className}>
       <ReactMarkdown

--- a/ecosystem-explorer/src/components/ui/truncated-description.test.tsx
+++ b/ecosystem-explorer/src/components/ui/truncated-description.test.tsx
@@ -60,4 +60,32 @@ describe("TruncatedDescription", () => {
     const rest = screen.getByTestId("truncated-rest");
     expect(button.getAttribute("aria-controls")).toBe(rest.id);
   });
+
+  it("renders multi-paragraph descriptions as multiple <p> elements when expanded", () => {
+    const text =
+      "Configure the propagators. Entries are appended.\n\nThe value is a comma separated list. See details.\n\nBuilt-in identifiers include: tracecontext, baggage.";
+    const { container } = render(<TruncatedDescription text={text} />);
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    const ps = container.querySelectorAll("p");
+    expect(ps.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders bullet lists as <ul><li> when expanded", () => {
+    const text =
+      "Known values include the following supported entries.\n\n- alpha: first value\n- beta: second value";
+    const { container } = render(<TruncatedDescription text={text} />);
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelectorAll("ul li").length).toBe(2);
+  });
+
+  it("autolinks bare URLs in the rendered description", () => {
+    const text =
+      "Configure tracing. See the spec.\n\nReference: https://example.com/spec for full details.";
+    render(<TruncatedDescription text={text} />);
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    const link = screen.getByRole("link", { name: "https://example.com/spec" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
 });

--- a/ecosystem-explorer/src/components/ui/truncated-description.tsx
+++ b/ecosystem-explorer/src/components/ui/truncated-description.tsx
@@ -15,6 +15,7 @@
  */
 import { useId, useMemo, useState, type JSX } from "react";
 import { truncateDescription } from "@/lib/truncate-description";
+import { MarkdownDescription } from "./markdown-description";
 
 interface TruncatedDescriptionProps {
   text: string;
@@ -33,14 +34,13 @@ export function TruncatedDescription({
   if (summary === "") return null;
 
   return (
-    <p className={className ?? "text-muted-foreground text-xs"}>
-      {summary}
+    <div className={className ?? "text-muted-foreground text-xs"}>
+      <MarkdownDescription text={summary} />
       {rest !== null && (
         <>
-          {" "}
-          <span id={tailId} data-testid="truncated-rest" hidden={!expanded}>
-            {rest}
-          </span>{" "}
+          <div id={tailId} data-testid="truncated-rest" hidden={!expanded}>
+            <MarkdownDescription text={rest} />
+          </div>
           <button
             type="button"
             onClick={() => setExpanded((e) => !e)}
@@ -52,6 +52,6 @@ export function TruncatedDescription({
           </button>
         </>
       )}
-    </p>
+    </div>
   );
 }

--- a/ecosystem-explorer/src/components/ui/truncated-description.tsx
+++ b/ecosystem-explorer/src/components/ui/truncated-description.tsx
@@ -35,22 +35,27 @@ export function TruncatedDescription({
 
   return (
     <div className={className ?? "text-muted-foreground text-xs"}>
-      <MarkdownDescription text={summary} />
+      <p>
+        <MarkdownDescription text={summary} inline />
+        {rest !== null && (
+          <>
+            {" "}
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              aria-expanded={expanded}
+              aria-controls={tailId}
+              className="text-primary underline-offset-2 hover:underline"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          </>
+        )}
+      </p>
       {rest !== null && (
-        <>
-          <div id={tailId} data-testid="truncated-rest" hidden={!expanded}>
-            <MarkdownDescription text={rest} />
-          </div>
-          <button
-            type="button"
-            onClick={() => setExpanded((e) => !e)}
-            aria-expanded={expanded}
-            aria-controls={tailId}
-            className="text-primary underline-offset-2 hover:underline"
-          >
-            {expanded ? "Show less" : "Show more"}
-          </button>
-        </>
+        <div id={tailId} data-testid="truncated-rest" hidden={!expanded}>
+          <MarkdownDescription text={rest} />
+        </div>
       )}
     </div>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.test.tsx
@@ -162,9 +162,8 @@ describe("ControlWrapper", () => {
         <input id="my-input" aria-describedby="my-desc" />
       </ControlWrapper>
     );
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip.id).toBe("my-desc");
-    expect(tooltip).toHaveTextContent("URL to send telemetry to.");
+    const description = screen.getByText("URL to send telemetry to.");
+    expect(description.id).toBe("my-desc");
     expect(screen.queryAllByText("URL to send telemetry to.")).toHaveLength(1);
   });
 

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
@@ -35,6 +35,13 @@ interface ControlWrapperProps {
    */
   inlineControl?: boolean;
   /**
+   * When true, suppress the label row entirely (label, required asterisk,
+   * stability badge, description tooltip). Used by list-like controls that
+   * delegate the header to a FieldSection inside their children, so the Add
+   * button sits next to the label instead of below it.
+   */
+  hideLabel?: boolean;
+  /**
    * Describes the schema's default for this field. When `isNull` is true,
    * the wrapper renders a "default" badge alongside the children. The leaf
    * control is responsible for using `value` to position itself in the
@@ -72,9 +79,11 @@ export function ControlWrapper({
   error,
   onClear,
   inlineControl = false,
+  hideLabel = false,
   defaultPreview,
   children,
 }: ControlWrapperProps) {
+  const labelHidden = hideLabel || node.hideLabel;
   const isUnset = node.nullable === true && isNull;
   const showReset = node.nullable === true && !isNull && !!onClear;
   const trailing: ReactNode = isUnset ? (
@@ -88,7 +97,7 @@ export function ControlWrapper({
 
   return (
     <div className="space-y-2">
-      {!node.hideLabel && (
+      {!labelHidden && (
         <div className="flex items-center gap-2">
           {inputId ? (
             <label htmlFor={inputId} className="text-foreground text-sm font-medium">

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/focus-managed-input-list.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/focus-managed-input-list.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ReactNode } from "react";
-import { useCallback, useRef } from "react";
-import { Plus, X } from "lucide-react";
+import type { ReactNode, RefObject } from "react";
+import { useCallback, useImperativeHandle, useRef } from "react";
+import { X } from "lucide-react";
 
 interface RenderInputProps<T> {
   value: T;
@@ -23,48 +23,64 @@ interface RenderInputProps<T> {
   ariaLabel: string;
 }
 
+export interface FocusManagedInputListHandle {
+  /**
+   * Call after the consumer's Add handler emits a new item. Schedules focus
+   * on the newly-rendered last input and announces "Item added" via the
+   * polite live region owned by this component.
+   */
+  notifyAdded: () => void;
+}
+
 interface FocusManagedInputListProps<T> {
   label: string;
   items: T[];
-  canAdd: boolean;
   canRemove: boolean;
-  makeEmpty: () => T;
   onChange: (next: T[]) => void;
   renderInput: (props: RenderInputProps<T>) => ReactNode;
+  /** Add button rendered by the consumer (inside FieldSection.Action). When the
+   *  list empties on remove, focus falls back to this button. */
+  addButtonRef: RefObject<HTMLButtonElement | null>;
+  /** Optional imperative handle; the consumer's Add handler should call
+   *  `current?.notifyAdded()` after emitting the new item. */
+  handleRef?: RefObject<FocusManagedInputListHandle | null>;
 }
 
 /**
- * Visual + a11y shell for list-of-input controls. Owns the Add/Remove
- * buttons, the live-region announcer, and the post-mutation focus
- * restoration (focus the new last input on add; the next surviving input
- * on remove; the Add button if the list is now empty). Per-row inputs are
- * supplied by the caller via `renderInput`.
+ * Renders the rows of inputs plus the per-row Remove buttons for a primitive
+ * list (string / number). Owns the live-region announcer and the post-mutation
+ * focus restoration. The Add button lives in the consumer's FieldSection.Action
+ * slot so the header layout stays consistent across all list-like controls.
  */
 export function FocusManagedInputList<T>({
   label,
   items,
-  canAdd,
   canRemove,
-  makeEmpty,
   onChange,
   renderInput,
+  addButtonRef,
+  handleRef,
 }: FocusManagedInputListProps<T>) {
   const listRef = useRef<HTMLUListElement>(null);
-  const addButtonRef = useRef<HTMLButtonElement>(null);
   const statusRef = useRef<HTMLSpanElement>(null);
 
   const announce = useCallback((message: string) => {
     if (statusRef.current) statusRef.current.textContent = message;
   }, []);
 
-  const handleAdd = () => {
-    onChange([...items, makeEmpty()]);
-    requestAnimationFrame(() => {
-      const inputs = listRef.current?.querySelectorAll("input");
-      inputs?.item(inputs.length - 1)?.focus();
-    });
-    announce("Item added");
-  };
+  useImperativeHandle(
+    handleRef ?? { current: null },
+    () => ({
+      notifyAdded: () => {
+        requestAnimationFrame(() => {
+          const inputs = listRef.current?.querySelectorAll("input");
+          inputs?.item(inputs.length - 1)?.focus();
+        });
+        announce("Item added");
+      },
+    }),
+    [announce]
+  );
 
   const handleRemove = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
@@ -87,25 +103,9 @@ export function FocusManagedInputList<T>({
   };
 
   return (
-    <div className="space-y-2">
+    <>
       <span ref={statusRef} className="sr-only" aria-live="polite" />
-      <div className="flex justify-end">
-        {canAdd && (
-          <button
-            ref={addButtonRef}
-            type="button"
-            onClick={handleAdd}
-            aria-label={`Add item to ${label}`}
-            className="border-border/60 bg-background/80 text-foreground hover:border-primary/40 flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-all"
-          >
-            <Plus className="text-primary h-3 w-3" aria-hidden="true" />
-            Add
-          </button>
-        )}
-      </div>
-      {items.length === 0 ? (
-        <p className="text-muted-foreground text-xs">No items</p>
-      ) : (
+      {items.length > 0 && (
         <ul ref={listRef} className="space-y-2" aria-label={`${label} items`}>
           {items.map((item, index) => (
             <li key={index} className="flex gap-2">
@@ -128,6 +128,6 @@ export function FocusManagedInputList<T>({
           ))}
         </ul>
       )}
-    </div>
+    </>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.test.tsx
@@ -131,7 +131,7 @@ describe("KeyValueMapControl", () => {
 
   it("shows empty state text when value is empty object", () => {
     render(<KeyValueMapControl node={node} path={node.path} value={{}} onChange={vi.fn()} />);
-    expect(screen.getByText("No entries")).toBeInTheDocument();
+    expect(screen.getByText("No entries yet")).toBeInTheDocument();
   });
 
   it("renders the error from state when validationErrors has this path", () => {

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/key-value-map-control.tsx
@@ -18,6 +18,7 @@ import { Plus, X } from "lucide-react";
 import type { KeyValueMapNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
+import { FieldSection } from "../field-section";
 
 interface KeyValueMapControlProps {
   node: KeyValueMapNode;
@@ -81,67 +82,80 @@ export function KeyValueMapControl({ node, path, value, onChange }: KeyValueMapC
   };
 
   return (
-    <ControlWrapper node={node} isNull={isNull} error={error} onClear={() => onChange(path, null)}>
-      <div className="space-y-2">
-        <span ref={statusRef} className="sr-only" aria-live="polite" />
-        <div className="flex justify-end">
-          <button
-            ref={addButtonRef}
-            type="button"
-            onClick={handleAdd}
-            aria-label={`Add entry to ${node.label}`}
-            className="border-border/60 bg-background/80 text-foreground hover:border-primary/40 flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-all"
-          >
-            <Plus className="text-primary h-3 w-3" aria-hidden="true" />
-            Add
-          </button>
-        </div>
-        {entries.length === 0 ? (
-          <p className="text-muted-foreground text-xs">No entries</p>
-        ) : (
-          <ul ref={listRef} className="space-y-2" aria-label={`${node.label} entries`}>
-            {entries.map((entry, index) => (
-              <li key={index} className="flex items-center gap-2">
-                <input
-                  type="text"
-                  aria-label={`Key ${index + 1}`}
-                  placeholder="key"
-                  value={entry.key}
-                  onChange={(e) => {
-                    const next = [...entries];
-                    next[index] = { ...next[index], key: e.target.value };
-                    emit(next);
-                  }}
-                  className={`w-2/5 ${INPUT_CLASS}`}
-                />
-                <span className="text-muted-foreground" aria-hidden="true">
-                  =
-                </span>
-                <input
-                  type="text"
-                  aria-label={`Value ${index + 1}`}
-                  placeholder="value"
-                  value={entry.value}
-                  onChange={(e) => {
-                    const next = [...entries];
-                    next[index] = { ...next[index], value: e.target.value };
-                    emit(next);
-                  }}
-                  className={`min-w-0 flex-1 ${INPUT_CLASS}`}
-                />
-                <button
-                  type="button"
-                  onClick={() => handleRemove(index)}
-                  aria-label={`Remove entry ${index + 1}`}
-                  className="border-border/60 bg-background/80 text-muted-foreground shrink-0 rounded-lg border p-2 transition-all hover:border-red-500/40 hover:text-red-400"
-                >
-                  <X className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+    <ControlWrapper
+      node={node}
+      isNull={isNull}
+      error={error}
+      onClear={() => onChange(path, null)}
+      hideLabel
+    >
+      <FieldSection node={node} level="field" value={value ?? {}} asGroup={false}>
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Stability />
+          <FieldSection.Info />
+          <FieldSection.Action>
+            <button
+              ref={addButtonRef}
+              type="button"
+              onClick={handleAdd}
+              aria-label={`Add entry to ${node.label}`}
+              className="border-border/60 bg-background/80 hover:border-primary/40 text-foreground flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-all"
+            >
+              <Plus className="text-primary h-3 w-3" aria-hidden="true" />
+              Add
+            </button>
+          </FieldSection.Action>
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <span ref={statusRef} className="sr-only" aria-live="polite" />
+          {entries.length === 0 ? (
+            <FieldSection.Empty>No entries yet</FieldSection.Empty>
+          ) : (
+            <ul ref={listRef} className="space-y-2" aria-label={`${node.label} entries`}>
+              {entries.map((entry, index) => (
+                <li key={index} className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    aria-label={`Key ${index + 1}`}
+                    placeholder="key"
+                    value={entry.key}
+                    onChange={(e) => {
+                      const next = [...entries];
+                      next[index] = { ...next[index], key: e.target.value };
+                      emit(next);
+                    }}
+                    className={`w-2/5 ${INPUT_CLASS}`}
+                  />
+                  <span className="text-muted-foreground" aria-hidden="true">
+                    =
+                  </span>
+                  <input
+                    type="text"
+                    aria-label={`Value ${index + 1}`}
+                    placeholder="value"
+                    value={entry.value}
+                    onChange={(e) => {
+                      const next = [...entries];
+                      next[index] = { ...next[index], value: e.target.value };
+                      emit(next);
+                    }}
+                    className={`min-w-0 flex-1 ${INPUT_CLASS}`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(index)}
+                    aria-label={`Remove entry ${index + 1}`}
+                    className="border-border/60 bg-background/80 text-muted-foreground shrink-0 rounded-lg border p-2 transition-all hover:border-red-500/40 hover:text-red-400"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </FieldSection.Body>
+      </FieldSection>
     </ControlWrapper>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-input-control.tsx
@@ -96,7 +96,6 @@ export function NumberInputControl({ node, path, value, onChange }: NumberInputC
         value={draft}
         min={min}
         max={max}
-        placeholder={node.defaultBehavior ?? ""}
         aria-describedby={node.description ? descId : undefined}
         aria-required={node.required || undefined}
         onChange={handleChange}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/number-list-control.tsx
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useRef } from "react";
+import { Plus } from "lucide-react";
 import type { NumberListNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 import { LIST_INPUT_CLASS } from "./control-styles";
-import { FocusManagedInputList } from "./focus-managed-input-list";
+import {
+  FocusManagedInputList,
+  type FocusManagedInputListHandle,
+} from "./focus-managed-input-list";
+import { FieldSection } from "../field-section";
 
 interface NumberListControlProps {
   node: NumberListNode;
@@ -32,32 +38,69 @@ export function NumberListControl({ node, path, value, onChange }: NumberListCon
   const { state } = useConfigurationBuilder();
   const error = state.validationErrors[path] ?? null;
   const { constraints } = node;
-  const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+  const handleRef = useRef<FocusManagedInputListHandle>(null);
+
+  const handleAdd = () => {
+    onChange(path, [...items, 0]);
+    handleRef.current?.notifyAdded();
+  };
 
   return (
-    <ControlWrapper node={node} isNull={isNull} error={error} onClear={() => onChange(path, null)}>
-      <FocusManagedInputList<number>
-        label={node.label}
-        items={items}
-        canAdd={canAdd}
-        canRemove={canRemove}
-        makeEmpty={() => 0}
-        onChange={(next) => onChange(path, next)}
-        renderInput={({ value, setValue, ariaLabel }) => (
-          <input
-            type="number"
-            aria-label={ariaLabel}
-            value={value}
-            onChange={(e) => {
-              const num = e.target.value === "" ? 0 : parseFloat(e.target.value);
-              if (isNaN(num)) return;
-              setValue(num);
-            }}
-            className={LIST_INPUT_CLASS}
-          />
-        )}
-      />
+    <ControlWrapper
+      node={node}
+      isNull={isNull}
+      error={error}
+      onClear={() => onChange(path, null)}
+      hideLabel
+    >
+      <FieldSection node={node} level="field" value={items} asGroup={false}>
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Stability />
+          <FieldSection.Info />
+          <FieldSection.Action>
+            <button
+              ref={addButtonRef}
+              type="button"
+              onClick={handleAdd}
+              aria-label={`Add item to ${node.label}`}
+              className="border-border/60 bg-background/80 hover:border-primary/40 text-foreground inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-all"
+            >
+              <Plus className="text-primary h-3 w-3" aria-hidden="true" />
+              Add
+            </button>
+          </FieldSection.Action>
+        </FieldSection.Header>
+        <FieldSection.Body>
+          {items.length === 0 ? (
+            <FieldSection.Empty />
+          ) : (
+            <FocusManagedInputList<number>
+              label={node.label}
+              items={items}
+              canRemove={canRemove}
+              onChange={(next) => onChange(path, next)}
+              addButtonRef={addButtonRef}
+              handleRef={handleRef}
+              renderInput={({ value, setValue, ariaLabel }) => (
+                <input
+                  type="number"
+                  aria-label={ariaLabel}
+                  value={value}
+                  onChange={(e) => {
+                    const num = e.target.value === "" ? 0 : parseFloat(e.target.value);
+                    if (isNaN(num)) return;
+                    setValue(num);
+                  }}
+                  className={LIST_INPUT_CLASS}
+                />
+              )}
+            />
+          )}
+        </FieldSection.Body>
+      </FieldSection>
     </ControlWrapper>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/string-list-control.tsx
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useRef } from "react";
+import { Plus } from "lucide-react";
 import type { StringListNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { ControlWrapper } from "./control-wrapper";
 import { LIST_INPUT_CLASS } from "./control-styles";
-import { FocusManagedInputList } from "./focus-managed-input-list";
+import {
+  FocusManagedInputList,
+  type FocusManagedInputListHandle,
+} from "./focus-managed-input-list";
+import { FieldSection } from "../field-section";
 
 interface StringListControlProps {
   node: StringListNode;
@@ -32,28 +38,65 @@ export function StringListControl({ node, path, value, onChange }: StringListCon
   const { state } = useConfigurationBuilder();
   const error = state.validationErrors[path] ?? null;
   const { constraints } = node;
-  const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+  const handleRef = useRef<FocusManagedInputListHandle>(null);
+
+  const handleAdd = () => {
+    onChange(path, [...items, ""]);
+    handleRef.current?.notifyAdded();
+  };
 
   return (
-    <ControlWrapper node={node} isNull={isNull} error={error} onClear={() => onChange(path, null)}>
-      <FocusManagedInputList<string>
-        label={node.label}
-        items={items}
-        canAdd={canAdd}
-        canRemove={canRemove}
-        makeEmpty={() => ""}
-        onChange={(next) => onChange(path, next)}
-        renderInput={({ value, setValue, ariaLabel }) => (
-          <input
-            type="text"
-            aria-label={ariaLabel}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            className={LIST_INPUT_CLASS}
-          />
-        )}
-      />
+    <ControlWrapper
+      node={node}
+      isNull={isNull}
+      error={error}
+      onClear={() => onChange(path, null)}
+      hideLabel
+    >
+      <FieldSection node={node} level="field" value={items} asGroup={false}>
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Stability />
+          <FieldSection.Info />
+          <FieldSection.Action>
+            <button
+              ref={addButtonRef}
+              type="button"
+              onClick={handleAdd}
+              aria-label={`Add item to ${node.label}`}
+              className="border-border/60 bg-background/80 hover:border-primary/40 text-foreground inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-all"
+            >
+              <Plus className="text-primary h-3 w-3" aria-hidden="true" />
+              Add
+            </button>
+          </FieldSection.Action>
+        </FieldSection.Header>
+        <FieldSection.Body>
+          {items.length === 0 ? (
+            <FieldSection.Empty />
+          ) : (
+            <FocusManagedInputList<string>
+              label={node.label}
+              items={items}
+              canRemove={canRemove}
+              onChange={(next) => onChange(path, next)}
+              addButtonRef={addButtonRef}
+              handleRef={handleRef}
+              renderInput={({ value, setValue, ariaLabel }) => (
+                <input
+                  type="text"
+                  aria-label={ariaLabel}
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  className={LIST_INPUT_CLASS}
+                />
+              )}
+            />
+          )}
+        </FieldSection.Body>
+      </FieldSection>
     </ControlWrapper>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/text-input-control.tsx
@@ -46,7 +46,6 @@ export function TextInputControl({ node, path, value, onChange }: TextInputContr
         id={id}
         type="text"
         value={value ?? ""}
-        placeholder={node.defaultBehavior ?? ""}
         aria-describedby={node.description ? descId : undefined}
         aria-required={node.required || undefined}
         onChange={(e) => onChange(path, e.target.value)}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.test.tsx
@@ -1,0 +1,431 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FieldSection, useFieldSectionCanAdd } from "./field-section";
+import type { GroupNode, ListNode, KeyValueMapNode } from "@/types/configuration";
+
+const groupNode: GroupNode = {
+  controlType: "group",
+  key: "tracer",
+  label: "Tracer Provider",
+  path: "tracer_provider",
+  children: [],
+};
+
+describe("FieldSection — root", () => {
+  it("renders a role=group wrapper at level=field with aria-labelledby pointing at the label", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Header>
+          <FieldSection.Label />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    const group = screen.getByRole("group", { name: "Tracer Provider" });
+    const heading = screen.getByRole("heading", { level: 4, name: "Tracer Provider" });
+    expect(group).toContainElement(heading);
+    expect(group.getAttribute("aria-labelledby")).toBe(heading.id);
+  });
+});
+
+describe("FieldSection — section level", () => {
+  it("renders the label as h3 at level=section", () => {
+    render(
+      <FieldSection node={groupNode} level="section">
+        <FieldSection.Header>
+          <FieldSection.Label />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByRole("heading", { level: 3, name: "Tracer Provider" })).toBeInTheDocument();
+  });
+});
+
+describe("FieldSection — chevron + body", () => {
+  it("hides the body when defaultExpanded=false and renders a chevron with aria-expanded/aria-controls", () => {
+    render(
+      <FieldSection node={groupNode} level="field" defaultExpanded={false}>
+        <FieldSection.Header>
+          <FieldSection.Chevron />
+          <FieldSection.Label />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    const chevron = screen.getByRole("button", { name: /Expand|Collapse/ });
+    expect(chevron).toHaveAttribute("aria-expanded", "false");
+    expect(chevron).toHaveAttribute("aria-controls");
+    expect(screen.queryByText("body content")).toBeNull();
+  });
+
+  it("toggles the body when the chevron is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <FieldSection node={groupNode} level="field" defaultExpanded={false}>
+        <FieldSection.Header>
+          <FieldSection.Chevron />
+          <FieldSection.Label />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    await user.click(screen.getByRole("button", { name: /Expand/ }));
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+
+  it("renders the body by default at level=field (no chevron, no defaultExpanded)", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Header>
+          <FieldSection.Label />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+
+  it("body has id matching aria-controls on chevron", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Header>
+          <FieldSection.Chevron />
+          <FieldSection.Label />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    const chevron = screen.getByRole("button", { name: /Collapse/ });
+    const body = screen.getByText("body content").closest("[id]");
+    expect(chevron.getAttribute("aria-controls")).toBe(body?.getAttribute("id"));
+  });
+});
+
+const listNode: ListNode = {
+  controlType: "list",
+  key: "processors",
+  label: "Processors",
+  path: "tp.processors",
+  itemSchema: { controlType: "group", key: "item", label: "Item", path: "x", children: [] },
+};
+
+const kvNode: KeyValueMapNode = {
+  controlType: "key_value_map",
+  key: "attributes",
+  label: "Attributes",
+  path: "resource.attributes",
+};
+
+describe("FieldSection — badge", () => {
+  it("renders 'N items' for a list node with N > 0", () => {
+    render(
+      <FieldSection node={listNode} level="field" value={[{}, {}, {}]}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+  });
+
+  it("singularizes to '1 item'", () => {
+    render(
+      <FieldSection node={listNode} level="field" value={[{}]}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+  });
+
+  it("renders 'N entries' for a key-value map", () => {
+    render(
+      <FieldSection node={kvNode} level="field" value={{ a: "1", b: "2" }}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("2 entries")).toBeInTheDocument();
+  });
+
+  it("renders 'N fields set' for a group with configured leaves", () => {
+    const grp: GroupNode = {
+      ...groupNode,
+      children: [
+        {
+          controlType: "text_input",
+          key: "endpoint",
+          label: "Endpoint",
+          path: "x.endpoint",
+        },
+      ],
+    };
+    render(
+      <FieldSection node={grp} level="field" value={{ endpoint: "http://x" }}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("1 field set")).toBeInTheDocument();
+  });
+
+  it("hides when count is 0", () => {
+    render(
+      <FieldSection node={listNode} level="field" value={[]}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.queryByText(/items?$/)).toBeNull();
+  });
+
+  it("treats null value as 0 (nullable list)", () => {
+    render(
+      <FieldSection node={listNode} level="field" value={null}>
+        <FieldSection.Header>
+          <FieldSection.Badge />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.queryByText(/items?$/)).toBeNull();
+  });
+});
+
+describe("FieldSection — stability/info/description", () => {
+  it("renders StabilityBadge whenever node.stability is set, at any level", () => {
+    const dev = { ...groupNode, stability: "development" as const };
+    const { rerender } = render(
+      <FieldSection node={dev} level="section">
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Stability />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("dev")).toBeInTheDocument();
+    rerender(
+      <FieldSection node={dev} level="field">
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Stability />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("dev")).toBeInTheDocument();
+  });
+
+  it("renders nothing when node.stability is unset", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Header>
+          <FieldSection.Stability />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.queryByText("dev")).toBeNull();
+  });
+
+  it("renders InfoTooltip from node.description in the header", () => {
+    const withDesc = { ...groupNode, description: "Configures the tracer." };
+    render(
+      <FieldSection node={withDesc} level="field">
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Info />
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    expect(screen.getByText("Configures the tracer.")).toBeInTheDocument();
+  });
+
+  it("renders TruncatedDescription only at level=section via .Description", () => {
+    const withDesc = { ...groupNode, description: "Long description." };
+    render(
+      <FieldSection node={withDesc} level="section">
+        <FieldSection.Header>
+          <FieldSection.Label />
+        </FieldSection.Header>
+        <FieldSection.Description />
+      </FieldSection>
+    );
+    expect(screen.getByText("Long description.")).toBeInTheDocument();
+  });
+});
+
+describe("FieldSection — empty", () => {
+  it("renders a p with role=status and the default text", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Body>
+          <FieldSection.Empty />
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    const empty = screen.getByRole("status");
+    expect(empty.tagName).toBe("P");
+    expect(empty).toHaveTextContent("No items yet");
+  });
+
+  it("uses the children text when provided", () => {
+    render(
+      <FieldSection node={groupNode} level="field">
+        <FieldSection.Body>
+          <FieldSection.Empty>No entries yet</FieldSection.Empty>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("No entries yet");
+  });
+});
+
+describe("FieldSection — action slot", () => {
+  it("renders children with ml-auto", () => {
+    render(
+      <FieldSection node={listNode} level="field">
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Action>
+            <button type="button">+ Add</button>
+          </FieldSection.Action>
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    const btn = screen.getByRole("button", { name: "+ Add" });
+    expect(btn.parentElement).toHaveClass("ml-auto");
+  });
+
+  it("hides the slot when canAdd is false (maxItems reached) but keeps children mounted", () => {
+    const capped: ListNode = { ...listNode, constraints: { maxItems: 2 } };
+    render(
+      <FieldSection node={capped} level="field" value={[{}, {}]}>
+        <FieldSection.Header>
+          <FieldSection.Label />
+          <FieldSection.Action>
+            <button type="button" data-testid="add">
+              + Add
+            </button>
+          </FieldSection.Action>
+        </FieldSection.Header>
+      </FieldSection>
+    );
+    const btn = screen.getByTestId("add");
+    expect(btn).not.toBeVisible();
+  });
+});
+
+describe("FieldSection — useFieldSectionCanAdd", () => {
+  it("exposes canAdd via the hook", () => {
+    const capped: ListNode = { ...listNode, constraints: { maxItems: 1 } };
+    function Probe() {
+      const { canAdd } = useFieldSectionCanAdd();
+      return <span data-testid="probe">{String(canAdd)}</span>;
+    }
+    render(
+      <FieldSection node={capped} level="field" value={[{}]}>
+        <Probe />
+      </FieldSection>
+    );
+    expect(screen.getByTestId("probe").textContent).toBe("false");
+  });
+});
+
+describe("FieldSection — headless", () => {
+  it("suppresses the header but keeps role=group + aria-labelledby (using labelledBy prop)", () => {
+    render(
+      <>
+        <h3 id="outer-label">Outer Label</h3>
+        <FieldSection node={groupNode} level="field" headless labelledBy="outer-label">
+          <FieldSection.Header>
+            <FieldSection.Label />
+          </FieldSection.Header>
+          <FieldSection.Body>
+            <p>body content</p>
+          </FieldSection.Body>
+        </FieldSection>
+      </>
+    );
+    expect(screen.queryByRole("heading", { level: 4 })).toBeNull();
+    const group = screen.getByRole("group", { name: "Outer Label" });
+    expect(group).toContainElement(screen.getByText("body content"));
+  });
+
+  it("body always renders in headless mode regardless of open state", () => {
+    render(
+      <FieldSection node={groupNode} level="field" headless labelledBy="x" open={false}>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+
+  it("Description is suppressed in headless mode", () => {
+    const withDesc = { ...groupNode, description: "Some description." };
+    render(
+      <FieldSection node={withDesc} level="section" headless labelledBy="x">
+        <FieldSection.Description />
+      </FieldSection>
+    );
+    expect(screen.queryByText("Some description.")).toBeNull();
+  });
+});
+
+describe("FieldSection — controlled mode", () => {
+  it("respects open/onOpenChange when provided", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <FieldSection node={groupNode} level="field" open={false} onOpenChange={onOpenChange}>
+        <FieldSection.Header>
+          <FieldSection.Chevron />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    expect(screen.queryByText("body content")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /Expand/ }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText("body content")).toBeNull();
+    rerender(
+      <FieldSection node={groupNode} level="field" open onOpenChange={onOpenChange}>
+        <FieldSection.Header>
+          <FieldSection.Chevron />
+        </FieldSection.Header>
+        <FieldSection.Body>
+          <p>body content</p>
+        </FieldSection.Body>
+      </FieldSection>
+    );
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.tsx
@@ -1,0 +1,274 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable react-refresh/only-export-components -- compound component pattern: FieldSection is a compound (Object.assign) and useFieldSectionCanAdd is a thin context-reader hook, both legitimately co-located. */
+import { createContext, useContext, useId, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { ConfigNodeBase, Constraints } from "@/types/configuration";
+import type { ConfigValue } from "@/types/configuration-builder";
+import { SummaryBadge } from "@/components/ui/summary-badge";
+import { StabilityBadge } from "@/components/ui/stability-badge";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
+import { TruncatedDescription } from "@/components/ui/truncated-description";
+import { countConfiguredLeaves } from "@/lib/state-summary";
+
+type Level = "section" | "field";
+
+interface FieldSectionContextValue {
+  node: ConfigNodeBase;
+  level: Level;
+  value: ConfigValue | null | undefined;
+  labelId: string;
+  bodyId: string;
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  canAdd: boolean;
+  headless: boolean;
+  labelledBy?: string;
+}
+
+const FieldSectionContext = createContext<FieldSectionContextValue | null>(null);
+
+function useFieldSection(): FieldSectionContextValue {
+  const ctx = useContext(FieldSectionContext);
+  if (!ctx) throw new Error("FieldSection.* must render inside <FieldSection>");
+  return ctx;
+}
+
+export interface FieldSectionProps {
+  node: ConfigNodeBase;
+  level?: Level;
+  value?: ConfigValue | null;
+  defaultExpanded?: boolean;
+  open?: boolean;
+  onOpenChange?: (next: boolean) => void;
+  headless?: boolean;
+  labelledBy?: string;
+  /**
+   * Whether to render the wrapper as a labelled group (`role="group"` +
+   * `aria-labelledby`). Defaults to true at level=field and false at
+   * level=section. Set explicitly to false when an outer container already
+   * provides the labelling — SectionCardShell at top-level group, or
+   * ControlWrapper for list/map controls.
+   */
+  asGroup?: boolean;
+  children: ReactNode;
+}
+
+function Root({
+  node,
+  level = "field",
+  value,
+  defaultExpanded,
+  open: openProp,
+  onOpenChange,
+  headless = false,
+  labelledBy,
+  asGroup,
+  children,
+}: FieldSectionProps) {
+  const labelId = useId();
+  const bodyId = useId();
+  // Body defaults to visible. Consumers that want collapse-by-default render
+  // <FieldSection.Chevron/> and pass `defaultExpanded={false}` (or drive `open`
+  // in controlled mode). Defaulting to true keeps no-chevron consumers visible.
+  const initialOpen = defaultExpanded ?? true;
+  const [openInternal, setOpenInternal] = useState(initialOpen);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? (openProp as boolean) : openInternal;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setOpenInternal(next);
+    onOpenChange?.(next);
+  };
+
+  const items = countItems(value);
+  const constraints = (node as ConfigNodeBase & { constraints?: Constraints }).constraints;
+  const canAdd = constraints?.maxItems == null || items < constraints.maxItems;
+
+  const useGroupRole = asGroup ?? level === "field";
+  const wrapperLabelledBy = labelledBy ?? (headless ? undefined : labelId);
+  const wrapperProps: Record<string, string> = {};
+  if (useGroupRole) wrapperProps.role = "group";
+  if (wrapperLabelledBy) wrapperProps["aria-labelledby"] = wrapperLabelledBy;
+
+  return (
+    <FieldSectionContext.Provider
+      value={{
+        node,
+        level,
+        value,
+        labelId,
+        bodyId,
+        open,
+        setOpen,
+        canAdd,
+        headless,
+        labelledBy,
+      }}
+    >
+      <div className="space-y-2" {...wrapperProps}>
+        {children}
+      </div>
+    </FieldSectionContext.Provider>
+  );
+}
+
+function countItems(value: ConfigValue | null | undefined): number {
+  if (value == null) return 0;
+  if (Array.isArray(value)) return value.length;
+  if (typeof value === "object") return Object.keys(value).length;
+  return 0;
+}
+
+function Header({ children }: { children: ReactNode }) {
+  const { headless } = useFieldSection();
+  if (headless) return null;
+  return <div className="flex items-center gap-2">{children}</div>;
+}
+
+function Label() {
+  const { node, level, labelId } = useFieldSection();
+  if (level === "section") {
+    return (
+      <h3 id={labelId} className="text-foreground truncate text-base font-semibold">
+        {node.label}
+      </h3>
+    );
+  }
+  return (
+    <h4 id={labelId} className="text-foreground text-sm font-medium">
+      {node.label}
+    </h4>
+  );
+}
+
+function Chevron() {
+  const { node, open, setOpen, bodyId } = useFieldSection();
+  const Icon = open ? ChevronDown : ChevronRight;
+  return (
+    <button
+      type="button"
+      aria-expanded={open}
+      aria-controls={bodyId}
+      aria-label={open ? `Collapse ${node.label}` : `Expand ${node.label}`}
+      onClick={() => setOpen(!open)}
+      className="text-muted-foreground hover:text-foreground"
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+    </button>
+  );
+}
+
+function Body({ children }: { children: ReactNode }) {
+  const { open, bodyId, headless } = useFieldSection();
+  // Headless suppresses the header so collapsing would strand content;
+  // otherwise honor `open`. The Root defaults `open=true`, so consumers that
+  // don't render <Chevron/> (and don't pass `defaultExpanded`/`open`) get a
+  // body that's always visible.
+  if (!headless && !open) return null;
+  return (
+    <div id={bodyId} className="mt-3">
+      {children}
+    </div>
+  );
+}
+
+function Empty({ children }: { children?: ReactNode }) {
+  return (
+    <p role="status" className="text-muted-foreground text-xs italic">
+      {children ?? "No items yet"}
+    </p>
+  );
+}
+
+function deriveBadgeText(
+  node: ConfigNodeBase,
+  value: ConfigValue | null | undefined
+): string | null {
+  if (node.controlType === "group") {
+    const fields = countConfiguredLeaves(value ?? null);
+    if (fields === 0) return null;
+    return `${fields} ${fields === 1 ? "field" : "fields"} set`;
+  }
+  if (node.controlType === "key_value_map") {
+    const n =
+      value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value).length : 0;
+    if (n === 0) return null;
+    return `${n} ${n === 1 ? "entry" : "entries"}`;
+  }
+  if (
+    node.controlType === "list" ||
+    node.controlType === "string_list" ||
+    node.controlType === "number_list"
+  ) {
+    const n = Array.isArray(value) ? value.length : 0;
+    if (n === 0) return null;
+    return `${n} ${n === 1 ? "item" : "items"}`;
+  }
+  return null;
+}
+
+function Badge() {
+  const { node, value } = useFieldSection();
+  const text = deriveBadgeText(node, value);
+  if (!text) return null;
+  return <SummaryBadge>{text}</SummaryBadge>;
+}
+
+function Stability() {
+  const { node } = useFieldSection();
+  return <StabilityBadge stability={node.stability} />;
+}
+
+function Info() {
+  const { node } = useFieldSection();
+  if (!node.description) return null;
+  return <InfoTooltip text={node.description} />;
+}
+
+function Description() {
+  const { node, level, headless } = useFieldSection();
+  if (headless) return null;
+  if (level !== "section") return null;
+  if (!node.description) return null;
+  return <TruncatedDescription text={node.description} />;
+}
+
+function Action({ children }: { children: ReactNode }) {
+  const { canAdd } = useFieldSection();
+  return (
+    <span className="ml-auto" hidden={!canAdd}>
+      {children}
+    </span>
+  );
+}
+
+export function useFieldSectionCanAdd(): { canAdd: boolean } {
+  const { canAdd } = useFieldSection();
+  return { canAdd };
+}
+
+export const FieldSection = Object.assign(Root, {
+  Header,
+  Label,
+  Chevron,
+  Body,
+  Empty,
+  Badge,
+  Stability,
+  Info,
+  Description,
+  Action,
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/field-section.tsx
@@ -179,7 +179,7 @@ function Body({ children }: { children: ReactNode }) {
   // body that's always visible.
   if (!headless && !open) return null;
   return (
-    <div id={bodyId} className="mt-3">
+    <div id={bodyId} className={headless ? undefined : "mt-3"}>
       {children}
     </div>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.test.tsx
@@ -206,8 +206,6 @@ describe("GroupRenderer", () => {
       children: [],
     };
     render(<GroupRenderer node={node} depth={1} path="tracer.processors[0].batch" />);
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveTextContent("Batch span processor.");
     const allMatches = screen.getAllByText("Batch span processor.");
     expect(allMatches).toHaveLength(1);
   });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 import { useState, type JSX } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import type { GroupNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { getByPath, parsePath } from "@/lib/config-path";
-import { countConfiguredLeaves } from "@/lib/state-summary";
-import { SummaryBadge } from "@/components/ui/summary-badge";
-import { InfoTooltip } from "@/components/ui/info-tooltip";
-import { StabilityBadge } from "@/components/ui/stability-badge";
 import { SwitchPill } from "@/components/ui/switch-pill";
-import { TruncatedDescription } from "@/components/ui/truncated-description";
 import { SchemaRenderer } from "./schema-renderer";
 import { SectionCardShell } from "./section-card-shell";
+import { FieldSection } from "./field-section";
 
 const DEEP_NESTING_DEPTH = 3;
 
@@ -37,7 +32,8 @@ export interface GroupRendererProps {
    * When true, skip the chevron + label header and render the body inline.
    * Set by parents that already named the choice (e.g. PluginSelectRenderer
    * showing "Batch" in its discriminator and not wanting a duplicate header
-   * underneath). Only honored at depth >= 1.
+   * underneath, or ListRenderer wrapping object-list items). Only honored at
+   * depth >= 1.
    */
   headless?: boolean;
 }
@@ -59,7 +55,9 @@ export function GroupRenderer({
     if (enabled) setExpanded(true);
   }
 
-  const body = enabled ? (
+  const value = getByPath(state.values, parsePath(path));
+
+  const body = (
     <div
       className={
         depth >= DEEP_NESTING_DEPTH ? "border-border/40 space-y-3 border-l pl-3" : "space-y-3"
@@ -74,67 +72,55 @@ export function GroupRenderer({
         />
       ))}
     </div>
-  ) : null;
+  );
 
   if (isTopLevel) {
     return (
       <SectionCardShell sectionKey={node.key}>
-        <header className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {enabled && (
-              <button
-                type="button"
-                aria-expanded={expanded}
-                aria-label={expanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
-                onClick={() => setExpanded((e) => !e)}
-                className="text-muted-foreground hover:text-foreground"
-              >
-                {expanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-              </button>
-            )}
-            <h3 className="text-foreground truncate text-base font-semibold">{node.label}</h3>
-            <StabilityBadge stability={node.stability} />
-          </div>
-          <SwitchPill
-            checked={enabled}
-            ariaLabel={`Enable ${node.label}`}
-            onClick={() => setEnabled(node.key, !enabled)}
-          />
-        </header>
-        {node.description && <TruncatedDescription text={node.description} />}
-        {expanded && body}
+        <FieldSection
+          node={node}
+          level="section"
+          value={value}
+          asGroup={false}
+          open={expanded}
+          onOpenChange={setExpanded}
+        >
+          <FieldSection.Header>
+            {enabled && <FieldSection.Chevron />}
+            <FieldSection.Label />
+            <FieldSection.Stability />
+            <FieldSection.Action>
+              <SwitchPill
+                checked={enabled}
+                ariaLabel={`Enable ${node.label}`}
+                onClick={() => setEnabled(node.key, !enabled)}
+              />
+            </FieldSection.Action>
+          </FieldSection.Header>
+          <FieldSection.Description />
+          {enabled && <FieldSection.Body>{body}</FieldSection.Body>}
+        </FieldSection>
       </SectionCardShell>
     );
   }
 
-  const fieldsSet = countConfiguredLeaves(getByPath(state.values, parsePath(path)));
-
+  // Nested group (depth >= 1).
   return (
-    <div className="space-y-2">
-      {!headless && (
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            aria-expanded={expanded}
-            aria-label={expanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
-            onClick={() => setExpanded((e) => !e)}
-            className="text-foreground hover:text-primary flex items-center gap-1 text-sm font-medium"
-          >
-            {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-            {node.label}
-          </button>
-          {fieldsSet > 0 && (
-            <SummaryBadge>{`${fieldsSet} ${fieldsSet === 1 ? "field" : "fields"} set`}</SummaryBadge>
-          )}
-          {node.description && <InfoTooltip text={node.description} />}
-        </div>
-      )}
-      {headless && node.description && <InfoTooltip text={node.description} />}
-      {(headless || expanded) && body}
-    </div>
+    <FieldSection
+      node={node}
+      level="field"
+      value={value}
+      headless={headless}
+      open={expanded}
+      onOpenChange={setExpanded}
+    >
+      <FieldSection.Header>
+        <FieldSection.Chevron />
+        <FieldSection.Label />
+        <FieldSection.Badge />
+        <FieldSection.Info />
+      </FieldSection.Header>
+      <FieldSection.Body>{body}</FieldSection.Body>
+    </FieldSection>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/group-renderer.tsx
@@ -104,13 +104,17 @@ export function GroupRenderer({
     );
   }
 
-  // Nested group (depth >= 1).
+  // Nested group (depth >= 1). When headless, the parent owns the visible label
+  // (e.g. ListRenderer's item card header, PluginSelectRenderer's tablist), so
+  // skip role="group" on the FieldSection wrapper too — otherwise it would
+  // render an unnamed group.
   return (
     <FieldSection
       node={node}
       level="field"
       value={value}
       headless={headless}
+      asGroup={!headless}
       open={expanded}
       onOpenChange={setExpanded}
     >

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.test.tsx
@@ -93,11 +93,14 @@ describe("ListRenderer", () => {
     expect(screen.queryByText(/field set/i)).toBeNull();
   });
 
-  it("renders the + Add button in the list header", () => {
+  it("renders the + Add button inline in the list header (sibling of chevron via FieldSection.Action)", () => {
     render(<ListRenderer node={listNode} depth={1} path="tp.processors" />);
     const expand = screen.getByRole("button", { name: /Expand Processors/ });
     const add = screen.getByRole("button", { name: /Add item to Processors/ });
-    expect(expand.parentElement).toBe(add.parentElement);
+    // Chevron and the Action wrapper are siblings inside the header flex row.
+    const chevronHeader = expand.parentElement!;
+    const actionWrapper = add.parentElement!;
+    expect(chevronHeader).toBe(actionWrapper.parentElement);
   });
 
   it("dispatches addListItem when Add clicked", () => {
@@ -118,8 +121,7 @@ describe("ListRenderer", () => {
       description: "Configure processors.",
     };
     render(<ListRenderer node={node} depth={1} path="tp.processors" />);
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveTextContent("Configure processors.");
+    expect(screen.getByText("Configure processors.")).toBeInTheDocument();
     expect(screen.getAllByText("Configure processors.")).toHaveLength(1);
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/list-renderer.tsx
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, type JSX } from "react";
-import { ChevronDown, ChevronRight, Plus, X } from "lucide-react";
+import type { JSX } from "react";
+import { Plus, X } from "lucide-react";
 import type { ListNode } from "@/types/configuration";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { SchemaRenderer } from "./schema-renderer";
 import { parsePath, getByPath } from "@/lib/config-path";
 import { deriveListItemLabel } from "@/lib/derive-list-item-label";
-import { SummaryBadge } from "@/components/ui/summary-badge";
-import { InfoTooltip } from "@/components/ui/info-tooltip";
+import { FieldSection } from "./field-section";
 
 export interface ListRendererProps {
   node: ListNode;
@@ -34,94 +33,78 @@ export function ListRenderer({ node, depth, path }: ListRendererProps): JSX.Elem
   const raw = getByPath(state.values, parsePath(path));
   const items = Array.isArray(raw) ? raw : [];
   const { constraints } = node;
-  const canAdd = !constraints?.maxItems || items.length < constraints.maxItems;
   const canRemove = !constraints?.minItems || items.length > constraints.minItems;
   const storedIds = state.listItemIds?.[path];
-  // Reducer-owned ids are authoritative for ADD / REMOVE / LOAD_STATE flows;
-  // fall back to path+index keys when an entry is absent or out of sync (e.g.
-  // arrays seeded by SET_ENABLED or SELECT_PLUGIN, which don't allocate ids).
   const itemKeys =
     storedIds && storedIds.length === items.length
       ? storedIds
       : items.map((_, i) => `${path}#${i}`);
-  const [expanded, setExpanded] = useState(false);
-
-  const body = (
-    <div className="space-y-3">
-      {items.length === 0 ? (
-        <p className="text-muted-foreground text-xs">No items</p>
-      ) : (
-        <ul className="space-y-3">
-          {items.map((itemValue, i) => {
-            const itemPath = `${path}[${i}]`;
-            const { label, derived } = deriveListItemLabel(node, itemValue, i);
-            return (
-              <li
-                key={itemKeys[i]}
-                className="border-border/40 bg-background/30 space-y-3 rounded-lg border p-4"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="flex items-center gap-2 text-sm font-medium">
-                    <span className="text-muted-foreground tabular-nums">{i + 1}</span>
-                    <span className={derived ? "text-foreground" : "text-muted-foreground italic"}>
-                      {label}
-                    </span>
-                  </span>
-                  {canRemove && (
-                    <button
-                      type="button"
-                      aria-label={`Remove item ${i + 1}`}
-                      onClick={() => removeListItem(path, i)}
-                      className="border-border/60 text-muted-foreground rounded-md border p-1 hover:border-red-500/40 hover:text-red-400"
-                    >
-                      <X className="h-3 w-3" aria-hidden="true" />
-                    </button>
-                  )}
-                </div>
-                <SchemaRenderer
-                  node={node.itemSchema}
-                  depth={depth + 1}
-                  path={itemPath}
-                  headless={node.itemSchema.controlType === "group"}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </div>
-  );
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          aria-expanded={expanded}
-          aria-label={expanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
-          onClick={() => setExpanded((e) => !e)}
-          className="text-foreground hover:text-primary flex items-center gap-1 text-sm font-medium"
-        >
-          {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-          {node.label}
-        </button>
-        {items.length > 0 && (
-          <SummaryBadge>{`${items.length} ${items.length === 1 ? "item" : "items"}`}</SummaryBadge>
-        )}
-        {node.description && <InfoTooltip text={node.description} />}
-        {canAdd && (
+    <FieldSection node={node} level="field" value={items} defaultExpanded={false}>
+      <FieldSection.Header>
+        <FieldSection.Chevron />
+        <FieldSection.Label />
+        <FieldSection.Stability />
+        <FieldSection.Badge />
+        <FieldSection.Info />
+        <FieldSection.Action>
           <button
             type="button"
             aria-label={`Add item to ${node.label}`}
             onClick={() => addListItem(path)}
-            className="border-border/60 text-foreground hover:border-primary/40 ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+            className="border-border/60 hover:border-primary/40 text-foreground inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
           >
             <Plus className="text-primary h-3 w-3" aria-hidden="true" />
             Add
           </button>
+        </FieldSection.Action>
+      </FieldSection.Header>
+      <FieldSection.Body>
+        {items.length === 0 ? (
+          <FieldSection.Empty />
+        ) : (
+          <ul className="space-y-3">
+            {items.map((itemValue, i) => {
+              const itemPath = `${path}[${i}]`;
+              const { label, derived } = deriveListItemLabel(node, itemValue, i);
+              return (
+                <li
+                  key={itemKeys[i]}
+                  className="border-border/40 bg-background/30 space-y-3 rounded-lg border p-4"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2 text-sm font-medium">
+                      <span className="text-muted-foreground tabular-nums">{i + 1}</span>
+                      <span
+                        className={derived ? "text-foreground" : "text-muted-foreground italic"}
+                      >
+                        {label}
+                      </span>
+                    </span>
+                    {canRemove && (
+                      <button
+                        type="button"
+                        aria-label={`Remove item ${i + 1}`}
+                        onClick={() => removeListItem(path, i)}
+                        className="border-border/60 text-muted-foreground rounded-md border p-1 hover:border-red-500/40 hover:text-red-400"
+                      >
+                        <X className="h-3 w-3" aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                  <SchemaRenderer
+                    node={node.itemSchema}
+                    depth={depth + 1}
+                    path={itemPath}
+                    headless={node.itemSchema.controlType === "group"}
+                  />
+                </li>
+              );
+            })}
+          </ul>
         )}
-      </div>
-      {expanded && body}
-    </div>
+      </FieldSection.Body>
+    </FieldSection>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/plugin-select-renderer.test.tsx
@@ -169,8 +169,7 @@ describe("PluginSelectRenderer", () => {
     };
     mockConfigState.values = { exporter: { otlp_http: {} } };
     render(<PluginSelectRenderer node={nodeWithDesc} depth={1} path="exporter" />);
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveTextContent("Choose the exporter variant.");
+    expect(screen.getByText("Choose the exporter variant.")).toBeInTheDocument();
     expect(screen.getAllByRole("tab")).toHaveLength(2);
     expect(screen.getAllByText("Choose the exporter variant.")).toHaveLength(1);
   });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/union-renderer.test.tsx
@@ -194,8 +194,7 @@ describe("UnionRenderer", () => {
       ],
     };
     render(<UnionRenderer node={n} depth={1} path="tracer_provider.sampler" />);
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveTextContent("Choose a sampling strategy.");
+    expect(screen.getByText("Choose a sampling strategy.")).toBeInTheDocument();
     expect(screen.getAllByText("Choose a sampling strategy.")).toHaveLength(1);
   });
 


### PR DESCRIPTION
Closes #269.

**FieldSection refactor**: Group, list, primitive list, and KeyValueMap renderers now share a `FieldSection` compound component for the header/label/info/description/content layout. Same visual output, plus polish on stability badges, collapse animation, and Add-button alignment.

**Markdown descriptions**: Schema descriptions render as markdown via `react-markdown` + `remark-gfm`. Line breaks, dash/asterisk lists, and bare http(s) URLs render correctly. The ⓘ trigger is now a Radix HoverCard so the popover stays open when the cursor moves onto it and links inside are clickable.
