### PR TITLE
ci: gate scheduled workflow runs to upstream repo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: github.event_name != 'schedule' || github.repository == 'open-telemetry/opentelemetry-ecosystem-explorer'
     permissions:
       contents: read
       actions: read # for github/codeql-action/init to get workflow details

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   synchronize-inventory:
+    if: github.event_name != 'schedule' || github.repository == 'open-telemetry/opentelemetry-ecosystem-explorer'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,6 +12,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.event_name != 'schedule' || github.repository == 'open-telemetry/opentelemetry-ecosystem-explorer'
     runs-on: ubuntu-latest
     permissions:
       # Needed for Code scanning upload


### PR DESCRIPTION
On contributor forks with Actions enabled, the `schedule` triggers in `nightly-registry-update.yml`, `scorecard.yml`, and `codeql.yml` fire and produce daily/weekly failure notifications. The first two have no value on forks (target upstream-only assets and secrets); CodeQL's cron is also noise on forks though its push/PR runs stay useful for contributors.

Adds a one-line `if:` gate on each scheduled job so the cron only runs on the upstream repo. Push, pull_request, and workflow_dispatch events keep working on forks. Same pattern is used in `opentelemetry-java-instrumentation` (`code-review-sweep.yml`, `draft-release-notes.yml`).