### PR TITLE
ci: don't run notify jobs when synchronize-inventory is skipped

### DIFF
--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -141,7 +141,7 @@ jobs:
       contents: read
       issues: write
     needs: [synchronize-inventory]
-    if: always()
+    if: ${{ !cancelled() && needs.synchronize-inventory.result != 'skipped' }}
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.synchronize-inventory.outputs.collector_result == 'success' }}
@@ -152,7 +152,7 @@ jobs:
       contents: read
       issues: write
     needs: [synchronize-inventory]
-    if: always()
+    if: ${{ !cancelled() && needs.synchronize-inventory.result != 'skipped' }}
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.synchronize-inventory.outputs.java_result == 'success' }}
@@ -163,7 +163,7 @@ jobs:
       contents: read
       issues: write
     needs: [synchronize-inventory]
-    if: always()
+    if: ${{ !cancelled() && needs.synchronize-inventory.result != 'skipped' }}
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.synchronize-inventory.outputs.configuration_result == 'success' }}


### PR DESCRIPTION
#319 gated `synchronize-inventory` so it doesn't run on forks, but the three `notify-*` jobs in the same workflow still fire on every scheduled run because they use `if: always()`. With the upstream job skipped, they evaluate `success: false` (skipped jobs have empty outputs) and fail when calling `gh issue` on the fork, sending failure notifications to the fork owner.

Replaces `if: always()` with `!cancelled() && needs.synchronize-inventory.result != 'skipped'` so the notify jobs only run when `synchronize-inventory` actually executed (success or failure). Upstream behavior is unchanged.

Verified on my fork: latest scheduled run (25149018645) shows `synchronize-inventory: skipped`, `notify-*: failure`, which is the exact case this fixes.