### PR TITLE
feat(explorer): render inline code styling for backtick-wrapped description text

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -20,6 +20,7 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { StabilityBadge } from "@/components/ui/stability-badge";
 import { YamlCodeBlock } from "../configuration/components/yaml-code-block";
 import { formatDeclarativeYaml, getStabilityLabel } from "../utils/format";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 export type ConfigurationFormat = "system-property" | "declarative";
 
@@ -74,7 +75,9 @@ export function ConfigurationCard({ config, format }: ConfigurationCardProps) {
           </div>
         </div>
 
-        <p className="text-muted-foreground text-sm leading-relaxed">{config.description}</p>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          {renderWithInlineCode(config.description)}
+        </p>
 
         <div className="border-border/30 bg-muted/30 flex items-start gap-2 rounded-lg border p-3">
           <span className="text-muted-foreground shrink-0 text-xs font-medium">Default:</span>

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.tsx
@@ -19,6 +19,7 @@ import type { FilterState } from "./instrumentation-filter-bar";
 import { getBadgeInfo } from "../utils/badge-info";
 import { TargetBadges, TelemetryBadges } from "./instrumentation-badges";
 import { getInstrumentationDisplayName } from "../utils/format";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 interface InstrumentationCardProps {
   instrumentation: InstrumentationData;
@@ -64,7 +65,7 @@ export function InstrumentationCard({
 
         {instrumentation.description && (
           <p className="text-muted-foreground line-clamp-3 text-sm leading-relaxed">
-            {instrumentation.description}
+            {renderWithInlineCode(instrumentation.description)}
           </p>
         )}
 

--- a/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
@@ -20,6 +20,7 @@ import type { FilterState } from "./instrumentation-filter-bar";
 import { getAggregatedBadgeInfo } from "../utils/badge-info";
 import { TargetBadges, TelemetryBadges } from "./instrumentation-badges";
 import { SubInstrumentationItem } from "./sub-instrumentation-item";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 interface MultiInstrumentationGroupCardProps {
   group: InstrumentationGroup;
@@ -84,7 +85,7 @@ export function MultiInstrumentationGroupCard({
 
           {description && (
             <p className="text-muted-foreground line-clamp-2 pl-8 text-sm leading-relaxed">
-              {description}
+              {renderWithInlineCode(description)}
             </p>
           )}
 

--- a/ecosystem-explorer/src/features/java-agent/components/sub-instrumentation-item.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/sub-instrumentation-item.tsx
@@ -18,6 +18,7 @@ import type { InstrumentationData } from "@/types/javaagent";
 import type { FilterState } from "./instrumentation-filter-bar";
 import { getBadgeInfo } from "../utils/badge-info";
 import { TargetBadges, TelemetryBadges } from "./instrumentation-badges";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 interface SubInstrumentationItemProps {
   instrumentation: InstrumentationData;
@@ -44,7 +45,7 @@ export function SubInstrumentationItem({
           <span className="text-sm font-medium">{instrumentation.name}</span>
           {instrumentation.description && (
             <p className="text-muted-foreground mt-0.5 line-clamp-1 text-xs">
-              {instrumentation.description}
+              {renderWithInlineCode(instrumentation.description)}
             </p>
           )}
         </div>

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -45,6 +45,7 @@ import { VersionSelector } from "./components/version-selector";
 import { PageContainer } from "@/components/layout/page-container";
 import { Tooltip } from "@/components/ui/tooltip";
 import { InstrumentationConfigurationTab } from "./components/instrumentation-configuration-tab";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 function buildSourceUrl(sourcePath: string): string {
   try {
@@ -222,7 +223,7 @@ export function InstrumentationDetailPage() {
 
             {instrumentation.description && (
               <p className="text-muted-foreground max-w-4xl text-base leading-relaxed">
-                {instrumentation.description}
+                {renderWithInlineCode(instrumentation.description)}
               </p>
             )}
           </div>

--- a/ecosystem-explorer/src/lib/render-inline-code.tsx
+++ b/ecosystem-explorer/src/lib/render-inline-code.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReactNode } from "react";
+
+export function renderWithInlineCode(text: string): ReactNode {
+  const parts = text.split(/`([^`]+)`/g);
+  return parts.map((part, i) =>
+    i % 2 === 1 ? (
+      <code key={i} className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[0.875em]">
+        {part}
+      </code>
+    ) : (
+      part
+    )
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #302

Instrumentation and configuration descriptions contain backtick-wrapped
identifiers (e.g. `MBeanRegistration`, `BasicDataSource`) that were
rendering as plain text with visible backtick characters. This PR adds
proper inline code styling for those segments.

## Changes

- **New helper** `src/lib/render-inline-code.tsx` — `renderWithInlineCode(text)`
  splits on backtick-delimited segments and renders them as styled
  `<code>` elements (`bg-muted`, monospace font, small padding)
- Applied to **instrumentation list page** (card, group card, sub-item descriptions)
- Applied to **instrumentation detail page** (header description)
- Applied to **configuration option descriptions** (configuration card)