### PR TITLE
feat(explorer): Configuration Builder instrumentation browser

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.test.tsx
@@ -25,6 +25,11 @@ const sections = [
   { key: "attribute_limits", label: "Attribute Limits" },
 ];
 
+const instrumentationSections = [
+  { key: "general", label: "General settings" },
+  { key: "instrumentations", label: "Instrumentations" },
+];
+
 function renderSidebar(
   overrides: Partial<React.ComponentProps<typeof ConfigurationTocSidebar>> = {}
 ) {
@@ -57,11 +62,6 @@ describe("ConfigurationTocSidebar", () => {
     expect(within(nav).getByRole("button", { name: "Attribute Limits" })).toBeInTheDocument();
   });
 
-  it("does not render the TOC nav when Instrumentation is the active tab", () => {
-    renderSidebar({ activeTab: "instrumentation" });
-    expect(screen.queryByRole("navigation", { name: "Configuration sections" })).toBeNull();
-  });
-
   it("marks the button matching activeKey with aria-current='location'", () => {
     renderSidebar({ activeKey: "tracer_provider" });
     const tracer = screen.getByRole("button", { name: "Tracer Provider" });
@@ -76,5 +76,88 @@ describe("ConfigurationTocSidebar", () => {
     renderSidebar({ onSectionClick });
     await user.click(screen.getByRole("button", { name: "Tracer Provider" }));
     expect(onSectionClick).toHaveBeenCalledWith("tracer_provider");
+  });
+
+  it("does not render the search input or status section on the SDK tab", () => {
+    renderSidebar();
+    expect(screen.queryByPlaceholderText(/Search instrumentations/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Overridden/i })).toBeNull();
+  });
+
+  describe("instrumentation tab", () => {
+    it("renders search input + TOC and hides Status when overrideCount === 0", () => {
+      renderSidebar({
+        activeTab: "instrumentation",
+        sections: instrumentationSections,
+        activeKey: "general",
+        overrideCount: 0,
+      });
+      expect(screen.getByPlaceholderText(/Search instrumentations/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Overridden/i })).toBeNull();
+      const nav = screen.getByRole("navigation", { name: "Configuration sections" });
+      expect(within(nav).getByRole("button", { name: "General settings" })).toBeInTheDocument();
+      expect(within(nav).getByRole("button", { name: "Instrumentations" })).toBeInTheDocument();
+    });
+
+    it("renders the Overridden chip with the count when overrideCount > 0", () => {
+      renderSidebar({
+        activeTab: "instrumentation",
+        sections: instrumentationSections,
+        activeKey: "general",
+        overrideCount: 1,
+      });
+      const chip = screen.getByRole("button", { name: /Overridden/i });
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveTextContent("1");
+      expect(chip).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("fires onSearchChange when the user types in the search input", async () => {
+      const onSearchChange = vi.fn();
+      const user = userEvent.setup();
+      renderSidebar({
+        activeTab: "instrumentation",
+        sections: instrumentationSections,
+        activeKey: "general",
+        overrideCount: 0,
+        search: "",
+        onSearchChange,
+      });
+      await user.type(screen.getByPlaceholderText(/Search instrumentations/i), "cas");
+      expect(onSearchChange).toHaveBeenCalledTimes(3);
+      expect(onSearchChange).toHaveBeenLastCalledWith("s");
+    });
+
+    it("toggles statusFilter from 'all' to 'overridden' when the chip is clicked", async () => {
+      const onStatusFilterChange = vi.fn();
+      const user = userEvent.setup();
+      renderSidebar({
+        activeTab: "instrumentation",
+        sections: instrumentationSections,
+        activeKey: "general",
+        overrideCount: 2,
+        statusFilter: "all",
+        onStatusFilterChange,
+      });
+      await user.click(screen.getByRole("button", { name: /Overridden/i }));
+      expect(onStatusFilterChange).toHaveBeenCalledWith("overridden");
+    });
+
+    it("toggles statusFilter back to 'all' when the chip is clicked while active", async () => {
+      const onStatusFilterChange = vi.fn();
+      const user = userEvent.setup();
+      renderSidebar({
+        activeTab: "instrumentation",
+        sections: instrumentationSections,
+        activeKey: "general",
+        overrideCount: 2,
+        statusFilter: "overridden",
+        onStatusFilterChange,
+      });
+      const chip = screen.getByRole("button", { name: /Overridden/i });
+      expect(chip).toHaveAttribute("aria-pressed", "true");
+      await user.click(chip);
+      expect(onStatusFilterChange).toHaveBeenCalledWith("all");
+    });
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.test.tsx
@@ -123,9 +123,8 @@ describe("ConfigurationTocSidebar", () => {
         search: "",
         onSearchChange,
       });
-      await user.type(screen.getByPlaceholderText(/Search instrumentations/i), "cas");
-      expect(onSearchChange).toHaveBeenCalledTimes(3);
-      expect(onSearchChange).toHaveBeenLastCalledWith("s");
+      await user.type(screen.getByPlaceholderText(/Search instrumentations/i), "c");
+      expect(onSearchChange).toHaveBeenCalledWith("c");
     });
 
     it("toggles statusFilter from 'all' to 'overridden' when the chip is clicked", async () => {

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import type { JSX } from "react";
+import { Search } from "lucide-react";
 import { SegmentedTabList } from "@/components/ui/segmented-tabs";
 
 export interface TocSection {
@@ -21,11 +22,19 @@ export interface TocSection {
   label: string;
 }
 
+export type StatusFilter = "all" | "overridden";
+
 export interface ConfigurationTocSidebarProps {
   activeTab: string;
   sections: TocSection[];
   activeKey: string | null;
   onSectionClick: (key: string) => void;
+  /** Only meaningful when activeTab === "instrumentation". */
+  search?: string;
+  onSearchChange?: (value: string) => void;
+  statusFilter?: StatusFilter;
+  onStatusFilterChange?: (value: StatusFilter) => void;
+  overrideCount?: number;
 }
 
 const TABS = [
@@ -37,32 +46,82 @@ const LINK_BASE = "block w-full rounded-md px-3 py-1.5 text-left text-sm transit
 const LINK_ACTIVE = "bg-card/80 font-medium text-foreground";
 const LINK_INACTIVE = "text-muted-foreground hover:bg-card/40 hover:text-foreground";
 
+const SECTION_LABEL =
+  "text-muted-foreground/80 mb-1.5 px-1 text-[10px] font-medium tracking-wider uppercase";
+
 export function ConfigurationTocSidebar({
   activeTab,
   sections,
   activeKey,
   onSectionClick,
+  search,
+  onSearchChange,
+  statusFilter = "all",
+  onStatusFilterChange,
+  overrideCount = 0,
 }: ConfigurationTocSidebarProps): JSX.Element {
+  const isInstrumentation = activeTab === "instrumentation";
+  const showTocNav = activeTab === "sdk" || isInstrumentation;
+  const showStatusSection = isInstrumentation && overrideCount > 0;
+  const isOverriddenActive = statusFilter === "overridden";
+
   return (
     <aside className="lg:sticky lg:top-20 lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto">
       <SegmentedTabList tabs={TABS} value={activeTab} fullWidth />
-      {activeTab === "sdk" && (
-        <nav aria-label="Configuration sections" className="mt-3 space-y-0.5">
-          {sections.map((section) => {
-            const isActive = section.key === activeKey;
-            return (
-              <button
-                key={section.key}
-                type="button"
-                aria-current={isActive ? "location" : undefined}
-                onClick={() => onSectionClick(section.key)}
-                className={`${LINK_BASE} ${isActive ? LINK_ACTIVE : LINK_INACTIVE}`}
-              >
-                {section.label}
-              </button>
-            );
-          })}
-        </nav>
+      {isInstrumentation && (
+        <div className="mt-3">
+          <label className="relative block">
+            <span className="sr-only">Search instrumentations</span>
+            <Search
+              aria-hidden="true"
+              className="text-muted-foreground/70 pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2"
+            />
+            <input
+              type="search"
+              value={search ?? ""}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+              placeholder="Search instrumentations…"
+              className="border-border/50 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus:border-primary/40 focus:ring-primary/20 w-full rounded-md border py-1.5 pr-2 pl-8 text-sm focus:ring-1 focus:outline-none"
+            />
+          </label>
+        </div>
+      )}
+      {showStatusSection && (
+        <div className="mt-4">
+          <div className={SECTION_LABEL}>Status</div>
+          <button
+            type="button"
+            aria-pressed={isOverriddenActive}
+            onClick={() => onStatusFilterChange?.(isOverriddenActive ? "all" : "overridden")}
+            className={`${LINK_BASE} flex items-center justify-between ${
+              isOverriddenActive ? LINK_ACTIVE : LINK_INACTIVE
+            }`}
+          >
+            <span>Overridden</span>
+            <span className="text-primary text-xs font-medium tabular-nums">{overrideCount}</span>
+          </button>
+        </div>
+      )}
+      {showTocNav && sections.length > 0 && (
+        <div className="mt-4">
+          {isInstrumentation && <div className={SECTION_LABEL}>On this page</div>}
+          <nav aria-label="Configuration sections" className="space-y-0.5">
+            {sections.map((section) => {
+              const isActive = section.key === activeKey;
+              return (
+                <button
+                  key={section.key}
+                  type="button"
+                  aria-current={isActive ? "location" : undefined}
+                  onClick={() => onSectionClick(section.key)}
+                  className={`${LINK_BASE} ${isActive ? LINK_ACTIVE : LINK_INACTIVE}`}
+                >
+                  {section.label}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
       )}
     </aside>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { InstrumentationData } from "@/types/javaagent";
+import type { ConfigurationBuilderState } from "@/types/configuration-builder";
+
+const setValueByPath = vi.fn();
+const setEnabled = vi.fn();
+const removeMapEntry = vi.fn();
+
+let mockBuilderState: ConfigurationBuilderState;
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: mockBuilderState,
+    setValueByPath: (...args: unknown[]) => setValueByPath(...args),
+    setEnabled: (...args: unknown[]) => setEnabled(...args),
+    removeMapEntry: (...args: unknown[]) => removeMapEntry(...args),
+    setValue: vi.fn(),
+    selectPlugin: vi.fn(),
+    addListItem: vi.fn(),
+    removeListItem: vi.fn(),
+    setMapEntry: vi.fn(),
+    resetToDefaults: vi.fn(),
+    enableAllSections: vi.fn(),
+    loadFromYaml: vi.fn(),
+    validateField: vi.fn(),
+    validateAll: vi.fn(),
+    clearValidationError: vi.fn(),
+  }),
+}));
+
+const useInstrumentationsMock = vi.fn();
+vi.mock("@/hooks/use-javaagent-data", () => ({
+  useInstrumentations: (version: string) => useInstrumentationsMock(version),
+}));
+
+import { InstrumentationBrowser } from "./instrumentation-browser";
+
+const FIXTURE: InstrumentationData[] = [
+  {
+    name: "cassandra-4.4",
+    display_name: "Cassandra Driver",
+    description: "Database client spans + metrics for the DataStax Cassandra Driver.",
+    disabled_by_default: false,
+    scope: { name: "io.opentelemetry.cassandra-4.4" },
+  },
+  {
+    name: "akka-http-10.0",
+    display_name: "Akka HTTP 10.0",
+    description: "HTTP client + server spans for Akka HTTP.",
+    disabled_by_default: false,
+    scope: { name: "io.opentelemetry.akka-http-10.0" },
+  },
+  {
+    name: "jmx-metrics",
+    display_name: "JMX Metrics",
+    description: "Built-in JMX metric gatherer.",
+    disabled_by_default: true,
+    _is_custom: true,
+    scope: { name: "io.opentelemetry.jmx-metrics" },
+  },
+];
+
+function emptyState(): ConfigurationBuilderState {
+  return {
+    version: "1.0.0",
+    values: {},
+    enabledSections: {},
+    validationErrors: {},
+    isDirty: false,
+    listItemIds: {},
+  };
+}
+
+beforeEach(() => {
+  setValueByPath.mockReset();
+  setEnabled.mockReset();
+  removeMapEntry.mockReset();
+  mockBuilderState = emptyState();
+  useInstrumentationsMock.mockReset();
+});
+
+describe("InstrumentationBrowser", () => {
+  it("renders loading copy while loading", () => {
+    useInstrumentationsMock.mockReturnValue({ data: null, loading: true, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
+    expect(screen.getByText(/Loading instrumentations/i)).toBeInTheDocument();
+  });
+
+  it("renders error copy when the load fails", () => {
+    useInstrumentationsMock.mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error("boom"),
+    });
+    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
+    expect(screen.getByText(/Failed to load instrumentations/i)).toBeInTheDocument();
+  });
+
+  it("renders all instrumentations from the fixture", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
+    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
+    expect(screen.getByText("Akka HTTP 10.0")).toBeInTheDocument();
+    expect(screen.getByText("JMX Metrics")).toBeInTheDocument();
+  });
+
+  it("filters by name (case-insensitive)", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
+    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
+    expect(screen.queryByText("Akka HTTP 10.0")).toBeNull();
+    expect(screen.queryByText("JMX Metrics")).toBeNull();
+  });
+
+  it("filters by description substring", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="JMX metric" statusFilter="all" />);
+    expect(screen.getByText("JMX Metrics")).toBeInTheDocument();
+    expect(screen.queryByText("Cassandra Driver")).toBeNull();
+  });
+
+  it("statusFilter='overridden' shows only overridden rows", () => {
+    mockBuilderState = {
+      ...emptyState(),
+      values: {
+        "instrumentation/development": {
+          java: {
+            "cassandra-4.4": { enabled: false },
+          },
+        },
+      },
+    };
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="overridden" />);
+    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
+    expect(screen.queryByText("Akka HTTP 10.0")).toBeNull();
+    expect(screen.queryByText("JMX Metrics")).toBeNull();
+  });
+
+  it("renders the empty-search copy when nothing matches", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="nope-zzz" statusFilter="all" />);
+    expect(screen.getByText(/No instrumentations match/)).toBeInTheDocument();
+    expect(screen.getByText(/Clear the search to show all 3/)).toBeInTheDocument();
+  });
+
+  it("header readout reflects total and override count", () => {
+    mockBuilderState = {
+      ...emptyState(),
+      values: {
+        "instrumentation/development": {
+          java: {
+            "cassandra-4.4": { enabled: false },
+          },
+        },
+      },
+    };
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
+    expect(screen.getByText(/3 total/)).toBeInTheDocument();
+    expect(screen.getByText(/1 overridden/)).toBeInTheDocument();
+    expect(screen.getByText(/No filter · 3 instrumentations/)).toBeInTheDocument();
+  });
+
+  it("clicking + Override writes the opposite-of-default and enables the section", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
+    fireEvent.click(screen.getByRole("button", { name: /Override Cassandra Driver/ }));
+    // cassandra-4.4 is enabled-by-default → starting override is enabled: false
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "cassandra-4.4"],
+      { enabled: false }
+    );
+    expect(setEnabled).toHaveBeenCalledWith("instrumentation/development", true);
+  });
+
+  it("clicking + Override on a disabled-by-default row writes enabled: true", () => {
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="jmx" statusFilter="all" />);
+    fireEvent.click(screen.getByRole("button", { name: /Override JMX Metrics/ }));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "jmx-metrics"],
+      { enabled: true }
+    );
+  });
+
+  it("toggling an existing override writes only the enabled leaf", () => {
+    mockBuilderState = {
+      ...emptyState(),
+      values: {
+        "instrumentation/development": {
+          java: { "cassandra-4.4": { enabled: false } },
+        },
+      },
+    };
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
+    fireEvent.click(screen.getByRole("button", { name: "Enabled" }));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "cassandra-4.4", "enabled"],
+      true
+    );
+  });
+
+  it("removing an override calls removeMapEntry to actually delete the key", () => {
+    mockBuilderState = {
+      ...emptyState(),
+      values: {
+        "instrumentation/development": {
+          java: { "cassandra-4.4": { enabled: false } },
+        },
+      },
+    };
+    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
+    fireEvent.click(screen.getByRole("button", { name: /Remove override for Cassandra Driver/ }));
+    // removeMapEntry truly deletes the key — the section flag is then driven
+    // by the mirror effect in InstrumentationTabBody, not by the browser.
+    expect(removeMapEntry).toHaveBeenCalledWith(
+      "instrumentation/development.java",
+      "cassandra-4.4"
+    );
+    expect(setValueByPath).not.toHaveBeenCalled();
+    expect(setEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
@@ -15,17 +15,19 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { InstrumentationData } from "@/types/javaagent";
-import { useInstrumentations } from "@/hooks/use-javaagent-data";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { useOverrideStatusMap } from "@/hooks/use-override-status";
+import { useOverriddenModules } from "@/hooks/use-overridden-modules";
 import { InstrumentationBrowser } from "./instrumentation-browser";
 
-vi.mock("@/hooks/use-javaagent-data");
 vi.mock("@/hooks/use-configuration-builder");
 vi.mock("@/hooks/use-override-status");
+vi.mock("@/hooks/use-overridden-modules", () => ({
+  useOverriddenModules: vi.fn(() => new Set<string>()),
+}));
 
-const mockedInstr = vi.mocked(useInstrumentations);
 const mockedBuilder = vi.mocked(useConfigurationBuilder);
 const mockedOverride = vi.mocked(useOverrideStatusMap);
 
@@ -48,9 +50,14 @@ const FIXTURE: InstrumentationData[] = [
 
 const setOverride = vi.fn();
 
+const browserDefaults = {
+  loading: false,
+  error: null,
+  onJumpToGeneral: vi.fn(),
+} as const;
+
 beforeEach(() => {
   setOverride.mockReset();
-  mockedInstr.mockReturnValue({ data: FIXTURE, loading: false, error: null });
   mockedBuilder.mockReturnValue({
     state: {
       values: {},
@@ -63,11 +70,19 @@ beforeEach(() => {
     setOverride,
   } as unknown as ReturnType<typeof useConfigurationBuilder>);
   mockedOverride.mockReturnValue(new Map());
+  vi.mocked(useOverriddenModules).mockReturnValue(new Set<string>());
 });
 
 describe("InstrumentationBrowser", () => {
   it("groups entries into module rows with version count", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
     expect(screen.getByText("kafka_clients")).toBeInTheDocument();
     expect(screen.getByText("jmx_metrics")).toBeInTheDocument();
@@ -76,77 +91,250 @@ describe("InstrumentationBrowser", () => {
   });
 
   it("matches search against the registry name of any covered entry", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="cassandra-4.4" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search="cassandra-4.4"
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
     expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
   it("matches search against display_name on any covered entry", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="Kafka Clients" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search="Kafka Clients"
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText("kafka_clients")).toBeInTheDocument();
     expect(screen.queryByText("cassandra")).not.toBeInTheDocument();
   });
 
   it("matches search against description on any covered entry", () => {
     render(
-      <InstrumentationBrowser version="2.27.0" search="context propagation" statusFilter="all" />
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search="context propagation"
+        statusFilter="all"
+        {...browserDefaults}
+      />
     );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
     expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
   it("search is case-insensitive", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="CASSANDRA" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search="CASSANDRA"
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
   });
 
   it("filters to overridden when statusFilter='overridden'", () => {
-    mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="overridden" />);
+    vi.mocked(useOverriddenModules).mockReturnValue(new Set(["cassandra"]));
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="overridden"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
     expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
   it("calls setOverride('cassandra', 'disabled') when + Override is clicked on a default-enabled module", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     fireEvent.click(screen.getByLabelText("Override cassandra"));
     expect(setOverride).toHaveBeenCalledWith("cassandra", "disabled");
   });
 
   it("calls setOverride('jmx_metrics', 'enabled') when + Override is clicked on a default-disabled module", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     fireEvent.click(screen.getByLabelText("Override jmx_metrics"));
     expect(setOverride).toHaveBeenCalledWith("jmx_metrics", "enabled");
   });
 
   it("calls setOverride(name, 'none') when ✕ is clicked on an overridden row", () => {
     mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     fireEvent.click(screen.getByLabelText("Remove override for cassandra"));
     expect(setOverride).toHaveBeenCalledWith("cassandra", "none");
   });
 
   it("calls setOverride('cassandra', 'enabled') when toggling overridden Disabled→Enabled", () => {
     mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     fireEvent.click(screen.getAllByRole("button", { name: "Enabled" })[0]);
     expect(setOverride).toHaveBeenCalledWith("cassandra", "enabled");
   });
 
   it("renders empty state for unmatched search", () => {
-    render(<InstrumentationBrowser version="2.27.0" search="nonexistent" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={FIXTURE}
+        search="nonexistent"
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
     expect(screen.getByText(/No instrumentations match/)).toBeInTheDocument();
   });
 
   it("shows loading state", () => {
-    mockedInstr.mockReturnValue({ data: null, loading: true, error: null });
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={null}
+        loading={true}
+        error={null}
+        search=""
+        statusFilter="all"
+        onJumpToGeneral={vi.fn()}
+      />
+    );
     expect(screen.getByText(/Loading instrumentations/)).toBeInTheDocument();
   });
 
   it("shows error state", () => {
-    mockedInstr.mockReturnValue({ data: null, loading: false, error: new Error("boom") });
-    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    render(
+      <InstrumentationBrowser
+        instrumentations={null}
+        loading={false}
+        error={new Error("boom")}
+        search=""
+        statusFilter="all"
+        onJumpToGeneral={vi.fn()}
+      />
+    );
     expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentationBrowser — expansion and override filter", () => {
+  beforeEach(() => {
+    vi.mocked(useOverriddenModules).mockReturnValue(new Set<string>());
+  });
+
+  const cassandraData = [
+    {
+      name: "cassandra-4.4",
+      scope: { name: "io.opentelemetry.cassandra-4.4" },
+      configurations: [
+        {
+          name: "x",
+          declarative_name: "java.cassandra.query_sanitization.enabled",
+          description: "",
+          type: "boolean" as const,
+          default: true,
+        },
+      ],
+    },
+  ];
+  const twoModules = [
+    { name: "cassandra-4.4", scope: { name: "io.opentelemetry.cassandra-4.4" } },
+    { name: "graphql-java-20.0", scope: { name: "io.opentelemetry.graphql-java-20.0" } },
+  ];
+
+  it("expands a row when its toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <InstrumentationBrowser
+        instrumentations={cassandraData}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
+    const row = screen.getByTestId("instrumentation-row-cassandra");
+    expect(row.getAttribute("data-expanded")).toBe("false");
+    await user.click(screen.getByRole("button", { name: /toggle details for cassandra/i }));
+    expect(row.getAttribute("data-expanded")).toBe("true");
+  });
+
+  it("keeps multiple rows expanded simultaneously", async () => {
+    const user = userEvent.setup();
+    render(
+      <InstrumentationBrowser
+        instrumentations={twoModules}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
+    const cass = screen.getByTestId("instrumentation-row-cassandra");
+    const graphql = screen.getByTestId("instrumentation-row-graphql_java");
+    expect(cass.getAttribute("data-expanded")).toBe("false");
+    expect(graphql.getAttribute("data-expanded")).toBe("false");
+    await user.click(screen.getByRole("button", { name: /toggle details for cassandra/i }));
+    await user.click(screen.getByRole("button", { name: /toggle details for graphql_java/i }));
+    expect(cass.getAttribute("data-expanded")).toBe("true");
+    expect(graphql.getAttribute("data-expanded")).toBe("true");
+  });
+
+  it("uses useOverriddenModules to filter when statusFilter is 'overridden'", () => {
+    vi.mocked(useOverriddenModules).mockReturnValue(new Set(["cassandra"]));
+    render(
+      <InstrumentationBrowser
+        instrumentations={twoModules}
+        search=""
+        statusFilter="overridden"
+        {...browserDefaults}
+      />
+    );
+    expect(screen.getByTestId("instrumentation-row-cassandra")).toBeInTheDocument();
+    expect(screen.queryByTestId("instrumentation-row-graphql_java")).toBeNull();
+  });
+
+  it("renders the override count in the header from useOverriddenModules", () => {
+    vi.mocked(useOverriddenModules).mockReturnValue(new Set(["cassandra"]));
+    render(
+      <InstrumentationBrowser
+        instrumentations={[twoModules[0]]}
+        search=""
+        statusFilter="all"
+        {...browserDefaults}
+      />
+    );
+    expect(screen.getByText(/1 overridden/i)).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.test.tsx
@@ -16,227 +16,137 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { InstrumentationData } from "@/types/javaagent";
-import type { ConfigurationBuilderState } from "@/types/configuration-builder";
-
-const setValueByPath = vi.fn();
-const setEnabled = vi.fn();
-const removeMapEntry = vi.fn();
-
-let mockBuilderState: ConfigurationBuilderState;
-
-vi.mock("@/hooks/use-configuration-builder", () => ({
-  useConfigurationBuilder: () => ({
-    state: mockBuilderState,
-    setValueByPath: (...args: unknown[]) => setValueByPath(...args),
-    setEnabled: (...args: unknown[]) => setEnabled(...args),
-    removeMapEntry: (...args: unknown[]) => removeMapEntry(...args),
-    setValue: vi.fn(),
-    selectPlugin: vi.fn(),
-    addListItem: vi.fn(),
-    removeListItem: vi.fn(),
-    setMapEntry: vi.fn(),
-    resetToDefaults: vi.fn(),
-    enableAllSections: vi.fn(),
-    loadFromYaml: vi.fn(),
-    validateField: vi.fn(),
-    validateAll: vi.fn(),
-    clearValidationError: vi.fn(),
-  }),
-}));
-
-const useInstrumentationsMock = vi.fn();
-vi.mock("@/hooks/use-javaagent-data", () => ({
-  useInstrumentations: (version: string) => useInstrumentationsMock(version),
-}));
-
+import { useInstrumentations } from "@/hooks/use-javaagent-data";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { useOverrideStatusMap } from "@/hooks/use-override-status";
 import { InstrumentationBrowser } from "./instrumentation-browser";
 
-const FIXTURE: InstrumentationData[] = [
-  {
-    name: "cassandra-4.4",
-    display_name: "Cassandra Driver",
-    description: "Database client spans + metrics for the DataStax Cassandra Driver.",
-    disabled_by_default: false,
-    scope: { name: "io.opentelemetry.cassandra-4.4" },
-  },
-  {
-    name: "akka-http-10.0",
-    display_name: "Akka HTTP 10.0",
-    description: "HTTP client + server spans for Akka HTTP.",
-    disabled_by_default: false,
-    scope: { name: "io.opentelemetry.akka-http-10.0" },
-  },
-  {
-    name: "jmx-metrics",
-    display_name: "JMX Metrics",
-    description: "Built-in JMX metric gatherer.",
-    disabled_by_default: true,
-    _is_custom: true,
-    scope: { name: "io.opentelemetry.jmx-metrics" },
-  },
-];
+vi.mock("@/hooks/use-javaagent-data");
+vi.mock("@/hooks/use-configuration-builder");
+vi.mock("@/hooks/use-override-status");
 
-function emptyState(): ConfigurationBuilderState {
+const mockedInstr = vi.mocked(useInstrumentations);
+const mockedBuilder = vi.mocked(useConfigurationBuilder);
+const mockedOverride = vi.mocked(useOverrideStatusMap);
+
+function entry(name: string, opts: Partial<InstrumentationData> = {}): InstrumentationData {
   return {
-    version: "1.0.0",
-    values: {},
-    enabledSections: {},
-    validationErrors: {},
-    isDirty: false,
-    listItemIds: {},
-  };
+    name,
+    scope: { name: `io.opentelemetry.${name}` },
+    ...opts,
+  } as InstrumentationData;
 }
 
+const FIXTURE: InstrumentationData[] = [
+  entry("cassandra-3.0", { description: "Cassandra Driver context propagation" }),
+  entry("cassandra-4.0"),
+  entry("cassandra-4.4"),
+  entry("kafka-clients-0.11", { display_name: "Kafka Clients" }),
+  entry("kafka-clients-3.5"),
+  entry("jmx-metrics", { disabled_by_default: true }),
+];
+
+const setOverride = vi.fn();
+
 beforeEach(() => {
-  setValueByPath.mockReset();
-  setEnabled.mockReset();
-  removeMapEntry.mockReset();
-  mockBuilderState = emptyState();
-  useInstrumentationsMock.mockReset();
+  setOverride.mockReset();
+  mockedInstr.mockReturnValue({ data: FIXTURE, loading: false, error: null });
+  mockedBuilder.mockReturnValue({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: {},
+      isDirty: false,
+      version: "2.27.0",
+      listItemIds: {},
+    },
+    setOverride,
+  } as unknown as ReturnType<typeof useConfigurationBuilder>);
+  mockedOverride.mockReturnValue(new Map());
 });
 
 describe("InstrumentationBrowser", () => {
-  it("renders loading copy while loading", () => {
-    useInstrumentationsMock.mockReturnValue({ data: null, loading: true, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
-    expect(screen.getByText(/Loading instrumentations/i)).toBeInTheDocument();
+  it("groups entries into module rows with version count", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
+    expect(screen.getByText("kafka_clients")).toBeInTheDocument();
+    expect(screen.getByText("jmx_metrics")).toBeInTheDocument();
+    expect(screen.getByText(/3 versions/)).toBeInTheDocument();
+    expect(screen.getByText(/2 versions/)).toBeInTheDocument();
   });
 
-  it("renders error copy when the load fails", () => {
-    useInstrumentationsMock.mockReturnValue({
-      data: null,
-      loading: false,
-      error: new Error("boom"),
-    });
-    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
-    expect(screen.getByText(/Failed to load instrumentations/i)).toBeInTheDocument();
+  it("matches search against the registry name of any covered entry", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="cassandra-4.4" statusFilter="all" />);
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
+    expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
-  it("renders all instrumentations from the fixture", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
-    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
-    expect(screen.getByText("Akka HTTP 10.0")).toBeInTheDocument();
-    expect(screen.getByText("JMX Metrics")).toBeInTheDocument();
+  it("matches search against display_name on any covered entry", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="Kafka Clients" statusFilter="all" />);
+    expect(screen.getByText("kafka_clients")).toBeInTheDocument();
+    expect(screen.queryByText("cassandra")).not.toBeInTheDocument();
   });
 
-  it("filters by name (case-insensitive)", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
-    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
-    expect(screen.queryByText("Akka HTTP 10.0")).toBeNull();
-    expect(screen.queryByText("JMX Metrics")).toBeNull();
+  it("matches search against description on any covered entry", () => {
+    render(
+      <InstrumentationBrowser version="2.27.0" search="context propagation" statusFilter="all" />
+    );
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
+    expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
-  it("filters by description substring", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="JMX metric" statusFilter="all" />);
-    expect(screen.getByText("JMX Metrics")).toBeInTheDocument();
-    expect(screen.queryByText("Cassandra Driver")).toBeNull();
+  it("search is case-insensitive", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="CASSANDRA" statusFilter="all" />);
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
   });
 
-  it("statusFilter='overridden' shows only overridden rows", () => {
-    mockBuilderState = {
-      ...emptyState(),
-      values: {
-        "instrumentation/development": {
-          java: {
-            "cassandra-4.4": { enabled: false },
-          },
-        },
-      },
-    };
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="overridden" />);
-    expect(screen.getByText("Cassandra Driver")).toBeInTheDocument();
-    expect(screen.queryByText("Akka HTTP 10.0")).toBeNull();
-    expect(screen.queryByText("JMX Metrics")).toBeNull();
+  it("filters to overridden when statusFilter='overridden'", () => {
+    mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="overridden" />);
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
+    expect(screen.queryByText("kafka_clients")).not.toBeInTheDocument();
   });
 
-  it("renders the empty-search copy when nothing matches", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="nope-zzz" statusFilter="all" />);
+  it("calls setOverride('cassandra', 'disabled') when + Override is clicked on a default-enabled module", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    fireEvent.click(screen.getByLabelText("Override cassandra"));
+    expect(setOverride).toHaveBeenCalledWith("cassandra", "disabled");
+  });
+
+  it("calls setOverride('jmx_metrics', 'enabled') when + Override is clicked on a default-disabled module", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    fireEvent.click(screen.getByLabelText("Override jmx_metrics"));
+    expect(setOverride).toHaveBeenCalledWith("jmx_metrics", "enabled");
+  });
+
+  it("calls setOverride(name, 'none') when ✕ is clicked on an overridden row", () => {
+    mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    fireEvent.click(screen.getByLabelText("Remove override for cassandra"));
+    expect(setOverride).toHaveBeenCalledWith("cassandra", "none");
+  });
+
+  it("calls setOverride('cassandra', 'enabled') when toggling overridden Disabled→Enabled", () => {
+    mockedOverride.mockReturnValue(new Map([["cassandra", "disabled"]]));
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Enabled" })[0]);
+    expect(setOverride).toHaveBeenCalledWith("cassandra", "enabled");
+  });
+
+  it("renders empty state for unmatched search", () => {
+    render(<InstrumentationBrowser version="2.27.0" search="nonexistent" statusFilter="all" />);
     expect(screen.getByText(/No instrumentations match/)).toBeInTheDocument();
-    expect(screen.getByText(/Clear the search to show all 3/)).toBeInTheDocument();
   });
 
-  it("header readout reflects total and override count", () => {
-    mockBuilderState = {
-      ...emptyState(),
-      values: {
-        "instrumentation/development": {
-          java: {
-            "cassandra-4.4": { enabled: false },
-          },
-        },
-      },
-    };
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="" statusFilter="all" />);
-    expect(screen.getByText(/3 total/)).toBeInTheDocument();
-    expect(screen.getByText(/1 overridden/)).toBeInTheDocument();
-    expect(screen.getByText(/No filter · 3 instrumentations/)).toBeInTheDocument();
+  it("shows loading state", () => {
+    mockedInstr.mockReturnValue({ data: null, loading: true, error: null });
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    expect(screen.getByText(/Loading instrumentations/)).toBeInTheDocument();
   });
 
-  it("clicking + Override writes the opposite-of-default and enables the section", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
-    fireEvent.click(screen.getByRole("button", { name: /Override Cassandra Driver/ }));
-    // cassandra-4.4 is enabled-by-default → starting override is enabled: false
-    expect(setValueByPath).toHaveBeenCalledWith(
-      ["instrumentation/development", "java", "cassandra-4.4"],
-      { enabled: false }
-    );
-    expect(setEnabled).toHaveBeenCalledWith("instrumentation/development", true);
-  });
-
-  it("clicking + Override on a disabled-by-default row writes enabled: true", () => {
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="jmx" statusFilter="all" />);
-    fireEvent.click(screen.getByRole("button", { name: /Override JMX Metrics/ }));
-    expect(setValueByPath).toHaveBeenCalledWith(
-      ["instrumentation/development", "java", "jmx-metrics"],
-      { enabled: true }
-    );
-  });
-
-  it("toggling an existing override writes only the enabled leaf", () => {
-    mockBuilderState = {
-      ...emptyState(),
-      values: {
-        "instrumentation/development": {
-          java: { "cassandra-4.4": { enabled: false } },
-        },
-      },
-    };
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
-    fireEvent.click(screen.getByRole("button", { name: "Enabled" }));
-    expect(setValueByPath).toHaveBeenCalledWith(
-      ["instrumentation/development", "java", "cassandra-4.4", "enabled"],
-      true
-    );
-  });
-
-  it("removing an override calls removeMapEntry to actually delete the key", () => {
-    mockBuilderState = {
-      ...emptyState(),
-      values: {
-        "instrumentation/development": {
-          java: { "cassandra-4.4": { enabled: false } },
-        },
-      },
-    };
-    useInstrumentationsMock.mockReturnValue({ data: FIXTURE, loading: false, error: null });
-    render(<InstrumentationBrowser version="1.0.0" search="cassandra" statusFilter="all" />);
-    fireEvent.click(screen.getByRole("button", { name: /Remove override for Cassandra Driver/ }));
-    // removeMapEntry truly deletes the key — the section flag is then driven
-    // by the mirror effect in InstrumentationTabBody, not by the browser.
-    expect(removeMapEntry).toHaveBeenCalledWith(
-      "instrumentation/development.java",
-      "cassandra-4.4"
-    );
-    expect(setValueByPath).not.toHaveBeenCalled();
-    expect(setEnabled).not.toHaveBeenCalled();
+  it("shows error state", () => {
+    mockedInstr.mockReturnValue({ data: null, loading: false, error: new Error("boom") });
+    render(<InstrumentationBrowser version="2.27.0" search="" statusFilter="all" />);
+    expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
@@ -13,27 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useMemo, type JSX } from "react";
-import type { InstrumentationModule } from "@/types/javaagent";
-import { useInstrumentations } from "@/hooks/use-javaagent-data";
+import { useState, useCallback, useMemo, type JSX } from "react";
+import type { InstrumentationData, InstrumentationModule } from "@/types/javaagent";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
 import { useOverrideStatusMap, type OverrideStatus } from "@/hooks/use-override-status";
+import { useOverriddenModules } from "@/hooks/use-overridden-modules";
 import { groupByModule } from "@/lib/normalize-instrumentation";
 import { SectionCardShell } from "./section-card-shell";
 import { InstrumentationRow } from "./instrumentation-row";
 
 export interface InstrumentationBrowserProps {
-  version: string;
+  instrumentations: InstrumentationData[] | null;
+  loading: boolean;
+  error: Error | null;
   search: string;
   statusFilter: "all" | "overridden";
+  onJumpToGeneral: (sectionKey: string) => void;
 }
 
 export function InstrumentationBrowser({
-  version,
+  instrumentations,
+  loading,
+  error,
   search,
   statusFilter,
+  onJumpToGeneral,
 }: InstrumentationBrowserProps): JSX.Element {
-  const { data: instrumentations, loading, error } = useInstrumentations(version);
   const { setOverride } = useConfigurationBuilder();
   const overrideMap = useOverrideStatusMap();
 
@@ -42,18 +47,29 @@ export function InstrumentationBrowser({
     [instrumentations]
   );
 
-  const overrideCount = overrideMap.size;
+  const overriddenSet = useOverriddenModules(modules);
+  const overrideCount = overriddenSet.size;
+
+  const [expandedSet, setExpandedSet] = useState<Set<string>>(() => new Set());
+
+  const toggleExpand = useCallback((name: string) => {
+    setExpandedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
 
   const trimmedSearch = search.trim();
   const filtered = useMemo(() => {
     const q = trimmedSearch.toLowerCase();
     return modules.filter((m) => {
-      if (statusFilter === "overridden" && (overrideMap.get(m.name) ?? "none") === "none")
-        return false;
+      if (statusFilter === "overridden" && !overriddenSet.has(m.name)) return false;
       if (q && !matchesQuery(m, q)) return false;
       return true;
     });
-  }, [modules, overrideMap, trimmedSearch, statusFilter]);
+  }, [modules, overriddenSet, trimmedSearch, statusFilter]);
 
   const handleAddOverride = useCallback(
     (m: InstrumentationModule) => {
@@ -99,12 +115,15 @@ export function InstrumentationBrowser({
           total={modules.length}
           filtered={filtered}
           overrideMap={overrideMap}
+          expandedSet={expandedSet}
           search={trimmedSearch}
           statusFilter={statusFilter}
           overrideCount={overrideCount}
           onAddOverride={handleAddOverride}
           onSetEnabled={handleSetEnabled}
           onRemoveOverride={handleRemoveOverride}
+          onToggleExpand={toggleExpand}
+          onJumpToGeneral={onJumpToGeneral}
         />
       )}
     </SectionCardShell>
@@ -115,24 +134,30 @@ interface BodyProps {
   total: number;
   filtered: InstrumentationModule[];
   overrideMap: Map<string, "enabled" | "disabled">;
+  expandedSet: Set<string>;
   search: string;
   statusFilter: "all" | "overridden";
   overrideCount: number;
   onAddOverride: (m: InstrumentationModule) => void;
   onSetEnabled: (name: string, enabled: boolean) => void;
   onRemoveOverride: (name: string) => void;
+  onToggleExpand: (name: string) => void;
+  onJumpToGeneral: (sectionKey: string) => void;
 }
 
 function Body({
   total,
   filtered,
   overrideMap,
+  expandedSet,
   search,
   statusFilter,
   overrideCount,
   onAddOverride,
   onSetEnabled,
   onRemoveOverride,
+  onToggleExpand,
+  onJumpToGeneral,
 }: BodyProps): JSX.Element {
   return (
     <div className="space-y-3">
@@ -151,9 +176,12 @@ function Body({
                 <InstrumentationRow
                   module={m}
                   status={status}
+                  isExpanded={expandedSet.has(m.name)}
                   onAddOverride={() => onAddOverride(m)}
                   onSetEnabled={(enabled) => onSetEnabled(m.name, enabled)}
                   onRemoveOverride={() => onRemoveOverride(m.name)}
+                  onToggleExpand={() => onToggleExpand(m.name)}
+                  onJumpToGeneral={onJumpToGeneral}
                 />
               </li>
             );

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 import { useCallback, useMemo, type JSX } from "react";
-import type { InstrumentationData } from "@/types/javaagent";
-import type { ConfigValue, ConfigValues } from "@/types/configuration-builder";
+import type { InstrumentationModule } from "@/types/javaagent";
 import { useInstrumentations } from "@/hooks/use-javaagent-data";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { useOverrideStatusMap, type OverrideStatus } from "@/hooks/use-override-status";
+import { groupByModule } from "@/lib/normalize-instrumentation";
 import { SectionCardShell } from "./section-card-shell";
 import { InstrumentationRow } from "./instrumentation-row";
 
@@ -27,78 +28,52 @@ export interface InstrumentationBrowserProps {
   statusFilter: "all" | "overridden";
 }
 
-const SECTION_KEY = "instrumentation/development";
-const LANG = "java";
-
-type OverrideEntry = { enabled?: boolean } | undefined;
-
 export function InstrumentationBrowser({
   version,
   search,
   statusFilter,
 }: InstrumentationBrowserProps): JSX.Element {
   const { data: instrumentations, loading, error } = useInstrumentations(version);
-  const { state, setValueByPath, setEnabled, removeMapEntry } = useConfigurationBuilder();
+  const { setOverride } = useConfigurationBuilder();
+  const overrideMap = useOverrideStatusMap();
 
-  const overrides = useMemo<Record<string, OverrideEntry>>(() => {
-    const section = state.values[SECTION_KEY];
-    if (!isPlainObject(section)) return {};
-    const lang = section[LANG];
-    if (!isPlainObject(lang)) return {};
-    return lang as Record<string, OverrideEntry>;
-  }, [state.values]);
-
-  const sorted = useMemo(() => {
-    if (!instrumentations) return [];
-    return [...instrumentations].sort((a, b) => a.name.localeCompare(b.name));
-  }, [instrumentations]);
-
-  const overrideCount = useMemo(
-    () => sorted.filter((i) => isOverridden(overrides[i.name])).length,
-    [sorted, overrides]
+  const modules = useMemo<InstrumentationModule[]>(
+    () => (instrumentations ? groupByModule(instrumentations) : []),
+    [instrumentations]
   );
+
+  const overrideCount = overrideMap.size;
 
   const trimmedSearch = search.trim();
   const filtered = useMemo(() => {
     const q = trimmedSearch.toLowerCase();
-    return sorted.filter((inst) => {
-      if (statusFilter === "overridden" && !isOverridden(overrides[inst.name])) return false;
-      if (q && !matchesQuery(inst, q)) return false;
+    return modules.filter((m) => {
+      if (statusFilter === "overridden" && (overrideMap.get(m.name) ?? "none") === "none")
+        return false;
+      if (q && !matchesQuery(m, q)) return false;
       return true;
     });
-  }, [sorted, overrides, trimmedSearch, statusFilter]);
+  }, [modules, overrideMap, trimmedSearch, statusFilter]);
 
   const handleAddOverride = useCallback(
-    (inst: InstrumentationData) => {
-      const startEnabled = inst.disabled_by_default === true;
-      // setValueByPath bypasses parsePath's "." split — instrumentation IDs
-      // like "cassandra-4.4" must reach the reducer as discrete segments.
-      setValueByPath([SECTION_KEY, LANG, inst.name], { enabled: startEnabled });
-      setEnabled(SECTION_KEY, true);
+    (m: InstrumentationModule) => {
+      setOverride(m.name, m.defaultDisabled ? "enabled" : "disabled");
     },
-    [setValueByPath, setEnabled]
+    [setOverride]
   );
 
   const handleSetEnabled = useCallback(
-    (id: string, enabled: boolean) => {
-      setValueByPath([SECTION_KEY, LANG, id, "enabled"], enabled);
+    (name: string, enabled: boolean) => {
+      setOverride(name, enabled ? "enabled" : "disabled");
     },
-    [setValueByPath]
+    [setOverride]
   );
 
   const handleRemoveOverride = useCallback(
-    (id: string) => {
-      // removeMapEntry actually deletes the key, unlike setValueByPath(...,
-      // undefined) which would leave a stale `{ id: undefined }` entry that
-      // the section-flag mirror treats as "still has content". The dotted
-      // path is safe here: neither "instrumentation/development" nor "java"
-      // contains a "." that parsePath would split on.
-      removeMapEntry(`${SECTION_KEY}.${LANG}`, id);
-      // The mirror effect in InstrumentationTabBody flips
-      // enabledSections[SECTION_KEY] to false on the next render once the
-      // values tree is empty.
+    (name: string) => {
+      setOverride(name, "none");
     },
-    [removeMapEntry]
+    [setOverride]
   );
 
   return (
@@ -106,9 +81,9 @@ export function InstrumentationBrowser({
       <header className="flex flex-wrap items-baseline justify-between gap-2">
         <h3 className="text-foreground text-base font-semibold">
           Instrumentations
-          {sorted.length > 0 ? (
+          {modules.length > 0 ? (
             <span className="text-muted-foreground ml-2 text-xs font-normal">
-              · {sorted.length} total
+              · {modules.length} modules
               {overrideCount > 0 ? ` · ${overrideCount} overridden` : ""}
             </span>
           ) : null}
@@ -121,9 +96,9 @@ export function InstrumentationBrowser({
         <p className="text-sm text-red-400">Failed to load instrumentations.</p>
       ) : (
         <Body
-          total={sorted.length}
+          total={modules.length}
           filtered={filtered}
-          overrides={overrides}
+          overrideMap={overrideMap}
           search={trimmedSearch}
           statusFilter={statusFilter}
           overrideCount={overrideCount}
@@ -138,20 +113,20 @@ export function InstrumentationBrowser({
 
 interface BodyProps {
   total: number;
-  filtered: InstrumentationData[];
-  overrides: Record<string, OverrideEntry>;
+  filtered: InstrumentationModule[];
+  overrideMap: Map<string, "enabled" | "disabled">;
   search: string;
   statusFilter: "all" | "overridden";
   overrideCount: number;
-  onAddOverride: (inst: InstrumentationData) => void;
-  onSetEnabled: (id: string, enabled: boolean) => void;
-  onRemoveOverride: (id: string) => void;
+  onAddOverride: (m: InstrumentationModule) => void;
+  onSetEnabled: (name: string, enabled: boolean) => void;
+  onRemoveOverride: (name: string) => void;
 }
 
 function Body({
   total,
   filtered,
-  overrides,
+  overrideMap,
   search,
   statusFilter,
   overrideCount,
@@ -169,17 +144,20 @@ function Body({
         <EmptyState search={search} statusFilter={statusFilter} total={total} />
       ) : (
         <ul className="space-y-1.5">
-          {filtered.map((inst) => (
-            <li key={inst.name}>
-              <InstrumentationRow
-                instrumentation={inst}
-                override={toRowOverride(overrides[inst.name])}
-                onAddOverride={() => onAddOverride(inst)}
-                onSetEnabled={(enabled) => onSetEnabled(inst.name, enabled)}
-                onRemoveOverride={() => onRemoveOverride(inst.name)}
-              />
-            </li>
-          ))}
+          {filtered.map((m) => {
+            const status: OverrideStatus = overrideMap.get(m.name) ?? "none";
+            return (
+              <li key={m.name}>
+                <InstrumentationRow
+                  module={m}
+                  status={status}
+                  onAddOverride={() => onAddOverride(m)}
+                  onSetEnabled={(enabled) => onSetEnabled(m.name, enabled)}
+                  onRemoveOverride={() => onRemoveOverride(m.name)}
+                />
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>
@@ -220,30 +198,17 @@ function readout(
   statusFilter: "all" | "overridden",
   overrideCount: number
 ): string {
-  const parts: string[] = [];
-  if (search) parts.push(`Search "${search}" · ${shown} of ${total}`);
-  else if (statusFilter === "overridden") parts.push(`Overridden · ${overrideCount} of ${total}`);
-  else parts.push(`No filter · ${total} instrumentations`);
-  return parts.join(" · ");
+  if (search) return `Search "${search}" · ${shown} of ${total}`;
+  if (statusFilter === "overridden") return `Overridden · ${overrideCount} of ${total}`;
+  return `No filter · ${total} modules`;
 }
 
-function matchesQuery(inst: InstrumentationData, q: string): boolean {
-  return (
-    inst.name.toLowerCase().includes(q) ||
-    (inst.display_name?.toLowerCase().includes(q) ?? false) ||
-    (inst.description?.toLowerCase().includes(q) ?? false)
-  );
-}
-
-function isOverridden(entry: OverrideEntry): boolean {
-  return !!entry && typeof entry === "object" && typeof entry.enabled === "boolean";
-}
-
-function toRowOverride(entry: OverrideEntry): { enabled: boolean } | undefined {
-  if (!isOverridden(entry)) return undefined;
-  return { enabled: (entry as { enabled: boolean }).enabled };
-}
-
-function isPlainObject(v: ConfigValue | undefined): v is ConfigValues {
-  return !!v && typeof v === "object" && !Array.isArray(v);
+function matchesQuery(m: InstrumentationModule, q: string): boolean {
+  if (m.name.toLowerCase().includes(q)) return true;
+  for (const e of m.coveredEntries) {
+    if (e.name.toLowerCase().includes(q)) return true;
+    if (e.display_name?.toLowerCase().includes(q)) return true;
+    if (e.description?.toLowerCase().includes(q)) return true;
+  }
+  return false;
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-browser.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useMemo, type JSX } from "react";
+import type { InstrumentationData } from "@/types/javaagent";
+import type { ConfigValue, ConfigValues } from "@/types/configuration-builder";
+import { useInstrumentations } from "@/hooks/use-javaagent-data";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SectionCardShell } from "./section-card-shell";
+import { InstrumentationRow } from "./instrumentation-row";
+
+export interface InstrumentationBrowserProps {
+  version: string;
+  search: string;
+  statusFilter: "all" | "overridden";
+}
+
+const SECTION_KEY = "instrumentation/development";
+const LANG = "java";
+
+type OverrideEntry = { enabled?: boolean } | undefined;
+
+export function InstrumentationBrowser({
+  version,
+  search,
+  statusFilter,
+}: InstrumentationBrowserProps): JSX.Element {
+  const { data: instrumentations, loading, error } = useInstrumentations(version);
+  const { state, setValueByPath, setEnabled, removeMapEntry } = useConfigurationBuilder();
+
+  const overrides = useMemo<Record<string, OverrideEntry>>(() => {
+    const section = state.values[SECTION_KEY];
+    if (!isPlainObject(section)) return {};
+    const lang = section[LANG];
+    if (!isPlainObject(lang)) return {};
+    return lang as Record<string, OverrideEntry>;
+  }, [state.values]);
+
+  const sorted = useMemo(() => {
+    if (!instrumentations) return [];
+    return [...instrumentations].sort((a, b) => a.name.localeCompare(b.name));
+  }, [instrumentations]);
+
+  const overrideCount = useMemo(
+    () => sorted.filter((i) => isOverridden(overrides[i.name])).length,
+    [sorted, overrides]
+  );
+
+  const trimmedSearch = search.trim();
+  const filtered = useMemo(() => {
+    const q = trimmedSearch.toLowerCase();
+    return sorted.filter((inst) => {
+      if (statusFilter === "overridden" && !isOverridden(overrides[inst.name])) return false;
+      if (q && !matchesQuery(inst, q)) return false;
+      return true;
+    });
+  }, [sorted, overrides, trimmedSearch, statusFilter]);
+
+  const handleAddOverride = useCallback(
+    (inst: InstrumentationData) => {
+      const startEnabled = inst.disabled_by_default === true;
+      // setValueByPath bypasses parsePath's "." split — instrumentation IDs
+      // like "cassandra-4.4" must reach the reducer as discrete segments.
+      setValueByPath([SECTION_KEY, LANG, inst.name], { enabled: startEnabled });
+      setEnabled(SECTION_KEY, true);
+    },
+    [setValueByPath, setEnabled]
+  );
+
+  const handleSetEnabled = useCallback(
+    (id: string, enabled: boolean) => {
+      setValueByPath([SECTION_KEY, LANG, id, "enabled"], enabled);
+    },
+    [setValueByPath]
+  );
+
+  const handleRemoveOverride = useCallback(
+    (id: string) => {
+      // removeMapEntry actually deletes the key, unlike setValueByPath(...,
+      // undefined) which would leave a stale `{ id: undefined }` entry that
+      // the section-flag mirror treats as "still has content". The dotted
+      // path is safe here: neither "instrumentation/development" nor "java"
+      // contains a "." that parsePath would split on.
+      removeMapEntry(`${SECTION_KEY}.${LANG}`, id);
+      // The mirror effect in InstrumentationTabBody flips
+      // enabledSections[SECTION_KEY] to false on the next render once the
+      // values tree is empty.
+    },
+    [removeMapEntry]
+  );
+
+  return (
+    <SectionCardShell sectionKey="instrumentations">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-foreground text-base font-semibold">
+          Instrumentations
+          {sorted.length > 0 ? (
+            <span className="text-muted-foreground ml-2 text-xs font-normal">
+              · {sorted.length} total
+              {overrideCount > 0 ? ` · ${overrideCount} overridden` : ""}
+            </span>
+          ) : null}
+        </h3>
+      </header>
+
+      {loading ? (
+        <p className="text-muted-foreground text-sm">Loading instrumentations…</p>
+      ) : error ? (
+        <p className="text-sm text-red-400">Failed to load instrumentations.</p>
+      ) : (
+        <Body
+          total={sorted.length}
+          filtered={filtered}
+          overrides={overrides}
+          search={trimmedSearch}
+          statusFilter={statusFilter}
+          overrideCount={overrideCount}
+          onAddOverride={handleAddOverride}
+          onSetEnabled={handleSetEnabled}
+          onRemoveOverride={handleRemoveOverride}
+        />
+      )}
+    </SectionCardShell>
+  );
+}
+
+interface BodyProps {
+  total: number;
+  filtered: InstrumentationData[];
+  overrides: Record<string, OverrideEntry>;
+  search: string;
+  statusFilter: "all" | "overridden";
+  overrideCount: number;
+  onAddOverride: (inst: InstrumentationData) => void;
+  onSetEnabled: (id: string, enabled: boolean) => void;
+  onRemoveOverride: (id: string) => void;
+}
+
+function Body({
+  total,
+  filtered,
+  overrides,
+  search,
+  statusFilter,
+  overrideCount,
+  onAddOverride,
+  onSetEnabled,
+  onRemoveOverride,
+}: BodyProps): JSX.Element {
+  return (
+    <div className="space-y-3">
+      <div className="border-border/40 bg-background/30 text-muted-foreground rounded-md border px-3 py-2 text-xs">
+        {readout(total, filtered.length, search, statusFilter, overrideCount)}
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState search={search} statusFilter={statusFilter} total={total} />
+      ) : (
+        <ul className="space-y-1.5">
+          {filtered.map((inst) => (
+            <li key={inst.name}>
+              <InstrumentationRow
+                instrumentation={inst}
+                override={toRowOverride(overrides[inst.name])}
+                onAddOverride={() => onAddOverride(inst)}
+                onSetEnabled={(enabled) => onSetEnabled(inst.name, enabled)}
+                onRemoveOverride={() => onRemoveOverride(inst.name)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({
+  search,
+  statusFilter,
+  total,
+}: {
+  search: string;
+  statusFilter: "all" | "overridden";
+  total: number;
+}): JSX.Element {
+  if (search) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No instrumentations match &ldquo;{search}&rdquo;. Clear the search to show all {total}.
+      </p>
+    );
+  }
+  if (statusFilter === "overridden") {
+    return (
+      <p className="text-muted-foreground text-sm">
+        You haven&rsquo;t overridden any instrumentation yet. Click &ldquo;+ Override&rdquo; on a
+        row to add one.
+      </p>
+    );
+  }
+  return <p className="text-muted-foreground text-sm">No instrumentations available.</p>;
+}
+
+function readout(
+  total: number,
+  shown: number,
+  search: string,
+  statusFilter: "all" | "overridden",
+  overrideCount: number
+): string {
+  const parts: string[] = [];
+  if (search) parts.push(`Search "${search}" · ${shown} of ${total}`);
+  else if (statusFilter === "overridden") parts.push(`Overridden · ${overrideCount} of ${total}`);
+  else parts.push(`No filter · ${total} instrumentations`);
+  return parts.join(" · ");
+}
+
+function matchesQuery(inst: InstrumentationData, q: string): boolean {
+  return (
+    inst.name.toLowerCase().includes(q) ||
+    (inst.display_name?.toLowerCase().includes(q) ?? false) ||
+    (inst.description?.toLowerCase().includes(q) ?? false)
+  );
+}
+
+function isOverridden(entry: OverrideEntry): boolean {
+  return !!entry && typeof entry === "object" && typeof entry.enabled === "boolean";
+}
+
+function toRowOverride(entry: OverrideEntry): { enabled: boolean } | undefined {
+  if (!isOverridden(entry)) return undefined;
+  return { enabled: (entry as { enabled: boolean }).enabled };
+}
+
+function isPlainObject(v: ConfigValue | undefined): v is ConfigValues {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-field.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-field.test.tsx
@@ -1,0 +1,395 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Configuration } from "@/types/javaagent";
+import type { ConfigurationBuilderState, ConfigValue } from "@/types/configuration-builder";
+import type { AggregatedConfig } from "@/lib/configurations-aggregate";
+
+const setValueByPath = vi.fn();
+const removeMapEntry = vi.fn();
+
+let mockState: ConfigurationBuilderState;
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: mockState,
+    setValueByPath: (...args: unknown[]) => setValueByPath(...args),
+    removeMapEntry: (...args: unknown[]) => removeMapEntry(...args),
+  }),
+}));
+
+import { InstrumentationConfigField } from "./instrumentation-config-field";
+
+const baseState: ConfigurationBuilderState = {
+  version: "1.0.0",
+  values: {},
+  enabledSections: {},
+  validationErrors: {},
+  isDirty: false,
+};
+
+function makeAggregated(
+  partial: Partial<Configuration> & { declarative_name: string; type: Configuration["type"] }
+): AggregatedConfig {
+  const entry: Configuration = {
+    name: partial.name ?? "otel.placeholder",
+    description: partial.description ?? "Description.",
+    type: partial.type,
+    default: partial.default ?? "",
+    declarative_name: partial.declarative_name,
+  };
+  const scope = partial.declarative_name.startsWith("general.")
+    ? "general"
+    : partial.declarative_name.startsWith("java.common.")
+      ? "common"
+      : "owned";
+  return {
+    entry,
+    scope,
+    path: ["instrumentation/development", ...partial.declarative_name.split(".")],
+  };
+}
+
+describe("InstrumentationConfigField — boolean", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("renders the declarative_name label and description in default state", () => {
+    const cfg = makeAggregated({
+      declarative_name: "java.graphql.capture_query",
+      type: "boolean",
+      default: true,
+      description: "Whether to capture the query.",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText("java.graphql.capture_query")).toBeInTheDocument();
+    expect(screen.getByText(/whether to capture/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /override/i })).toBeInTheDocument();
+  });
+
+  it("clicking Override writes the parsed default at the path", async () => {
+    const user = userEvent.setup();
+    const cfg = makeAggregated({
+      declarative_name: "java.graphql.capture_query",
+      type: "boolean",
+      default: true,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "graphql", "capture_query"],
+      true
+    );
+  });
+
+  it("toggles via SwitchPill when overridden", async () => {
+    const user = userEvent.setup();
+    mockState = {
+      ...baseState,
+      values: {
+        "instrumentation/development": { java: { graphql: { capture_query: true } } },
+      },
+    };
+    const cfg = makeAggregated({
+      declarative_name: "java.graphql.capture_query",
+      type: "boolean",
+      default: true,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("switch"));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "graphql", "capture_query"],
+      false
+    );
+  });
+
+  it("Reset removes the leaf via removeMapEntry on the parent path", async () => {
+    const user = userEvent.setup();
+    mockState = {
+      ...baseState,
+      values: {
+        "instrumentation/development": { java: { graphql: { capture_query: false } } },
+      },
+    };
+    const cfg = makeAggregated({
+      declarative_name: "java.graphql.capture_query",
+      type: "boolean",
+      default: true,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /reset/i }));
+    expect(removeMapEntry).toHaveBeenCalledWith(
+      "instrumentation/development.java.graphql",
+      "capture_query"
+    );
+  });
+});
+
+describe("InstrumentationConfigField — list", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("Override parses CSV (with whitespace) into a real array, not a forwarded string", async () => {
+    const user = userEvent.setup();
+    const cfg = makeAggregated({
+      declarative_name: "java.common.http.known_methods",
+      type: "list",
+      default: " GET , POST ",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    const [, value] = setValueByPath.mock.calls[0];
+    expect(Array.isArray(value)).toBe(true);
+    expect(value).toEqual(["GET", "POST"]);
+  });
+
+  it("Override seeds with [] for an empty CSV default", async () => {
+    const user = userEvent.setup();
+    const cfg = makeAggregated({
+      declarative_name: "general.http.client.request_captured_headers",
+      type: "list",
+      default: "",
+    });
+    render(
+      <InstrumentationConfigField config={{ ...cfg, scope: "common" }} onJumpToGeneral={vi.fn()} />
+    );
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    const [, value] = setValueByPath.mock.calls[0];
+    expect(value).toEqual([]);
+  });
+});
+
+describe("InstrumentationConfigField — string / int / double", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("string Override seeds with the default string", async () => {
+    const user = userEvent.setup();
+    const cfg = makeAggregated({
+      declarative_name: "java.executors.include",
+      type: "string",
+      default: "io.foo.*",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "executors", "include"],
+      "io.foo.*"
+    );
+  });
+
+  it("int Override seeds with the numeric default", async () => {
+    const user = userEvent.setup();
+    const cfg = makeAggregated({
+      declarative_name: "java.example.max_queue",
+      type: "int",
+      default: 100,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    expect(setValueByPath).toHaveBeenCalledWith(
+      ["instrumentation/development", "java", "example", "max_queue"],
+      100
+    );
+  });
+});
+
+describe("InstrumentationConfigField — read-only general scope", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("does not render Override / Reset, renders a jump link instead", async () => {
+    const user = userEvent.setup();
+    const onJump = vi.fn();
+    const cfg = makeAggregated({
+      declarative_name: "general.http.server.request_captured_headers",
+      type: "list",
+      default: "",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={onJump} />);
+    expect(screen.queryByRole("button", { name: /override/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /reset/i })).toBeNull();
+    await user.click(screen.getByRole("button", { name: /edit in general settings/i }));
+    expect(onJump).toHaveBeenCalledWith("general");
+  });
+});
+
+describe("InstrumentationConfigField — pills", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("renders the java.common shared pill for common scope", () => {
+    const cfg = makeAggregated({
+      declarative_name: "java.common.http.known_methods",
+      type: "list",
+      default: "",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText(/java\.common · shared/i)).toBeInTheDocument();
+  });
+
+  it("renders the experimental pill when /development appears in the path", () => {
+    const cfg = makeAggregated({
+      declarative_name: "java.aws_sdk.experimental_span_attributes/development",
+      type: "boolean",
+      default: false,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText("experimental")).toBeInTheDocument();
+  });
+
+  it("does NOT render the experimental pill for stable paths (negative case)", () => {
+    const cfg = makeAggregated({
+      declarative_name: "java.graphql.capture_query",
+      type: "boolean",
+      default: true,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.queryByText(/experimental/i)).toBeNull();
+  });
+});
+
+describe("InstrumentationConfigField — imported value type mismatch", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("renders a mismatch pill when the loaded value's runtime type does not match the registry type", () => {
+    mockState = {
+      ...baseState,
+      values: {
+        "instrumentation/development": {
+          java: { common: { http: { known_methods: "not-a-list" } } },
+        },
+      },
+    };
+    const cfg = makeAggregated({
+      declarative_name: "java.common.http.known_methods",
+      type: "list",
+      default: "GET",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText(/imported value not a list/i)).toBeInTheDocument();
+  });
+
+  it("does NOT render the mismatch pill when types match", () => {
+    mockState = {
+      ...baseState,
+      values: {
+        "instrumentation/development": {
+          java: { common: { http: { known_methods: ["GET"] } } },
+        },
+      },
+    };
+    const cfg = makeAggregated({
+      declarative_name: "java.common.http.known_methods",
+      type: "list",
+      default: "GET",
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.queryByText(/imported value/i)).toBeNull();
+  });
+});
+
+describe("InstrumentationConfigField — number blank → reset", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("clearing a number input calls removeMapEntry, not setValueByPath(null)", async () => {
+    const user = userEvent.setup();
+    mockState = {
+      ...baseState,
+      values: {
+        "instrumentation/development": { java: { example: { max_queue: 50 } } },
+      },
+    };
+    const cfg = makeAggregated({
+      declarative_name: "java.example.max_queue",
+      type: "int",
+      default: 100,
+    });
+    render(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    const input = screen.getByRole("spinbutton");
+    await user.clear(input);
+    expect(removeMapEntry).toHaveBeenCalledWith(
+      "instrumentation/development.java.example",
+      "max_queue"
+    );
+    expect(setValueByPath).not.toHaveBeenCalledWith(expect.anything(), null);
+  });
+});
+
+describe("InstrumentationConfigField — map entries grow", () => {
+  beforeEach(() => {
+    setValueByPath.mockClear();
+    removeMapEntry.mockClear();
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("clicking 'Add entry' twice produces two entries (no key collapse)", async () => {
+    const user = userEvent.setup();
+    let stored: unknown = undefined;
+    setValueByPath.mockImplementation((_p: unknown, v: unknown) => {
+      stored = v;
+      mockState = {
+        ...baseState,
+        values: {
+          "instrumentation/development": {
+            java: { common: { peer_service_mapping: v as ConfigValue } },
+          },
+        },
+      };
+    });
+    const cfg = makeAggregated({
+      declarative_name: "java.common.peer_service_mapping",
+      type: "map",
+      default: "",
+    });
+    const { rerender } = render(
+      <InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />
+    );
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    rerender(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /add entry/i }));
+    rerender(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /add entry/i }));
+    rerender(<InstrumentationConfigField config={cfg} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getAllByRole("button", { name: /remove entry/i })).toHaveLength(2);
+    void stored;
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-field.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-field.tsx
@@ -1,0 +1,432 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useRef, type JSX } from "react";
+import { Plus, RotateCcw, X } from "lucide-react";
+import type { Configuration } from "@/types/javaagent";
+import type { ConfigValue, ConfigValues } from "@/types/configuration-builder";
+import type { AggregatedConfig } from "@/lib/configurations-aggregate";
+import { parseDefault } from "@/lib/declarative-name";
+import { getByPath } from "@/lib/config-path";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { SwitchPill } from "@/components/ui/switch-pill";
+import {
+  FocusManagedInputList,
+  type FocusManagedInputListHandle,
+} from "./controls/focus-managed-input-list";
+import { INPUT_CLASS, LIST_INPUT_CLASS } from "./controls/control-styles";
+
+export interface InstrumentationConfigFieldProps {
+  config: AggregatedConfig;
+  onJumpToGeneral: (sectionKey: string) => void;
+}
+
+interface ControlRendererProps {
+  value: ConfigValue;
+  onChange: (next: ConfigValue) => void;
+  onClear: () => void;
+  ariaLabel: string;
+  disabled: boolean;
+  showAdd: boolean;
+}
+
+type ControlRenderer = (props: ControlRendererProps) => JSX.Element;
+
+function BooleanRenderer({ value, onChange, ariaLabel, disabled }: ControlRendererProps) {
+  const checked = Boolean(value);
+  return (
+    <SwitchPill
+      checked={checked}
+      onClick={() => {
+        if (disabled) return;
+        onChange(!checked);
+      }}
+      ariaLabel={ariaLabel}
+    />
+  );
+}
+
+function StringRenderer({ value, onChange, ariaLabel, disabled }: ControlRendererProps) {
+  return (
+    <input
+      type="text"
+      aria-label={ariaLabel}
+      disabled={disabled}
+      value={typeof value === "string" ? value : ""}
+      onChange={(e) => onChange(e.target.value)}
+      className={INPUT_CLASS}
+    />
+  );
+}
+
+function NumberRenderer({ value, onChange, onClear, ariaLabel, disabled }: ControlRendererProps) {
+  return (
+    <input
+      type="number"
+      aria-label={ariaLabel}
+      disabled={disabled}
+      value={typeof value === "number" ? value : ""}
+      onChange={(e) => {
+        if (e.target.value === "") {
+          onClear();
+          return;
+        }
+        const num = Number(e.target.value);
+        if (Number.isFinite(num)) onChange(num);
+      }}
+      className={INPUT_CLASS}
+    />
+  );
+}
+
+function StringListRenderer({
+  value,
+  onChange,
+  ariaLabel,
+  disabled,
+  showAdd,
+}: ControlRendererProps) {
+  const items = Array.isArray(value)
+    ? (value.filter((v) => typeof v === "string") as string[])
+    : [];
+  const addBtnRef = useRef<HTMLButtonElement>(null);
+  const handleRef = useRef<FocusManagedInputListHandle | null>(null);
+  return (
+    <div className="w-full max-w-xl">
+      <FocusManagedInputList<string>
+        label={ariaLabel}
+        items={items}
+        canRemove={!disabled}
+        onChange={(next) => onChange(next as ConfigValue[])}
+        addButtonRef={addBtnRef}
+        handleRef={handleRef}
+        renderInput={({ value: v, setValue, ariaLabel: a }) => (
+          <input
+            type="text"
+            aria-label={a}
+            value={v}
+            disabled={disabled}
+            onChange={(e) => setValue(e.target.value)}
+            className={LIST_INPUT_CLASS}
+          />
+        )}
+      />
+      {showAdd ? (
+        <button
+          ref={addBtnRef}
+          type="button"
+          onClick={() => {
+            onChange([...items, ""]);
+            handleRef.current?.notifyAdded();
+          }}
+          className="border-border/60 text-foreground hover:bg-card/80 mt-2 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+interface MapEntry {
+  key: string;
+  value: string;
+}
+
+function toEntries(value: ConfigValue): MapEntry[] {
+  if (!isPlainObject(value)) return [];
+  return Object.entries(value).map(([k, v]) => ({
+    key: k,
+    value: typeof v === "string" ? v : String(v),
+  }));
+}
+
+function fromEntries(entries: MapEntry[]): ConfigValues {
+  const out: ConfigValues = {};
+  for (const e of entries) out[e.key] = e.value;
+  return out;
+}
+
+function KeyValueMapRenderer({
+  value,
+  onChange,
+  ariaLabel,
+  disabled,
+  showAdd,
+}: ControlRendererProps) {
+  const entries = toEntries(value);
+  const update = (next: MapEntry[]) => onChange(fromEntries(next));
+  return (
+    <div className="w-full max-w-xl space-y-1.5" aria-label={ariaLabel}>
+      {entries.map((entry, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <input
+            type="text"
+            aria-label={`${ariaLabel} key ${idx}`}
+            value={entry.key}
+            disabled={disabled}
+            onChange={(e) => {
+              const next = [...entries];
+              next[idx] = { ...next[idx], key: e.target.value };
+              update(next);
+            }}
+            className={LIST_INPUT_CLASS}
+          />
+          <input
+            type="text"
+            aria-label={`${ariaLabel} value ${idx}`}
+            value={entry.value}
+            disabled={disabled}
+            onChange={(e) => {
+              const next = [...entries];
+              next[idx] = { ...next[idx], value: e.target.value };
+              update(next);
+            }}
+            className={LIST_INPUT_CLASS}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const next = entries.filter((_, i) => i !== idx);
+              update(next);
+            }}
+            disabled={disabled}
+            className="text-muted-foreground hover:text-foreground rounded-md p-1"
+            aria-label={`Remove entry ${idx}`}
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </div>
+      ))}
+      {showAdd ? (
+        <button
+          type="button"
+          onClick={() => update([...entries, { key: `new_key_${entries.length + 1}`, value: "" }])}
+          className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add entry
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+const RENDER_BY_TYPE: Record<Configuration["type"], ControlRenderer> = {
+  boolean: BooleanRenderer,
+  string: StringRenderer,
+  int: NumberRenderer,
+  double: NumberRenderer,
+  list: StringListRenderer,
+  map: KeyValueMapRenderer,
+};
+
+export function InstrumentationConfigField({
+  config,
+  onJumpToGeneral,
+}: InstrumentationConfigFieldProps): JSX.Element {
+  const { entry, scope, path } = config;
+  const declarativeName = entry.declarative_name ?? "";
+  const isReadOnly = scope === "general";
+  const isExperimental = declarativeName.includes("/development");
+
+  const { state, setValueByPath, removeMapEntry } = useConfigurationBuilder();
+  const currentValue = getByPath(state.values, path);
+  const isOverridden = currentValue !== undefined && currentValue !== null;
+  const typeMismatch = isOverridden && !valueMatchesType(currentValue, entry.type);
+
+  const parentPath = path.slice(0, -1).join(".");
+  const leafKey = String(path[path.length - 1]);
+
+  const handleOverride = () => {
+    setValueByPath(path, parseDefault(entry.type, entry.default));
+  };
+
+  const handleReset = () => {
+    removeMapEntry(parentPath, leafKey);
+  };
+
+  const handleChange = (next: ConfigValue) => {
+    setValueByPath(path, next);
+  };
+
+  const Render = RENDER_BY_TYPE[entry.type];
+
+  return (
+    <div
+      data-testid={`config-field-${declarativeName}`}
+      data-scope={scope}
+      className={fieldClass(scope)}
+    >
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-foreground font-mono text-sm">{declarativeName}</span>
+        <ScopePill scope={scope} />
+        {isExperimental ? <ExperimentalPill /> : null}
+        {typeMismatch ? <MismatchPill type={entry.type} /> : null}
+      </div>
+
+      {entry.description ? (
+        <p className="text-muted-foreground mt-1 text-xs">{entry.description}</p>
+      ) : null}
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {isReadOnly ? (
+          <Render
+            value={currentValue ?? defaultRenderValue(entry.type)}
+            onChange={() => {}}
+            onClear={() => {}}
+            ariaLabel={declarativeName}
+            disabled={true}
+            showAdd={false}
+          />
+        ) : isOverridden ? (
+          <Render
+            value={currentValue as ConfigValue}
+            onChange={handleChange}
+            onClear={handleReset}
+            ariaLabel={declarativeName}
+            disabled={false}
+            showAdd={true}
+          />
+        ) : (
+          <DefaultPreview type={entry.type} raw={entry.default} />
+        )}
+
+        {isReadOnly ? (
+          <button
+            type="button"
+            onClick={() => onJumpToGeneral("general")}
+            className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-1 text-xs"
+          >
+            Edit in General Settings ↑
+          </button>
+        ) : isOverridden ? (
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded-md p-1 text-xs"
+            aria-label={`Reset ${declarativeName}`}
+          >
+            <RotateCcw className="h-3 w-3" aria-hidden="true" />
+            Reset
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleOverride}
+            className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+            Override
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function valueMatchesType(value: ConfigValue | undefined, type: Configuration["type"]): boolean {
+  switch (type) {
+    case "boolean":
+      return typeof value === "boolean";
+    case "string":
+      return typeof value === "string";
+    case "int":
+    case "double":
+      return typeof value === "number";
+    case "list":
+      return Array.isArray(value);
+    case "map":
+      return isPlainObject(value);
+  }
+}
+
+function defaultRenderValue(type: Configuration["type"]): ConfigValue {
+  switch (type) {
+    case "boolean":
+      return false;
+    case "string":
+      return "";
+    case "int":
+    case "double":
+      return 0;
+    case "list":
+      return [];
+    case "map":
+      return {};
+  }
+}
+
+function fieldClass(scope: AggregatedConfig["scope"]): string {
+  const base = "rounded-md border border-border/60 bg-background/40 px-3 py-2";
+  if (scope === "general") return `${base} border-l-[3px] border-l-purple-400/60 opacity-90`;
+  if (scope === "common") return `${base} border-l-[3px] border-l-amber-400/60`;
+  return base;
+}
+
+function ScopePill({ scope }: { scope: AggregatedConfig["scope"] }) {
+  if (scope === "general") {
+    return (
+      <span className="inline-flex items-center rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-0.5 text-[10px] leading-none text-purple-300">
+        general · shared
+      </span>
+    );
+  }
+  if (scope === "common") {
+    return (
+      <span className="inline-flex items-center rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-[10px] leading-none text-amber-300">
+        java.common · shared
+      </span>
+    );
+  }
+  return null;
+}
+
+function ExperimentalPill() {
+  return (
+    <span className="inline-flex items-center rounded-full border border-red-400/40 bg-red-400/10 px-2 py-0.5 text-[10px] leading-none text-red-300">
+      experimental
+    </span>
+  );
+}
+
+function MismatchPill({ type }: { type: Configuration["type"] }) {
+  const article = type === "int" || type === "double" ? "a number" : `a ${type}`;
+  return (
+    <span className="inline-flex items-center rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-[10px] leading-none text-yellow-300">
+      imported value not {article}
+    </span>
+  );
+}
+
+function DefaultPreview({
+  type,
+  raw,
+}: {
+  type: Configuration["type"];
+  raw: string | boolean | number;
+}) {
+  const text = type === "list" || type === "map" ? "" : String(raw);
+  return (
+    <span className="text-muted-foreground text-xs italic">
+      default: <code className="font-mono">{text === "" ? "(empty)" : text}</code>
+    </span>
+  );
+}
+
+function isPlainObject(v: ConfigValue | undefined): v is ConfigValues {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-form.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-form.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { InstrumentationModule } from "@/types/javaagent";
+import type { ConfigurationBuilderState } from "@/types/configuration-builder";
+
+const mockState: ConfigurationBuilderState = {
+  version: "1.0.0",
+  values: {},
+  enabledSections: {},
+  validationErrors: {},
+  isDirty: false,
+};
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: mockState,
+    setValueByPath: vi.fn(),
+    removeMapEntry: vi.fn(),
+  }),
+}));
+
+import { InstrumentationConfigForm } from "./instrumentation-config-form";
+
+function makeModule(
+  coveredEntries: InstrumentationModule["coveredEntries"]
+): InstrumentationModule {
+  return { name: "graphql_java", defaultDisabled: false, coveredEntries };
+}
+
+describe("InstrumentationConfigForm", () => {
+  it("renders the empty-state copy when the module has no configurations array at all", () => {
+    const mod = makeModule([
+      { name: "graphql-java-20.0", scope: { name: "io.opentelemetry.graphql-java-20.0" } },
+    ]);
+    render(<InstrumentationConfigForm module={mod} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText(/no configurable options/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty-state copy when every config is env-var-only (no declarative_name)", () => {
+    const mod = makeModule([
+      {
+        name: "x-1",
+        scope: { name: "io.opentelemetry.x-1" },
+        configurations: [
+          { name: "otel.env.only", description: "", type: "boolean", default: false },
+        ],
+      },
+    ]);
+    render(<InstrumentationConfigForm module={mod} onJumpToGeneral={vi.fn()} />);
+    expect(screen.getByText(/no configurable options/i)).toBeInTheDocument();
+  });
+
+  it("renders one field per aggregated config in scope order", () => {
+    const mod = makeModule([
+      {
+        name: "graphql-java-20.0",
+        scope: { name: "io.opentelemetry.graphql-java-20.0" },
+        configurations: [
+          {
+            name: "owned-1",
+            declarative_name: "java.graphql.capture_query",
+            description: "owned",
+            type: "boolean",
+            default: true,
+          },
+          {
+            name: "general-1",
+            declarative_name: "general.http.server.request_captured_headers",
+            description: "general",
+            type: "list",
+            default: "",
+          },
+          {
+            name: "common-1",
+            declarative_name: "java.common.http.known_methods",
+            description: "common",
+            type: "list",
+            default: "",
+          },
+        ],
+      },
+    ]);
+    render(<InstrumentationConfigForm module={mod} onJumpToGeneral={vi.fn()} />);
+    const fields = screen.getAllByTestId(/^config-field-/);
+    expect(fields.map((el) => el.getAttribute("data-scope"))).toEqual([
+      "general",
+      "common",
+      "owned",
+    ]);
+  });
+
+  it("threads onJumpToGeneral down to fields", () => {
+    const onJump = vi.fn();
+    const mod = makeModule([
+      {
+        name: "graphql-java-20.0",
+        scope: { name: "io.opentelemetry.graphql-java-20.0" },
+        configurations: [
+          {
+            name: "general-1",
+            declarative_name: "general.http.server.request_captured_headers",
+            description: "general",
+            type: "list",
+            default: "",
+          },
+        ],
+      },
+    ]);
+    render(<InstrumentationConfigForm module={mod} onJumpToGeneral={onJump} />);
+    const jumpBtn = screen.getByRole("button", { name: /edit in general settings/i });
+    jumpBtn.click();
+    expect(onJump).toHaveBeenCalledWith("general");
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-form.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-config-form.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMemo, type JSX } from "react";
+import type { InstrumentationModule } from "@/types/javaagent";
+import { aggregateConfigurations } from "@/lib/configurations-aggregate";
+import { InstrumentationConfigField } from "./instrumentation-config-field";
+
+export interface InstrumentationConfigFormProps {
+  module: InstrumentationModule;
+  onJumpToGeneral: (sectionKey: string) => void;
+}
+
+export function InstrumentationConfigForm({
+  module: mod,
+  onJumpToGeneral,
+}: InstrumentationConfigFormProps): JSX.Element {
+  const aggregated = useMemo(() => aggregateConfigurations(mod), [mod]);
+
+  if (aggregated.length === 0) {
+    return (
+      <p className="text-muted-foreground border-border/40 bg-background/30 rounded-md border border-dashed px-3 py-3 text-xs">
+        No configurable options for this module.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {aggregated.map((cfg) => (
+        <InstrumentationConfigField
+          key={cfg.entry.declarative_name}
+          config={cfg}
+          onJumpToGeneral={onJumpToGeneral}
+        />
+      ))}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
@@ -15,162 +15,159 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { InstrumentationData, InstrumentationModule } from "@/types/javaagent";
 import { InstrumentationRow } from "./instrumentation-row";
-import type { InstrumentationData } from "@/types/javaagent";
 
-function makeInst(overrides: Partial<InstrumentationData> = {}): InstrumentationData {
+function entry(name: string, opts: Partial<InstrumentationData> = {}): InstrumentationData {
   return {
-    name: "cassandra-4.4",
-    display_name: "Cassandra Driver",
-    description: "Database client spans + metrics for the DataStax Cassandra Driver.",
-    disabled_by_default: false,
-    scope: { name: "io.opentelemetry.cassandra-4.4" },
-    ...overrides,
-  };
+    name,
+    scope: { name: `io.opentelemetry.${name}` },
+    ...opts,
+  } as InstrumentationData;
+}
+
+function moduleFixture(
+  name: string,
+  coveredEntries: InstrumentationData[],
+  defaultDisabled = false
+): InstrumentationModule {
+  return { name, defaultDisabled, coveredEntries };
 }
 
 describe("InstrumentationRow", () => {
-  it("shows 'enabled by default' pill and an Override button when not overridden and enabled-by-default", () => {
+  it("renders the module name as the primary label", () => {
     render(
       <InstrumentationRow
-        instrumentation={makeInst()}
-        override={undefined}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("cassandra", [entry("cassandra-3.0"), entry("cassandra-4.4")])}
+        status="none"
+        onAddOverride={() => {}}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
+      />
+    );
+    expect(screen.getByText("cassandra")).toBeInTheDocument();
+    expect(screen.getByText(/2 versions/)).toBeInTheDocument();
+  });
+
+  it("shows 'enabled by default' pill for default-enabled modules", () => {
+    render(
+      <InstrumentationRow
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="none"
+        onAddOverride={() => {}}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
       />
     );
     expect(screen.getByText("enabled by default")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Override Cassandra Driver/ })).toBeInTheDocument();
   });
 
-  it("shows 'disabled by default' pill when disabled_by_default is true", () => {
+  it("shows 'disabled by default' pill for default-disabled modules", () => {
     render(
       <InstrumentationRow
-        instrumentation={makeInst({
-          name: "jmx-metrics",
-          display_name: "JMX Metrics",
-          disabled_by_default: true,
-        })}
-        override={undefined}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("jmx_metrics", [entry("jmx-metrics")], true)}
+        status="none"
+        onAddOverride={() => {}}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
       />
     );
     expect(screen.getByText("disabled by default")).toBeInTheDocument();
   });
 
-  it("shows enabled toggle state and a remove button when overridden+enabled", () => {
+  it("calls onAddOverride when + Override is clicked", () => {
+    const onAdd = vi.fn();
     render(
       <InstrumentationRow
-        instrumentation={makeInst()}
-        override={{ enabled: true }}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="none"
+        onAddOverride={onAdd}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
       />
     );
-    const enabledBtn = screen.getByRole("button", { name: "Enabled" });
-    const disabledBtn = screen.getByRole("button", { name: "Disabled" });
-    expect(enabledBtn).toHaveAttribute("aria-pressed", "true");
-    expect(disabledBtn).toHaveAttribute("aria-pressed", "false");
-    expect(
-      screen.getByRole("button", { name: /Remove override for Cassandra Driver/ })
-    ).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Override cassandra/));
+    expect(onAdd).toHaveBeenCalledOnce();
   });
 
-  it("shows disabled toggle state when overridden+disabled", () => {
+  it("renders the toggle and ✕ when overridden, with correct aria-pressed", () => {
+    const onSetEnabled = vi.fn();
+    const onRemove = vi.fn();
     render(
       <InstrumentationRow
-        instrumentation={makeInst()}
-        override={{ enabled: false }}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="disabled"
+        onAddOverride={() => {}}
+        onSetEnabled={onSetEnabled}
+        onRemoveOverride={onRemove}
       />
-    );
-    expect(screen.getByRole("button", { name: "Disabled" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
     );
     expect(screen.getByRole("button", { name: "Enabled" })).toHaveAttribute(
       "aria-pressed",
       "false"
     );
+    expect(screen.getByRole("button", { name: "Disabled" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Enabled" }));
+    expect(onSetEnabled).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText(/Remove override for cassandra/));
+    expect(onRemove).toHaveBeenCalledOnce();
   });
 
-  it("renders the 'custom' badge when _is_custom is true", () => {
+  it("flips aria-pressed when status switches Disabled → Enabled", () => {
+    const onSetEnabled = vi.fn();
+    const { rerender } = render(
+      <InstrumentationRow
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="disabled"
+        onAddOverride={() => {}}
+        onSetEnabled={onSetEnabled}
+        onRemoveOverride={() => {}}
+      />
+    );
+    rerender(
+      <InstrumentationRow
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="enabled"
+        onAddOverride={() => {}}
+        onSetEnabled={onSetEnabled}
+        onRemoveOverride={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Enabled" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Disabled" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Disabled" }));
+    expect(onSetEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("renders a 'custom' badge when any covered entry has _is_custom", () => {
     render(
       <InstrumentationRow
-        instrumentation={makeInst({ name: "jmx-metrics", _is_custom: true })}
-        override={undefined}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("jmx_metrics", [entry("jmx-metrics", { _is_custom: true })], true)}
+        status="none"
+        onAddOverride={() => {}}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
       />
     );
     expect(screen.getByText("custom")).toBeInTheDocument();
   });
 
-  it("fires onAddOverride when the Override button is clicked", () => {
-    const onAddOverride = vi.fn();
+  it("does not render a 'custom' badge when no covered entry is custom", () => {
     render(
       <InstrumentationRow
-        instrumentation={makeInst()}
-        override={undefined}
-        onAddOverride={onAddOverride}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
+        module={moduleFixture("cassandra", [entry("cassandra-4.4")])}
+        status="none"
+        onAddOverride={() => {}}
+        onSetEnabled={() => {}}
+        onRemoveOverride={() => {}}
       />
     );
-    fireEvent.click(screen.getByRole("button", { name: /Override Cassandra Driver/ }));
-    expect(onAddOverride).toHaveBeenCalledTimes(1);
-  });
-
-  it("fires onSetEnabled with the new value when toggling state", () => {
-    const onSetEnabled = vi.fn();
-    render(
-      <InstrumentationRow
-        instrumentation={makeInst()}
-        override={{ enabled: true }}
-        onAddOverride={vi.fn()}
-        onSetEnabled={onSetEnabled}
-        onRemoveOverride={vi.fn()}
-      />
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Disabled" }));
-    expect(onSetEnabled).toHaveBeenCalledWith(false);
-    fireEvent.click(screen.getByRole("button", { name: "Enabled" }));
-    expect(onSetEnabled).toHaveBeenCalledWith(true);
-  });
-
-  it("fires onRemoveOverride when the remove button is clicked", () => {
-    const onRemoveOverride = vi.fn();
-    render(
-      <InstrumentationRow
-        instrumentation={makeInst()}
-        override={{ enabled: false }}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={onRemoveOverride}
-      />
-    );
-    fireEvent.click(screen.getByRole("button", { name: /Remove override for Cassandra Driver/ }));
-    expect(onRemoveOverride).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders dotted IDs verbatim without round-tripping through parsePath", () => {
-    render(
-      <InstrumentationRow
-        instrumentation={makeInst({ name: "akka-http-10.0", display_name: "Akka HTTP 10.0" })}
-        override={undefined}
-        onAddOverride={vi.fn()}
-        onSetEnabled={vi.fn()}
-        onRemoveOverride={vi.fn()}
-      />
-    );
-    expect(screen.getByText("akka-http-10.0")).toBeInTheDocument();
-    expect(screen.getByText("Akka HTTP 10.0")).toBeInTheDocument();
+    expect(screen.queryByText("custom")).toBeNull();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
@@ -15,8 +15,15 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { InstrumentationData, InstrumentationModule } from "@/types/javaagent";
 import { InstrumentationRow } from "./instrumentation-row";
+
+vi.mock("./instrumentation-config-form", () => ({
+  InstrumentationConfigForm: ({ module: m }: { module: { name: string } }) => (
+    <div data-testid={`form-stub-${m.name}`} />
+  ),
+}));
 
 function entry(name: string, opts: Partial<InstrumentationData> = {}): InstrumentationData {
   return {
@@ -34,6 +41,12 @@ function moduleFixture(
   return { name, defaultDisabled, coveredEntries };
 }
 
+const expansionDefaults = {
+  isExpanded: false,
+  onToggleExpand: vi.fn(),
+  onJumpToGeneral: vi.fn(),
+} as const;
+
 describe("InstrumentationRow", () => {
   it("renders the module name as the primary label", () => {
     render(
@@ -43,6 +56,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByText("cassandra")).toBeInTheDocument();
@@ -57,6 +71,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByText("enabled by default")).toBeInTheDocument();
@@ -70,6 +85,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByText("disabled by default")).toBeInTheDocument();
@@ -84,6 +100,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={onAdd}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     fireEvent.click(screen.getByLabelText(/Override cassandra/));
@@ -100,6 +117,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={onSetEnabled}
         onRemoveOverride={onRemove}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByRole("button", { name: "Enabled" })).toHaveAttribute(
@@ -125,6 +143,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={onSetEnabled}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     rerender(
@@ -134,6 +153,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={onSetEnabled}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByRole("button", { name: "Enabled" })).toHaveAttribute("aria-pressed", "true");
@@ -153,6 +173,7 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.getByText("custom")).toBeInTheDocument();
@@ -166,8 +187,85 @@ describe("InstrumentationRow", () => {
         onAddOverride={() => {}}
         onSetEnabled={() => {}}
         onRemoveOverride={() => {}}
+        {...expansionDefaults}
       />
     );
     expect(screen.queryByText("custom")).toBeNull();
+  });
+});
+
+describe("InstrumentationRow — expansion", () => {
+  const baseModule = {
+    name: "cassandra",
+    defaultDisabled: false,
+    coveredEntries: [{ name: "cassandra-4.4", scope: { name: "io.opentelemetry.cassandra-4.4" } }],
+  };
+
+  it("calls onToggleExpand when the toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <InstrumentationRow
+        module={baseModule}
+        status="none"
+        isExpanded={false}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+        onToggleExpand={onToggle}
+        onJumpToGeneral={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /toggle details for cassandra/i }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the config form only when expanded", () => {
+    const props = {
+      module: baseModule,
+      status: "none" as const,
+      onAddOverride: vi.fn(),
+      onSetEnabled: vi.fn(),
+      onRemoveOverride: vi.fn(),
+      onToggleExpand: vi.fn(),
+      onJumpToGeneral: vi.fn(),
+    };
+    const { rerender } = render(<InstrumentationRow {...props} isExpanded={false} />);
+    expect(screen.queryByTestId("form-stub-cassandra")).toBeNull();
+    rerender(<InstrumentationRow {...props} isExpanded={true} />);
+    expect(screen.getByTestId("form-stub-cassandra")).toBeInTheDocument();
+  });
+
+  it("exposes data-expanded and rotates the chevron icon when expanded", () => {
+    const { rerender } = render(
+      <InstrumentationRow
+        module={baseModule}
+        status="none"
+        isExpanded={false}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onJumpToGeneral={vi.fn()}
+      />
+    );
+    const row = screen.getByTestId("instrumentation-row-cassandra");
+    expect(row.getAttribute("data-expanded")).toBe("false");
+    expect(row.querySelector(".rotate-90")).toBeNull();
+
+    rerender(
+      <InstrumentationRow
+        module={baseModule}
+        status="none"
+        isExpanded={true}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onJumpToGeneral={vi.fn()}
+      />
+    );
+    expect(row.getAttribute("data-expanded")).toBe("true");
+    expect(row.querySelector(".rotate-90")).not.toBeNull();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.test.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InstrumentationRow } from "./instrumentation-row";
+import type { InstrumentationData } from "@/types/javaagent";
+
+function makeInst(overrides: Partial<InstrumentationData> = {}): InstrumentationData {
+  return {
+    name: "cassandra-4.4",
+    display_name: "Cassandra Driver",
+    description: "Database client spans + metrics for the DataStax Cassandra Driver.",
+    disabled_by_default: false,
+    scope: { name: "io.opentelemetry.cassandra-4.4" },
+    ...overrides,
+  };
+}
+
+describe("InstrumentationRow", () => {
+  it("shows 'enabled by default' pill and an Override button when not overridden and enabled-by-default", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={undefined}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    expect(screen.getByText("enabled by default")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Override Cassandra Driver/ })).toBeInTheDocument();
+  });
+
+  it("shows 'disabled by default' pill when disabled_by_default is true", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst({
+          name: "jmx-metrics",
+          display_name: "JMX Metrics",
+          disabled_by_default: true,
+        })}
+        override={undefined}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    expect(screen.getByText("disabled by default")).toBeInTheDocument();
+  });
+
+  it("shows enabled toggle state and a remove button when overridden+enabled", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={{ enabled: true }}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    const enabledBtn = screen.getByRole("button", { name: "Enabled" });
+    const disabledBtn = screen.getByRole("button", { name: "Disabled" });
+    expect(enabledBtn).toHaveAttribute("aria-pressed", "true");
+    expect(disabledBtn).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: /Remove override for Cassandra Driver/ })
+    ).toBeInTheDocument();
+  });
+
+  it("shows disabled toggle state when overridden+disabled", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={{ enabled: false }}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Disabled" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: "Enabled" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("renders the 'custom' badge when _is_custom is true", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst({ name: "jmx-metrics", _is_custom: true })}
+        override={undefined}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    expect(screen.getByText("custom")).toBeInTheDocument();
+  });
+
+  it("fires onAddOverride when the Override button is clicked", () => {
+    const onAddOverride = vi.fn();
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={undefined}
+        onAddOverride={onAddOverride}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Override Cassandra Driver/ }));
+    expect(onAddOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onSetEnabled with the new value when toggling state", () => {
+    const onSetEnabled = vi.fn();
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={{ enabled: true }}
+        onAddOverride={vi.fn()}
+        onSetEnabled={onSetEnabled}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Disabled" }));
+    expect(onSetEnabled).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByRole("button", { name: "Enabled" }));
+    expect(onSetEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("fires onRemoveOverride when the remove button is clicked", () => {
+    const onRemoveOverride = vi.fn();
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst()}
+        override={{ enabled: false }}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={onRemoveOverride}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Remove override for Cassandra Driver/ }));
+    expect(onRemoveOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders dotted IDs verbatim without round-tripping through parsePath", () => {
+    render(
+      <InstrumentationRow
+        instrumentation={makeInst({ name: "akka-http-10.0", display_name: "Akka HTTP 10.0" })}
+        override={undefined}
+        onAddOverride={vi.fn()}
+        onSetEnabled={vi.fn()}
+        onRemoveOverride={vi.fn()}
+      />
+    );
+    expect(screen.getByText("akka-http-10.0")).toBeInTheDocument();
+    expect(screen.getByText("Akka HTTP 10.0")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
@@ -17,21 +17,28 @@ import type { JSX } from "react";
 import { ChevronRight, Plus, X } from "lucide-react";
 import type { InstrumentationModule } from "@/types/javaagent";
 import type { OverrideStatus } from "@/hooks/use-override-status";
+import { InstrumentationConfigForm } from "./instrumentation-config-form";
 
 export interface InstrumentationRowProps {
   module: InstrumentationModule;
   status: OverrideStatus;
+  isExpanded: boolean;
   onAddOverride: () => void;
   onSetEnabled: (enabled: boolean) => void;
   onRemoveOverride: () => void;
+  onToggleExpand: () => void;
+  onJumpToGeneral: (sectionKey: string) => void;
 }
 
 export function InstrumentationRow({
   module,
   status,
+  isExpanded,
   onAddOverride,
   onSetEnabled,
   onRemoveOverride,
+  onToggleExpand,
+  onJumpToGeneral,
 }: InstrumentationRowProps): JSX.Element {
   const isOverridden = status !== "none";
   const overrideEnabled = status === "enabled";
@@ -54,67 +61,83 @@ export function InstrumentationRow({
   return (
     <div
       data-testid={`instrumentation-row-${module.name}`}
-      className={`flex flex-col gap-2 rounded-md border px-3 py-2 transition-colors sm:flex-row sm:items-center sm:gap-3 ${containerClass}`}
+      data-expanded={String(isExpanded)}
+      className={`rounded-md border transition-colors ${containerClass}`}
     >
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <span className="text-foreground font-mono text-sm font-medium">{module.name}</span>
-          {module.coveredEntries.length > 1 ? (
-            <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
-              {module.coveredEntries.length} versions
-            </span>
+      <div className="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="text-foreground font-mono text-sm font-medium">{module.name}</span>
+            {module.coveredEntries.length > 1 ? (
+              <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
+                {module.coveredEntries.length} versions
+              </span>
+            ) : null}
+            {module.coveredEntries.some((e) => e._is_custom === true) ? (
+              <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
+                custom
+              </span>
+            ) : null}
+          </div>
+          {description ? (
+            <p className="text-muted-foreground mt-0.5 truncate text-xs">{description}</p>
           ) : null}
-          {module.coveredEntries.some((e) => e._is_custom === true) ? (
-            <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
-              custom
-            </span>
+          {versionsCovered ? (
+            <p className="text-muted-foreground/70 mt-0.5 truncate text-[11px]">
+              covers {versionsCovered}
+            </p>
           ) : null}
         </div>
-        {description ? (
-          <p className="text-muted-foreground mt-0.5 truncate text-xs">{description}</p>
-        ) : null}
-        {versionsCovered ? (
-          <p className="text-muted-foreground/70 mt-0.5 truncate text-[11px]">
-            covers {versionsCovered}
-          </p>
-        ) : null}
-      </div>
 
-      <div className="flex items-center gap-2 sm:contents">
-        {isOverridden ? (
-          <OverrideToggle enabled={overrideEnabled} onChange={onSetEnabled} />
-        ) : (
-          <DefaultPill enabledByDefault={enabledByDefault} />
-        )}
+        <div className="flex items-center gap-2 sm:contents">
+          {isOverridden ? (
+            <OverrideToggle enabled={overrideEnabled} onChange={onSetEnabled} />
+          ) : (
+            <DefaultPill enabledByDefault={enabledByDefault} />
+          )}
 
-        {isOverridden ? (
+          {isOverridden ? (
+            <button
+              type="button"
+              aria-label={`Remove override for ${module.name}`}
+              onClick={onRemoveOverride}
+              className="text-muted-foreground hover:text-foreground rounded-md p-1"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onAddOverride}
+              aria-label={`Override ${module.name}`}
+              className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+            >
+              <Plus className="h-3 w-3" aria-hidden="true" />
+              Override
+            </button>
+          )}
+
           <button
             type="button"
-            aria-label={`Remove override for ${module.name}`}
-            onClick={onRemoveOverride}
-            className="text-muted-foreground hover:text-foreground rounded-md p-1"
+            data-row-toggle
+            aria-label={`Toggle details for ${module.name}`}
+            aria-expanded={isExpanded}
+            onClick={onToggleExpand}
+            className="text-muted-foreground/60 hover:text-foreground hidden h-5 w-5 items-center justify-center sm:inline-flex"
           >
-            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            <ChevronRight
+              className={`h-4 w-4 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+              aria-hidden="true"
+            />
           </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onAddOverride}
-            aria-label={`Override ${module.name}`}
-            className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
-          >
-            <Plus className="h-3 w-3" aria-hidden="true" />
-            Override
-          </button>
-        )}
-
-        <span
-          aria-hidden="true"
-          className="text-muted-foreground/60 hidden h-5 w-5 items-center justify-center sm:inline-flex"
-        >
-          <ChevronRight className="h-4 w-4" />
-        </span>
+        </div>
       </div>
+
+      {isExpanded ? (
+        <div className="border-border/40 border-t px-3 py-3">
+          <InstrumentationConfigForm module={module} onJumpToGeneral={onJumpToGeneral} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { JSX } from "react";
+import { ChevronRight, Plus, X } from "lucide-react";
+import type { InstrumentationData } from "@/types/javaagent";
+
+export interface InstrumentationRowProps {
+  instrumentation: InstrumentationData;
+  override: { enabled: boolean } | undefined;
+  onAddOverride: () => void;
+  onSetEnabled: (enabled: boolean) => void;
+  onRemoveOverride: () => void;
+}
+
+export function InstrumentationRow({
+  instrumentation,
+  override,
+  onAddOverride,
+  onSetEnabled,
+  onRemoveOverride,
+}: InstrumentationRowProps): JSX.Element {
+  const display = instrumentation.display_name ?? instrumentation.name;
+  const enabledByDefault = !instrumentation.disabled_by_default;
+  const isOverridden = override !== undefined;
+  const overrideEnabled = override?.enabled ?? false;
+
+  const containerClass = isOverridden
+    ? overrideEnabled
+      ? "border-primary/40 bg-primary/5"
+      : "border-red-500/40 bg-red-500/5"
+    : "border-border/60 bg-background/30 hover:bg-background/50";
+
+  return (
+    <div
+      data-testid={`instrumentation-row-${instrumentation.name}`}
+      className={`flex flex-col gap-2 rounded-md border px-3 py-2 transition-colors sm:flex-row sm:items-center sm:gap-3 ${containerClass}`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="text-foreground text-sm font-medium">{display}</span>
+          <span className="text-muted-foreground font-mono text-xs break-all">
+            {instrumentation.name}
+          </span>
+          {instrumentation._is_custom ? (
+            <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
+              custom
+            </span>
+          ) : null}
+        </div>
+        {instrumentation.description ? (
+          <p className="text-muted-foreground mt-0.5 truncate text-xs">
+            {instrumentation.description}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex items-center gap-2 sm:contents">
+        {isOverridden ? (
+          <OverrideToggle enabled={overrideEnabled} onChange={onSetEnabled} />
+        ) : (
+          <DefaultPill enabledByDefault={enabledByDefault} />
+        )}
+
+        {isOverridden ? (
+          <button
+            type="button"
+            aria-label={`Remove override for ${display}`}
+            onClick={onRemoveOverride}
+            className="text-muted-foreground hover:text-foreground rounded-md p-1"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onAddOverride}
+            aria-label={`Override ${display}`}
+            className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+            Override
+          </button>
+        )}
+
+        {/* Reserved for PR2 inline configurations[] expansion. Hidden on
+            narrow viewports because there's no body to reveal yet and it
+            takes scarce horizontal space. */}
+        <span
+          aria-hidden="true"
+          className="text-muted-foreground/60 hidden h-5 w-5 items-center justify-center sm:inline-flex"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DefaultPill({ enabledByDefault }: { enabledByDefault: boolean }) {
+  if (enabledByDefault) {
+    return (
+      <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] leading-none text-emerald-300">
+        enabled by default
+      </span>
+    );
+  }
+  return (
+    <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
+      disabled by default
+    </span>
+  );
+}
+
+function OverrideToggle({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const onClass = "bg-emerald-500/20 text-emerald-300";
+  const offClass = "bg-red-500/20 text-red-300";
+  const baseClass = "px-2 py-1 text-[11px] leading-none";
+  return (
+    <div
+      role="group"
+      aria-label="Override state"
+      className="border-border/60 inline-flex overflow-hidden rounded-md border"
+    >
+      <button
+        type="button"
+        onClick={() => onChange(true)}
+        aria-pressed={enabled}
+        className={`${baseClass} ${enabled ? onClass : "text-muted-foreground"}`}
+      >
+        Enabled
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange(false)}
+        aria-pressed={!enabled}
+        className={`${baseClass} ${!enabled ? offClass : "text-muted-foreground"}`}
+      >
+        Disabled
+      </button>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/instrumentation-row.tsx
@@ -15,27 +15,35 @@
  */
 import type { JSX } from "react";
 import { ChevronRight, Plus, X } from "lucide-react";
-import type { InstrumentationData } from "@/types/javaagent";
+import type { InstrumentationModule } from "@/types/javaagent";
+import type { OverrideStatus } from "@/hooks/use-override-status";
 
 export interface InstrumentationRowProps {
-  instrumentation: InstrumentationData;
-  override: { enabled: boolean } | undefined;
+  module: InstrumentationModule;
+  status: OverrideStatus;
   onAddOverride: () => void;
   onSetEnabled: (enabled: boolean) => void;
   onRemoveOverride: () => void;
 }
 
 export function InstrumentationRow({
-  instrumentation,
-  override,
+  module,
+  status,
   onAddOverride,
   onSetEnabled,
   onRemoveOverride,
 }: InstrumentationRowProps): JSX.Element {
-  const display = instrumentation.display_name ?? instrumentation.name;
-  const enabledByDefault = !instrumentation.disabled_by_default;
-  const isOverridden = override !== undefined;
-  const overrideEnabled = override?.enabled ?? false;
+  const isOverridden = status !== "none";
+  const overrideEnabled = status === "enabled";
+  const enabledByDefault = !module.defaultDisabled;
+
+  const description =
+    module.coveredEntries[module.coveredEntries.length - 1]?.description ?? undefined;
+  const dashedName = module.name.replace(/_/g, "-");
+  const versionsCovered = module.coveredEntries
+    .map((e) => e.name.replace(`${dashedName}-`, "").replace(dashedName, ""))
+    .filter((s) => s !== "")
+    .join(", ");
 
   const containerClass = isOverridden
     ? overrideEnabled
@@ -45,24 +53,29 @@ export function InstrumentationRow({
 
   return (
     <div
-      data-testid={`instrumentation-row-${instrumentation.name}`}
+      data-testid={`instrumentation-row-${module.name}`}
       className={`flex flex-col gap-2 rounded-md border px-3 py-2 transition-colors sm:flex-row sm:items-center sm:gap-3 ${containerClass}`}
     >
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <span className="text-foreground text-sm font-medium">{display}</span>
-          <span className="text-muted-foreground font-mono text-xs break-all">
-            {instrumentation.name}
-          </span>
-          {instrumentation._is_custom ? (
+          <span className="text-foreground font-mono text-sm font-medium">{module.name}</span>
+          {module.coveredEntries.length > 1 ? (
+            <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
+              {module.coveredEntries.length} versions
+            </span>
+          ) : null}
+          {module.coveredEntries.some((e) => e._is_custom === true) ? (
             <span className="border-border/60 text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] leading-none">
               custom
             </span>
           ) : null}
         </div>
-        {instrumentation.description ? (
-          <p className="text-muted-foreground mt-0.5 truncate text-xs">
-            {instrumentation.description}
+        {description ? (
+          <p className="text-muted-foreground mt-0.5 truncate text-xs">{description}</p>
+        ) : null}
+        {versionsCovered ? (
+          <p className="text-muted-foreground/70 mt-0.5 truncate text-[11px]">
+            covers {versionsCovered}
           </p>
         ) : null}
       </div>
@@ -77,7 +90,7 @@ export function InstrumentationRow({
         {isOverridden ? (
           <button
             type="button"
-            aria-label={`Remove override for ${display}`}
+            aria-label={`Remove override for ${module.name}`}
             onClick={onRemoveOverride}
             className="text-muted-foreground hover:text-foreground rounded-md p-1"
           >
@@ -87,7 +100,7 @@ export function InstrumentationRow({
           <button
             type="button"
             onClick={onAddOverride}
-            aria-label={`Override ${display}`}
+            aria-label={`Override ${module.name}`}
             className="border-border/60 text-foreground hover:bg-card/80 inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs"
           >
             <Plus className="h-3 w-3" aria-hidden="true" />
@@ -95,9 +108,6 @@ export function InstrumentationRow({
           </button>
         )}
 
-        {/* Reserved for PR2 inline configurations[] expansion. Hidden on
-            narrow viewports because there's no body to reveal yet and it
-            takes scarce horizontal space. */}
         <span
           aria-hidden="true"
           className="text-muted-foreground/60 hidden h-5 w-5 items-center justify-center sm:inline-flex"

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -26,9 +26,13 @@ import {
 } from "@/hooks/use-configuration-data";
 import { ConfigurationBuilderProvider } from "@/hooks/configuration-builder-provider";
 import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
-import { useVersions as useJavaAgentVersions } from "@/hooks/use-javaagent-data";
+import {
+  useVersions as useJavaAgentVersions,
+  useInstrumentations,
+} from "@/hooks/use-javaagent-data";
+import { groupByModule } from "@/lib/normalize-instrumentation";
+import { useOverriddenModules } from "@/hooks/use-overridden-modules";
 import type { GroupNode } from "@/types/configuration";
-import { getByPath } from "@/lib/config-path";
 import { hasMeaningfulLeaf } from "@/lib/state-hydrate";
 import { SchemaRenderer } from "./components/schema-renderer";
 import { PreviewCard } from "./components/preview-card";
@@ -182,15 +186,13 @@ function InstrumentationTabBody({ activeTab, schema, generalNode }: Instrumentat
 
   const { state, setEnabled } = useConfigurationBuilder();
 
-  const overrideCount = useMemo(() => {
-    const inst = getByPath(state.values, ["distribution", "javaagent", "instrumentation"]);
-    if (!inst || typeof inst !== "object" || Array.isArray(inst)) return 0;
-    const enabled = (inst as Record<string, unknown>).enabled;
-    const disabled = (inst as Record<string, unknown>).disabled;
-    const ec = Array.isArray(enabled) ? enabled.length : 0;
-    const dc = Array.isArray(disabled) ? disabled.length : 0;
-    return ec + dc;
-  }, [state.values]);
+  const instrumentationsState = useInstrumentations(javaAgentVersion);
+  const modules = useMemo(
+    () => (instrumentationsState.data ? groupByModule(instrumentationsState.data) : []),
+    [instrumentationsState.data]
+  );
+  const overriddenSet = useOverriddenModules(modules);
+  const overrideCount = overriddenSet.size;
 
   const devSection = state.values[INSTRUMENTATION_DEV_KEY];
   const hasDevContent = useMemo(() => hasMeaningfulLeaf(devSection), [devSection]);
@@ -229,9 +231,12 @@ function InstrumentationTabBody({ activeTab, schema, generalNode }: Instrumentat
       <div ref={sectionsContainerRef} className="space-y-4">
         <InstrumentationGeneralCard generalNode={generalNode} />
         <InstrumentationBrowser
-          version={javaAgentVersion}
+          instrumentations={instrumentationsState.data}
+          loading={instrumentationsState.loading}
+          error={instrumentationsState.error}
           search={search}
           statusFilter={statusFilter}
+          onJumpToGeneral={scrollToSection}
         />
       </div>
       <PreviewCard schema={schema} />

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { BackButton } from "@/components/ui/back-button";
 import { PageContainer } from "@/components/layout/page-container";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
@@ -24,21 +25,50 @@ import {
   useConfigStarter,
 } from "@/hooks/use-configuration-data";
 import { ConfigurationBuilderProvider } from "@/hooks/configuration-builder-provider";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+import { useVersions as useJavaAgentVersions } from "@/hooks/use-javaagent-data";
 import type { GroupNode } from "@/types/configuration";
+import { getByPath } from "@/lib/config-path";
+import { hasMeaningfulLeaf } from "@/lib/state-hydrate";
 import { SchemaRenderer } from "./components/schema-renderer";
 import { PreviewCard } from "./components/preview-card";
-import { ConfigurationTocSidebar, type TocSection } from "./components/configuration-toc-sidebar";
+import {
+  ConfigurationTocSidebar,
+  type StatusFilter,
+  type TocSection,
+} from "./components/configuration-toc-sidebar";
 import {
   GeneralSectionCard,
   GENERAL_SECTION_KEY,
   GENERAL_SECTION_LABEL,
 } from "./components/general-section-card";
+import { InstrumentationBrowser } from "./components/instrumentation-browser";
+import { SectionCardShell } from "./components/section-card-shell";
 import { useActiveSection } from "./hooks/use-active-section";
 
-const HIDDEN_SDK_KEYS = new Set(["file_format", "instrumentation/development", "distribution"]);
+// Per-tab hidden-keys: SDK hides the entire `instrumentation/development`
+// subtree (the Instrumentation tab owns it), while the Instrumentation tab
+// only hides the always-synthetic top-level keys. The Instrumentation tab
+// renders explicitly-picked subtrees, so HIDDEN_KEYS_BY_TAB.instrumentation
+// is currently advisory; it pins the asymmetry for future call sites.
+const HIDDEN_KEYS_BY_TAB = {
+  sdk: new Set(["file_format", "instrumentation/development", "distribution"]),
+  instrumentation: new Set(["file_format", "distribution"]),
+};
+const SDK_HIDDEN_KEYS = HIDDEN_KEYS_BY_TAB.sdk;
 
-const SDK_GRID = "grid grid-cols-1 gap-6 lg:grid-cols-[256px_1fr_420px] lg:gap-7";
-const INSTRUMENTATION_GRID = "grid grid-cols-1 gap-6 lg:grid-cols-[256px_1fr] lg:gap-7";
+// Both tabs render a 3-column shell (sidebar / content / live preview).
+// `minmax(0, 1fr)` overrides Grid's default `min-width: auto` on the middle
+// track so long descendant content (instrumentation IDs, code spans) cannot
+// expand the column past its 1fr share. Without it the third column gets
+// pushed off-screen.
+const BUILDER_GRID = "grid grid-cols-1 gap-6 lg:grid-cols-[256px_minmax(0,1fr)_420px] lg:gap-7";
+
+const INSTRUMENTATION_DEV_KEY = "instrumentation/development";
+const GENERAL_SUBKEY = "general";
+const INSTRUMENTATIONS_SECTION_KEY = "instrumentations";
+const INSTRUMENTATIONS_SECTION_LABEL = "Instrumentations";
+const GENERAL_SETTINGS_LABEL = "General settings";
 
 interface SdkTabContentProps {
   schema: GroupNode;
@@ -49,7 +79,7 @@ interface SdkTabContentProps {
 
 function SdkTabContent({ schema, starter, version, activeTab }: SdkTabContentProps) {
   const { groupChildren, leafChildren } = useMemo(() => {
-    const visible = schema.children.filter((c) => !HIDDEN_SDK_KEYS.has(c.key));
+    const visible = schema.children.filter((c) => !SDK_HIDDEN_KEYS.has(c.key));
     return {
       groupChildren: visible.filter((c) => c.controlType === "group"),
       leafChildren: visible.filter((c) => c.controlType !== "group"),
@@ -69,7 +99,7 @@ function SdkTabContent({ schema, starter, version, activeTab }: SdkTabContentPro
 
   return (
     <ConfigurationBuilderProvider key={version} schema={schema} version={version} starter={starter}>
-      <div className={SDK_GRID}>
+      <div className={BUILDER_GRID}>
         <ConfigurationTocSidebar
           activeTab={activeTab}
           sections={tocSections}
@@ -88,19 +118,182 @@ function SdkTabContent({ schema, starter, version, activeTab }: SdkTabContentPro
   );
 }
 
-function InstrumentationTabContent({ activeTab }: { activeTab: string }) {
+interface InstrumentationTabContentProps {
+  schema: GroupNode;
+  starter: ReturnType<typeof useConfigStarter>["data"];
+  version: string;
+  activeTab: string;
+}
+
+function InstrumentationTabContent({
+  schema,
+  starter,
+  version,
+  activeTab,
+}: InstrumentationTabContentProps) {
+  const generalNode = useMemo<GroupNode | null>(() => {
+    const devNode = schema.children.find((c) => c.key === INSTRUMENTATION_DEV_KEY);
+    if (!devNode || devNode.controlType !== "group") return null;
+    const general = devNode.children.find((c) => c.key === GENERAL_SUBKEY);
+    if (!general || general.controlType !== "group") return null;
+    return general;
+  }, [schema]);
+
   return (
-    <div className={INSTRUMENTATION_GRID}>
+    <ConfigurationBuilderProvider key={version} schema={schema} version={version} starter={starter}>
+      <InstrumentationTabBody activeTab={activeTab} schema={schema} generalNode={generalNode} />
+    </ConfigurationBuilderProvider>
+  );
+}
+
+interface InstrumentationTabBodyProps {
+  activeTab: string;
+  schema: GroupNode;
+  generalNode: GroupNode | null;
+}
+
+function InstrumentationTabBody({ activeTab, schema, generalNode }: InstrumentationTabBodyProps) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+  // The page-level `version` is the SDK config schema version (e.g. "1.0.0").
+  // The instrumentation registry is keyed by Java agent version (e.g. "2.27.0")
+  // — a separate namespace. Resolve the latest agent version for the browser
+  // until a unified version picker lands as a follow-up.
+  const javaAgentVersions = useJavaAgentVersions();
+  const javaAgentVersion = useMemo(
+    () =>
+      javaAgentVersions.data?.versions.find((v) => v.is_latest)?.version ??
+      javaAgentVersions.data?.versions[0]?.version ??
+      "",
+    [javaAgentVersions.data]
+  );
+
+  const tocSections: TocSection[] = useMemo(
+    () => [
+      { key: GENERAL_SECTION_KEY, label: GENERAL_SETTINGS_LABEL },
+      { key: INSTRUMENTATIONS_SECTION_KEY, label: INSTRUMENTATIONS_SECTION_LABEL },
+    ],
+    []
+  );
+  const sectionKeys = useMemo(() => tocSections.map((s) => s.key), [tocSections]);
+  const sectionsContainerRef = useRef<HTMLDivElement>(null);
+  const { activeKey, scrollToSection } = useActiveSection(sectionKeys, sectionsContainerRef);
+
+  // The SDK schema declares `instrumentation/development.java` as a
+  // `key_value_map` (opaque), so the values-tree shape we write under
+  // `["instrumentation/development", "java", <id>, "enabled"]` round-trips
+  // verbatim through the YAML generator without a schema lookup.
+  const { state, setEnabled } = useConfigurationBuilder();
+
+  const overrideCount = useMemo(() => {
+    const javaTree = getByPath(state.values, [INSTRUMENTATION_DEV_KEY, "java"]);
+    if (!javaTree || typeof javaTree !== "object" || Array.isArray(javaTree)) return 0;
+    let count = 0;
+    for (const entry of Object.values(javaTree as Record<string, unknown>)) {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        !Array.isArray(entry) &&
+        "enabled" in (entry as Record<string, unknown>)
+      ) {
+        count += 1;
+      }
+    }
+    return count;
+  }, [state.values]);
+
+  // Mirror `enabledSections["instrumentation/development"]` to whether any
+  // user content exists under it. The General card and the Instrumentation
+  // browser both write through values-tree paths rooted at this section,
+  // but neither owns a SwitchPill that would otherwise drive the flag.
+  // The predicate has to walk the tree (not just check the section's
+  // top-level presence) because removeMapEntry can leave behind an empty
+  // map like `{ java: {} }` that should not keep the section enabled.
+  const devSection = state.values[INSTRUMENTATION_DEV_KEY];
+  const hasDevContent = useMemo(() => hasMeaningfulLeaf(devSection), [devSection]);
+  const isDevEnabled = state.enabledSections[INSTRUMENTATION_DEV_KEY] === true;
+  useEffect(() => {
+    if (hasDevContent !== isDevEnabled) {
+      setEnabled(INSTRUMENTATION_DEV_KEY, hasDevContent);
+    }
+  }, [hasDevContent, isDevEnabled, setEnabled]);
+
+  return (
+    <div className={BUILDER_GRID}>
       <ConfigurationTocSidebar
         activeTab={activeTab}
-        sections={[]}
-        activeKey={null}
-        onSectionClick={() => {}}
+        sections={tocSections}
+        activeKey={activeKey}
+        onSectionClick={scrollToSection}
+        search={search}
+        onSearchChange={setSearch}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        overrideCount={overrideCount}
       />
-      <div className="border-border/40 bg-card/30 text-muted-foreground rounded-xl border p-8 text-center text-sm">
-        Instrumentation browser is coming in a follow-up PR (#250).
+      <div ref={sectionsContainerRef} className="space-y-4">
+        <InstrumentationGeneralCard generalNode={generalNode} />
+        <InstrumentationBrowser
+          version={javaAgentVersion}
+          search={search}
+          statusFilter={statusFilter}
+        />
       </div>
+      <PreviewCard schema={schema} />
     </div>
+  );
+}
+
+interface InstrumentationGeneralCardProps {
+  generalNode: GroupNode | null;
+}
+
+// Renders the `instrumentation/development.general.*` subtree as a card
+// without the depth=0 SwitchPill that GroupRenderer would otherwise add.
+// The SwitchPill is wrong here because its enable key is the GroupNode's
+// own `key` (`general`), not the top-level YAML section
+// `instrumentation/development` — see InstrumentationTabBody's effect for
+// the section-flag mirroring.
+function InstrumentationGeneralCard({ generalNode }: InstrumentationGeneralCardProps): JSX.Element {
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <SectionCardShell sectionKey={GENERAL_SECTION_KEY}>
+      <header className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={
+            expanded ? `Collapse ${GENERAL_SETTINGS_LABEL}` : `Expand ${GENERAL_SETTINGS_LABEL}`
+          }
+          onClick={() => setExpanded((e) => !e)}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+        <h3 className="text-foreground truncate text-base font-semibold">
+          {GENERAL_SETTINGS_LABEL}
+        </h3>
+      </header>
+      {expanded ? (
+        generalNode ? (
+          <div className="space-y-3">
+            {generalNode.children.map((child) => (
+              <SchemaRenderer
+                key={child.key}
+                node={child}
+                depth={1}
+                path={`${INSTRUMENTATION_DEV_KEY}.${GENERAL_SUBKEY}.${child.key}`}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            The schema for this version does not expose general instrumentation settings.
+          </p>
+        )
+      ) : null}
+    </SectionCardShell>
   );
 }
 
@@ -162,7 +355,20 @@ export function ConfigurationBuilderPage() {
             ) : null}
           </TabsContent>
           <TabsContent value="instrumentation">
-            <InstrumentationTabContent activeTab={activeTab} />
+            {schema.loading || starter.loading ? (
+              <p className="text-muted-foreground mt-4 text-sm">Loading schema…</p>
+            ) : schema.error || !root ? (
+              <p className="mt-4 text-sm text-red-400">Failed to load schema.</p>
+            ) : starter.error ? (
+              <p className="mt-4 text-sm text-red-400">Failed to load starter template.</p>
+            ) : version ? (
+              <InstrumentationTabContent
+                schema={root}
+                starter={starter.data}
+                version={version}
+                activeTab={activeTab}
+              />
+            ) : null}
           </TabsContent>
         </Tabs>
       </div>

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -180,36 +180,18 @@ function InstrumentationTabBody({ activeTab, schema, generalNode }: Instrumentat
   const sectionsContainerRef = useRef<HTMLDivElement>(null);
   const { activeKey, scrollToSection } = useActiveSection(sectionKeys, sectionsContainerRef);
 
-  // The SDK schema declares `instrumentation/development.java` as a
-  // `key_value_map` (opaque), so the values-tree shape we write under
-  // `["instrumentation/development", "java", <id>, "enabled"]` round-trips
-  // verbatim through the YAML generator without a schema lookup.
   const { state, setEnabled } = useConfigurationBuilder();
 
   const overrideCount = useMemo(() => {
-    const javaTree = getByPath(state.values, [INSTRUMENTATION_DEV_KEY, "java"]);
-    if (!javaTree || typeof javaTree !== "object" || Array.isArray(javaTree)) return 0;
-    let count = 0;
-    for (const entry of Object.values(javaTree as Record<string, unknown>)) {
-      if (
-        entry !== null &&
-        typeof entry === "object" &&
-        !Array.isArray(entry) &&
-        "enabled" in (entry as Record<string, unknown>)
-      ) {
-        count += 1;
-      }
-    }
-    return count;
+    const inst = getByPath(state.values, ["distribution", "javaagent", "instrumentation"]);
+    if (!inst || typeof inst !== "object" || Array.isArray(inst)) return 0;
+    const enabled = (inst as Record<string, unknown>).enabled;
+    const disabled = (inst as Record<string, unknown>).disabled;
+    const ec = Array.isArray(enabled) ? enabled.length : 0;
+    const dc = Array.isArray(disabled) ? disabled.length : 0;
+    return ec + dc;
   }, [state.values]);
 
-  // Mirror `enabledSections["instrumentation/development"]` to whether any
-  // user content exists under it. The General card and the Instrumentation
-  // browser both write through values-tree paths rooted at this section,
-  // but neither owns a SwitchPill that would otherwise drive the flag.
-  // The predicate has to walk the tree (not just check the section's
-  // top-level presence) because removeMapEntry can leave behind an empty
-  // map like `{ java: {} }` that should not keep the section enabled.
   const devSection = state.values[INSTRUMENTATION_DEV_KEY];
   const hasDevContent = useMemo(() => hasMeaningfulLeaf(devSection), [devSection]);
   const isDevEnabled = state.enabledSections[INSTRUMENTATION_DEV_KEY] === true;
@@ -218,6 +200,18 @@ function InstrumentationTabBody({ activeTab, schema, generalNode }: Instrumentat
       setEnabled(INSTRUMENTATION_DEV_KEY, hasDevContent);
     }
   }, [hasDevContent, isDevEnabled, setEnabled]);
+
+  const distributionSection = state.values["distribution"];
+  const hasDistributionContent = useMemo(
+    () => hasMeaningfulLeaf(distributionSection),
+    [distributionSection]
+  );
+  const isDistributionEnabled = state.enabledSections["distribution"] === true;
+  useEffect(() => {
+    if (hasDistributionContent !== isDistributionEnabled) {
+      setEnabled("distribution", hasDistributionContent);
+    }
+  }, [hasDistributionContent, isDistributionEnabled, setEnabled]);
 
   return (
     <div className={BUILDER_GRID}>

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
@@ -336,4 +336,91 @@ describe("configurationBuilderReducer", () => {
       expect(next.isDirty).toBe(false);
     });
   });
+
+  describe("SET_OVERRIDE", () => {
+    const PATH = ["distribution", "javaagent", "instrumentation"] as const;
+    const initial = { ...INITIAL_STATE, version: "1.0.0" };
+
+    function getInst(s: ReturnType<typeof configurationBuilderReducer>) {
+      let cur: unknown = s.values;
+      for (const seg of PATH) {
+        if (!cur || typeof cur !== "object") return undefined;
+        cur = (cur as Record<string, unknown>)[seg];
+      }
+      return cur as { enabled?: string[]; disabled?: string[] } | undefined;
+    }
+
+    it("adds a module to disabled[] sorted alphabetically", () => {
+      let s = configurationBuilderReducer(initial, {
+        type: "SET_OVERRIDE",
+        module: "kafka_clients",
+        status: "disabled",
+      });
+      s = configurationBuilderReducer(s, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "disabled",
+      });
+      expect(getInst(s)?.disabled).toEqual(["cassandra", "kafka_clients"]);
+      expect(getInst(s)?.enabled).toBeUndefined();
+    });
+
+    it("moves a module between arrays atomically (no duplicates)", () => {
+      let s = configurationBuilderReducer(initial, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "disabled",
+      });
+      s = configurationBuilderReducer(s, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "enabled",
+      });
+      expect(getInst(s)?.disabled).toBeUndefined();
+      expect(getInst(s)?.enabled).toEqual(["cassandra"]);
+    });
+
+    it("removes a module from both arrays when status is none", () => {
+      let s = configurationBuilderReducer(initial, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "disabled",
+      });
+      s = configurationBuilderReducer(s, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "none",
+      });
+      expect(s.values["distribution"]).toBeUndefined();
+    });
+
+    it("recovers from corrupt initial state (module in both arrays)", () => {
+      const corrupt = {
+        ...initial,
+        values: {
+          distribution: {
+            javaagent: {
+              instrumentation: { enabled: ["cassandra"], disabled: ["cassandra"] },
+            },
+          },
+        },
+      };
+      const s = configurationBuilderReducer(corrupt, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "disabled",
+      });
+      expect(getInst(s)?.enabled).toBeUndefined();
+      expect(getInst(s)?.disabled).toEqual(["cassandra"]);
+    });
+
+    it("sets isDirty", () => {
+      const s = configurationBuilderReducer(initial, {
+        type: "SET_OVERRIDE",
+        module: "cassandra",
+        status: "disabled",
+      });
+      expect(s.isDirty).toBe(true);
+    });
+  });
 });

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
@@ -171,6 +171,41 @@ export function configurationBuilderReducer(
       return { ...state, values: newValues, enabledSections: newEnabled, isDirty: true };
     }
 
+    case "SET_OVERRIDE": {
+      const path = ["distribution", "javaagent", "instrumentation"];
+      const current = getByPath(state.values, path);
+      const inst = isPlainObject(current) ? current : {};
+      const enabledArr = Array.isArray(inst.enabled) ? (inst.enabled as string[]) : [];
+      const disabledArr = Array.isArray(inst.disabled) ? (inst.disabled as string[]) : [];
+
+      const remainingEnabled = enabledArr.filter((m) => m !== action.module);
+      const remainingDisabled = disabledArr.filter((m) => m !== action.module);
+
+      let nextEnabled = remainingEnabled;
+      let nextDisabled = remainingDisabled;
+      if (action.status === "enabled") {
+        nextEnabled = [...remainingEnabled, action.module].sort();
+      } else if (action.status === "disabled") {
+        nextDisabled = [...remainingDisabled, action.module].sort();
+      }
+
+      if (nextEnabled.length === 0 && nextDisabled.length === 0) {
+        const { distribution: _omit, ...rest } = state.values;
+        void _omit;
+        return { ...state, values: rest, isDirty: true };
+      }
+
+      const newInstrumentation: ConfigValues = {};
+      if (nextEnabled.length > 0) newInstrumentation.enabled = nextEnabled;
+      if (nextDisabled.length > 0) newInstrumentation.disabled = nextDisabled;
+
+      return {
+        ...state,
+        values: setByPath(state.values, path, newInstrumentation),
+        isDirty: true,
+      };
+    }
+
     default:
       return state;
   }

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
@@ -24,7 +24,7 @@ import type {
   TextInputNode,
 } from "@/types/configuration";
 
-const STORAGE_KEY = "otel-config-builder-state-v1";
+const STORAGE_KEY = "otel-config-builder-state-v2";
 
 const mockSchema: GroupNode = {
   controlType: "group",
@@ -109,6 +109,18 @@ describe("useConfigurationBuilderState", () => {
     // through parsePath: that would split "cassandra-4.4" into "cassandra-4"
     // and "4" as separate segments.
     expect(development.java["cassandra-4"]).toBeUndefined();
+  });
+
+  it("setOverride dispatches SET_OVERRIDE and round-trips through state", () => {
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
+    act(() => {
+      result.current.setOverride("cassandra", "disabled");
+    });
+    const distribution = result.current.state.values["distribution"] as Record<
+      string,
+      Record<string, Record<string, unknown>>
+    >;
+    expect(distribution.javaagent.instrumentation.disabled).toEqual(["cassandra"]);
   });
 
   it("should enable a section with defaults", () => {

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.test.ts
@@ -83,6 +83,34 @@ describe("useConfigurationBuilderState", () => {
     expect(result.current.state.isDirty).toBe(true);
   });
 
+  it("setValueByPath writes the value at the array-form path", () => {
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
+    act(() => {
+      result.current.setValueByPath(["file_format"], "1.0");
+    });
+    expect(result.current.state.values.file_format).toBe("1.0");
+    expect(result.current.state.isDirty).toBe(true);
+  });
+
+  it("setValueByPath preserves dotted segments instead of splitting them", () => {
+    const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
+    act(() => {
+      result.current.setValueByPath(
+        ["instrumentation/development", "java", "cassandra-4.4", "enabled"],
+        true
+      );
+    });
+    const development = result.current.state.values["instrumentation/development"] as Record<
+      string,
+      Record<string, Record<string, unknown>>
+    >;
+    expect(development.java["cassandra-4.4"].enabled).toBe(true);
+    // Guard against future regressions where someone routes setValueByPath
+    // through parsePath: that would split "cassandra-4.4" into "cassandra-4"
+    // and "4" as separate segments.
+    expect(development.java["cassandra-4"]).toBeUndefined();
+  });
+
   it("should enable a section with defaults", () => {
     const { result } = renderHook(() => useConfigurationBuilderState(mockSchema, "1.0.0", null));
     act(() => {

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.ts
@@ -33,6 +33,7 @@ import type {
   ConfigValue,
   ConfigValues,
   ConfigurationBuilderState,
+  Path,
   ValidationResult,
 } from "@/types/configuration-builder";
 import { configurationBuilderReducer } from "./configuration-builder-reducer";
@@ -59,6 +60,7 @@ export interface ConfigurationBuilderStateContextValue {
 
 export interface ConfigurationBuilderActionsContextValue {
   setValue: (path: string, value: ConfigValue) => void;
+  setValueByPath: (path: Path, value: ConfigValue) => void;
   setEnabled: (section: string, enabled: boolean) => void;
   selectPlugin: (path: string, pluginKey: string) => void;
   addListItem: (path: string) => void;
@@ -153,6 +155,11 @@ export function useConfigurationBuilderState(
 
   const setValue = useCallback((path: string, value: ConfigValue) => {
     dispatch({ type: "SET_VALUE", path: parsePath(path), value });
+  }, []);
+
+  // Array-form sibling of setValue, for paths whose segments may contain dots.
+  const setValueByPath = useCallback((path: Path, value: ConfigValue) => {
+    dispatch({ type: "SET_VALUE", path, value });
   }, []);
 
   const setEnabled = useCallback((section: string, enabled: boolean) => {
@@ -283,6 +290,7 @@ export function useConfigurationBuilderState(
   const actions = useMemo(
     () => ({
       setValue,
+      setValueByPath,
       setEnabled,
       selectPlugin,
       addListItem,

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.ts
@@ -52,7 +52,7 @@ import {
   validateAll as validateAllNodes,
 } from "@/lib/config-validation";
 
-const STORAGE_KEY = "otel-config-builder-state-v1";
+const STORAGE_KEY = "otel-config-builder-state-v2";
 
 export interface ConfigurationBuilderStateContextValue {
   state: ConfigurationBuilderState;
@@ -61,6 +61,7 @@ export interface ConfigurationBuilderStateContextValue {
 export interface ConfigurationBuilderActionsContextValue {
   setValue: (path: string, value: ConfigValue) => void;
   setValueByPath: (path: Path, value: ConfigValue) => void;
+  setOverride: (module: string, status: "enabled" | "disabled" | "none") => void;
   setEnabled: (section: string, enabled: boolean) => void;
   selectPlugin: (path: string, pluginKey: string) => void;
   addListItem: (path: string) => void;
@@ -160,6 +161,10 @@ export function useConfigurationBuilderState(
   // Array-form sibling of setValue, for paths whose segments may contain dots.
   const setValueByPath = useCallback((path: Path, value: ConfigValue) => {
     dispatch({ type: "SET_VALUE", path, value });
+  }, []);
+
+  const setOverride = useCallback((module: string, status: "enabled" | "disabled" | "none") => {
+    dispatch({ type: "SET_OVERRIDE", module, status });
   }, []);
 
   const setEnabled = useCallback((section: string, enabled: boolean) => {
@@ -291,6 +296,7 @@ export function useConfigurationBuilderState(
     () => ({
       setValue,
       setValueByPath,
+      setOverride,
       setEnabled,
       selectPlugin,
       addListItem,

--- a/ecosystem-explorer/src/hooks/use-overridden-modules.test.ts
+++ b/ecosystem-explorer/src/hooks/use-overridden-modules.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ConfigurationBuilderState } from "@/types/configuration-builder";
+import type { InstrumentationModule } from "@/types/javaagent";
+
+let mockState: ConfigurationBuilderState;
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({ state: mockState }),
+}));
+
+import { useOverriddenModules } from "./use-overridden-modules";
+
+const baseState: ConfigurationBuilderState = {
+  version: "1.0.0",
+  values: {},
+  enabledSections: {},
+  validationErrors: {},
+  isDirty: false,
+};
+
+function makeModule(name: string, declarativeNames: string[]): InstrumentationModule {
+  return {
+    name,
+    defaultDisabled: false,
+    coveredEntries: [
+      {
+        name: `${name}-x`,
+        scope: { name: `io.opentelemetry.${name}` },
+        configurations: declarativeNames.map((d) => ({
+          name: "otel.x",
+          declarative_name: d,
+          description: "",
+          type: "boolean",
+          default: false,
+        })),
+      },
+    ],
+  };
+}
+
+describe("useOverriddenModules", () => {
+  beforeEach(() => {
+    mockState = { ...baseState, values: {} };
+  });
+
+  it("returns empty set when no overrides exist", () => {
+    const { result } = renderHook(() => useOverriddenModules([]));
+    expect(result.current.size).toBe(0);
+  });
+
+  it("includes modules in the enabled and disabled lists", () => {
+    mockState.values = {
+      distribution: {
+        javaagent: {
+          instrumentation: {
+            enabled: ["tomcat", "spring_webmvc"],
+            disabled: ["armeria_grpc"],
+          },
+        },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([]));
+    expect([...result.current].sort()).toEqual(["armeria_grpc", "spring_webmvc", "tomcat"]);
+  });
+
+  it("flags a module by its name when an owned-scope path has a meaningful leaf", () => {
+    const cassandra = makeModule("cassandra", ["java.cassandra.query_sanitization.enabled"]);
+    mockState.values = {
+      "instrumentation/development": {
+        java: { cassandra: { query_sanitization: { enabled: false } } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([cassandra]));
+    expect([...result.current]).toEqual(["cassandra"]);
+  });
+
+  it("flags kafka_clients when java.kafka.* has a meaningful leaf — names diverge from declarative segments", () => {
+    const kafkaClients = makeModule("kafka_clients", ["java.kafka.producer_propagation.enabled"]);
+    mockState.values = {
+      "instrumentation/development": {
+        java: { kafka: { producer_propagation: { enabled: false } } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([kafkaClients]));
+    expect([...result.current]).toEqual(["kafka_clients"]);
+  });
+
+  it("ignores java.common writes — shared scope flags no row", () => {
+    const akkaHttp = makeModule("akka_http", ["java.common.http.known_methods"]);
+    mockState.values = {
+      "instrumentation/development": {
+        java: { common: { http: { known_methods: ["GET"] } } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([akkaHttp]));
+    expect(result.current.size).toBe(0);
+  });
+
+  it("ignores general.* writes — shared scope flags no row", () => {
+    const akkaHttp = makeModule("akka_http", ["general.http.server.request_captured_headers"]);
+    mockState.values = {
+      "instrumentation/development": {
+        general: { http: { server: { request_captured_headers: ["X-Foo"] } } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([akkaHttp]));
+    expect(result.current.size).toBe(0);
+  });
+
+  it("ignores empty subtrees left behind by removeMapEntry", () => {
+    const cassandra = makeModule("cassandra", ["java.cassandra.query_sanitization.enabled"]);
+    mockState.values = {
+      "instrumentation/development": {
+        java: { cassandra: { query_sanitization: {} } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([cassandra]));
+    expect(result.current.size).toBe(0);
+  });
+
+  it("unions enabled-state and config-level overrides", () => {
+    const cassandra = makeModule("cassandra", ["java.cassandra.query_sanitization.enabled"]);
+    mockState.values = {
+      distribution: {
+        javaagent: { instrumentation: { enabled: ["tomcat"] } },
+      },
+      "instrumentation/development": {
+        java: { cassandra: { query_sanitization: { enabled: false } } },
+      },
+    };
+    const { result } = renderHook(() => useOverriddenModules([cassandra]));
+    expect([...result.current].sort()).toEqual(["cassandra", "tomcat"]);
+  });
+
+  it("does not flag a module whose owned paths are absent from values", () => {
+    const cassandra = makeModule("cassandra", ["java.cassandra.query_sanitization.enabled"]);
+    mockState.values = {
+      "instrumentation/development": { java: { graphql: { capture_query: true } } },
+    };
+    const { result } = renderHook(() => useOverriddenModules([cassandra]));
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/ecosystem-explorer/src/hooks/use-overridden-modules.ts
+++ b/ecosystem-explorer/src/hooks/use-overridden-modules.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMemo } from "react";
+import type { InstrumentationModule } from "@/types/javaagent";
+import { getByPath } from "@/lib/config-path";
+import { hasMeaningfulLeaf } from "@/lib/state-hydrate";
+import { aggregateConfigurations } from "@/lib/configurations-aggregate";
+import { useConfigurationBuilder } from "./use-configuration-builder";
+
+const ENABLED_PATH = ["distribution", "javaagent", "instrumentation"] as const;
+
+export function useOverriddenModules(modules: InstrumentationModule[]): Set<string> {
+  const { state } = useConfigurationBuilder();
+  return useMemo(() => {
+    const result = new Set<string>();
+
+    const enabledSection = getByPath(state.values, [...ENABLED_PATH]);
+    if (enabledSection && typeof enabledSection === "object" && !Array.isArray(enabledSection)) {
+      for (const key of ["enabled", "disabled"] as const) {
+        const list = (enabledSection as Record<string, unknown>)[key];
+        if (Array.isArray(list)) {
+          for (const m of list) {
+            if (typeof m === "string") result.add(m);
+          }
+        }
+      }
+    }
+
+    for (const module of modules) {
+      const aggregated = aggregateConfigurations(module);
+      for (const { scope, path } of aggregated) {
+        if (scope !== "owned") continue;
+        const v = getByPath(state.values, path);
+        if (hasMeaningfulLeaf(v)) {
+          result.add(module.name);
+          break;
+        }
+      }
+    }
+
+    return result;
+  }, [state.values, modules]);
+}

--- a/ecosystem-explorer/src/hooks/use-override-status.test.ts
+++ b/ecosystem-explorer/src/hooks/use-override-status.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useConfigurationBuilder } from "./use-configuration-builder";
+import { useOverrideStatus, useOverrideStatusMap } from "./use-override-status";
+
+vi.mock("./use-configuration-builder");
+
+const mocked = vi.mocked(useConfigurationBuilder);
+
+function fakeBuilderState(
+  enabled: string[] = [],
+  disabled: string[] = []
+): ReturnType<typeof useConfigurationBuilder> {
+  return {
+    state: {
+      version: "1.0.0",
+      values: {
+        distribution: {
+          javaagent: {
+            instrumentation: {
+              ...(enabled.length > 0 ? { enabled } : {}),
+              ...(disabled.length > 0 ? { disabled } : {}),
+            },
+          },
+        },
+      },
+      enabledSections: {},
+      validationErrors: {},
+      isDirty: false,
+      listItemIds: {},
+    },
+  } as unknown as ReturnType<typeof useConfigurationBuilder>;
+}
+
+describe("useOverrideStatusMap", () => {
+  beforeEach(() => mocked.mockReset());
+
+  it("returns an empty map when there are no overrides", () => {
+    mocked.mockReturnValue(fakeBuilderState());
+    const { result } = renderHook(() => useOverrideStatusMap());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("maps each module name to its status", () => {
+    mocked.mockReturnValue(fakeBuilderState(["jmx_metrics"], ["cassandra", "kafka_clients"]));
+    const { result } = renderHook(() => useOverrideStatusMap());
+    expect(result.current.get("cassandra")).toBe("disabled");
+    expect(result.current.get("jmx_metrics")).toBe("enabled");
+    expect(result.current.get("kafka_clients")).toBe("disabled");
+    expect(result.current.size).toBe(3);
+  });
+});
+
+describe("useOverrideStatus", () => {
+  beforeEach(() => mocked.mockReset());
+
+  it("returns 'none' for an unknown module", () => {
+    mocked.mockReturnValue(fakeBuilderState());
+    const { result } = renderHook(() => useOverrideStatus("cassandra"));
+    expect(result.current).toBe("none");
+  });
+
+  it("returns 'enabled' / 'disabled' as appropriate", () => {
+    mocked.mockReturnValue(fakeBuilderState(["jmx_metrics"], ["cassandra"]));
+    expect(renderHook(() => useOverrideStatus("cassandra")).result.current).toBe("disabled");
+    expect(renderHook(() => useOverrideStatus("jmx_metrics")).result.current).toBe("enabled");
+    expect(renderHook(() => useOverrideStatus("foo")).result.current).toBe("none");
+  });
+});
+
+describe("useOverrideStatusMap memoization", () => {
+  beforeEach(() => mocked.mockReset());
+
+  it("returns the same Map reference across re-renders when state.values is unchanged", () => {
+    mocked.mockReturnValue(fakeBuilderState(["jmx_metrics"], ["cassandra"]));
+    const { result, rerender } = renderHook(() => useOverrideStatusMap());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/ecosystem-explorer/src/hooks/use-override-status.ts
+++ b/ecosystem-explorer/src/hooks/use-override-status.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMemo } from "react";
+import { getByPath } from "@/lib/config-path";
+import { useConfigurationBuilder } from "./use-configuration-builder";
+
+export type OverrideStatus = "enabled" | "disabled" | "none";
+
+const PATH = ["distribution", "javaagent", "instrumentation"] as const;
+
+export function useOverrideStatusMap(): Map<string, "enabled" | "disabled"> {
+  const { state } = useConfigurationBuilder();
+  return useMemo(() => {
+    const inst = getByPath(state.values, [...PATH]);
+    const map = new Map<string, "enabled" | "disabled">();
+    if (!inst || typeof inst !== "object" || Array.isArray(inst)) return map;
+    const enabled = (inst as Record<string, unknown>).enabled;
+    const disabled = (inst as Record<string, unknown>).disabled;
+    if (Array.isArray(enabled)) {
+      for (const m of enabled) if (typeof m === "string") map.set(m, "enabled");
+    }
+    if (Array.isArray(disabled)) {
+      for (const m of disabled) if (typeof m === "string") map.set(m, "disabled");
+    }
+    return map;
+  }, [state.values]);
+}
+
+export function useOverrideStatus(module: string): OverrideStatus {
+  return useOverrideStatusMap().get(module) ?? "none";
+}

--- a/ecosystem-explorer/src/lib/configurations-aggregate.test.ts
+++ b/ecosystem-explorer/src/lib/configurations-aggregate.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import type { InstrumentationData, InstrumentationModule } from "@/types/javaagent";
+import { aggregateConfigurations } from "./configurations-aggregate";
+
+function makeEntry(
+  name: string,
+  configs: InstrumentationData["configurations"]
+): InstrumentationData {
+  return {
+    name,
+    scope: { name: `io.opentelemetry.${name}` },
+    configurations: configs,
+  };
+}
+
+function makeModule(name: string, coveredEntries: InstrumentationData[]): InstrumentationModule {
+  return { name, defaultDisabled: false, coveredEntries };
+}
+
+describe("aggregateConfigurations", () => {
+  it("returns empty array when no covered entry has configurations", () => {
+    const mod = makeModule("akka_actor", [makeEntry("akka-actor-2.3", undefined)]);
+    expect(aggregateConfigurations(mod)).toEqual([]);
+  });
+
+  it("drops entries without declarative_name", () => {
+    const mod = makeModule("akka_http", [
+      makeEntry("akka-http-10.0", [
+        {
+          name: "otel.instrumentation.http.no-declarative",
+          description: "env-var only",
+          type: "boolean",
+          default: false,
+        },
+        {
+          name: "otel.instrumentation.http.known-methods",
+          declarative_name: "java.common.http.known_methods",
+          description: "Recognized methods",
+          type: "list",
+          default: "GET,POST",
+        },
+      ]),
+    ]);
+    const out = aggregateConfigurations(mod);
+    expect(out).toHaveLength(1);
+    expect(out[0].entry.declarative_name).toBe("java.common.http.known_methods");
+  });
+
+  it("dedupes by declarative_name, preferring the latest covered version", () => {
+    const mod = makeModule("cassandra", [
+      makeEntry("cassandra-3.0", [
+        {
+          name: "otel.x",
+          declarative_name: "java.common.db.query_sanitization.enabled",
+          description: "older description",
+          type: "boolean",
+          default: true,
+        },
+      ]),
+      makeEntry("cassandra-4.4", [
+        {
+          name: "otel.x",
+          declarative_name: "java.common.db.query_sanitization.enabled",
+          description: "newer description",
+          type: "boolean",
+          default: true,
+        },
+      ]),
+    ]);
+    const out = aggregateConfigurations(mod);
+    expect(out).toHaveLength(1);
+    expect(out[0].entry.description).toBe("newer description");
+  });
+
+  it("orders general first, then java.common, then owned", () => {
+    const mod = makeModule("graphql_java", [
+      makeEntry("graphql-java-20.0", [
+        {
+          name: "owned-1",
+          declarative_name: "java.graphql.capture_query",
+          description: "",
+          type: "boolean",
+          default: true,
+        },
+        {
+          name: "general-1",
+          declarative_name: "general.http.server.request_captured_headers",
+          description: "",
+          type: "list",
+          default: "",
+        },
+        {
+          name: "common-1",
+          declarative_name: "java.common.http.known_methods",
+          description: "",
+          type: "list",
+          default: "",
+        },
+      ]),
+    ]);
+    const out = aggregateConfigurations(mod);
+    expect(out.map((c) => c.scope)).toEqual(["general", "common", "owned"]);
+  });
+
+  it("populates path from declarative_name", () => {
+    const mod = makeModule("graphql_java", [
+      makeEntry("graphql-java-20.0", [
+        {
+          name: "owned-1",
+          declarative_name: "java.graphql.capture_query",
+          description: "",
+          type: "boolean",
+          default: true,
+        },
+      ]),
+    ]);
+    const out = aggregateConfigurations(mod);
+    expect(out[0].path).toEqual([
+      "instrumentation/development",
+      "java",
+      "graphql",
+      "capture_query",
+    ]);
+  });
+});

--- a/ecosystem-explorer/src/lib/configurations-aggregate.ts
+++ b/ecosystem-explorer/src/lib/configurations-aggregate.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Configuration, InstrumentationModule } from "@/types/javaagent";
+import type { Path } from "@/types/configuration-builder";
+import { classifyScope, toValuePath, type DeclarativeScope } from "./declarative-name";
+
+export interface AggregatedConfig {
+  entry: Configuration;
+  scope: DeclarativeScope;
+  path: Path;
+}
+
+const SCOPE_ORDER: Record<DeclarativeScope, number> = {
+  general: 0,
+  common: 1,
+  owned: 2,
+};
+
+export function aggregateConfigurations(module: InstrumentationModule): AggregatedConfig[] {
+  const byDeclarative = new Map<string, Configuration>();
+  for (const covered of module.coveredEntries) {
+    if (!covered.configurations) continue;
+    for (const cfg of covered.configurations) {
+      if (!cfg.declarative_name) continue;
+      byDeclarative.set(cfg.declarative_name, cfg);
+    }
+  }
+
+  const aggregated: AggregatedConfig[] = [];
+  for (const [declarativeName, entry] of byDeclarative) {
+    aggregated.push({
+      entry,
+      scope: classifyScope(declarativeName),
+      path: toValuePath(declarativeName),
+    });
+  }
+
+  aggregated.sort((a, b) => {
+    const byScope = SCOPE_ORDER[a.scope] - SCOPE_ORDER[b.scope];
+    if (byScope !== 0) return byScope;
+    return (a.entry.declarative_name ?? "").localeCompare(b.entry.declarative_name ?? "");
+  });
+
+  return aggregated;
+}

--- a/ecosystem-explorer/src/lib/declarative-name.test.ts
+++ b/ecosystem-explorer/src/lib/declarative-name.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { classifyScope, toValuePath, parseDefault } from "./declarative-name";
+
+describe("classifyScope", () => {
+  it("returns 'general' for a name leading with general.", () => {
+    expect(classifyScope("general.http.server.request_captured_headers")).toBe("general");
+  });
+
+  it("returns 'common' for a name leading with java.common.", () => {
+    expect(classifyScope("java.common.http.known_methods")).toBe("common");
+  });
+
+  it("returns 'owned' for any other java.<id>.* name", () => {
+    expect(classifyScope("java.cassandra.query_sanitization.enabled")).toBe("owned");
+    expect(classifyScope("java.graphql.capture_query")).toBe("owned");
+  });
+
+  it("returns 'owned' as a safe default for unexpected shapes", () => {
+    expect(classifyScope("")).toBe("owned");
+    expect(classifyScope("nodots")).toBe("owned");
+  });
+});
+
+describe("toValuePath", () => {
+  it("prepends instrumentation/development and splits on dots", () => {
+    expect(toValuePath("java.cassandra.query_sanitization.enabled")).toEqual([
+      "instrumentation/development",
+      "java",
+      "cassandra",
+      "query_sanitization",
+      "enabled",
+    ]);
+  });
+
+  it("preserves /development inside a single segment when at the leaf", () => {
+    expect(toValuePath("java.aws_sdk.experimental_span_attributes/development")).toEqual([
+      "instrumentation/development",
+      "java",
+      "aws_sdk",
+      "experimental_span_attributes/development",
+    ]);
+  });
+
+  it("preserves /development as a single mid-path segment", () => {
+    expect(toValuePath("java.common.controller_telemetry/development.enabled")).toEqual([
+      "instrumentation/development",
+      "java",
+      "common",
+      "controller_telemetry/development",
+      "enabled",
+    ]);
+  });
+
+  it("handles general.* paths the same way", () => {
+    expect(toValuePath("general.http.server.request_captured_headers")).toEqual([
+      "instrumentation/development",
+      "general",
+      "http",
+      "server",
+      "request_captured_headers",
+    ]);
+  });
+});
+
+describe("parseDefault", () => {
+  it("returns the boolean as-is", () => {
+    expect(parseDefault("boolean", true)).toBe(true);
+    expect(parseDefault("boolean", false)).toBe(false);
+  });
+
+  it("returns strings unchanged", () => {
+    expect(parseDefault("string", "hello")).toBe("hello");
+    expect(parseDefault("string", "")).toBe("");
+  });
+
+  it("coerces int / double via Number", () => {
+    expect(parseDefault("int", 5000)).toBe(5000);
+    expect(parseDefault("int", "5000")).toBe(5000);
+    expect(parseDefault("double", "1.5")).toBe(1.5);
+  });
+
+  it("splits CSV defaults for list", () => {
+    expect(parseDefault("list", "CONNECT,DELETE,GET")).toEqual(["CONNECT", "DELETE", "GET"]);
+  });
+
+  it("treats empty-string list default as an empty array", () => {
+    expect(parseDefault("list", "")).toEqual([]);
+  });
+
+  it("returns an empty object for map default", () => {
+    expect(parseDefault("map", "")).toEqual({});
+  });
+
+  it("trims whitespace inside list CSV", () => {
+    expect(parseDefault("list", "A, B ,C")).toEqual(["A", "B", "C"]);
+  });
+});

--- a/ecosystem-explorer/src/lib/declarative-name.ts
+++ b/ecosystem-explorer/src/lib/declarative-name.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Configuration } from "@/types/javaagent";
+import type { ConfigValue, Path } from "@/types/configuration-builder";
+
+export type DeclarativeScope = "general" | "common" | "owned";
+
+const ROOT_SECTION = "instrumentation/development";
+
+export function classifyScope(declarativeName: string): DeclarativeScope {
+  if (declarativeName.startsWith("general.")) return "general";
+  if (declarativeName.startsWith("java.common.")) return "common";
+  return "owned";
+}
+
+export function toValuePath(declarativeName: string): Path {
+  return [ROOT_SECTION, ...declarativeName.split(".")];
+}
+
+export function parseDefault(
+  type: Configuration["type"],
+  raw: string | boolean | number
+): ConfigValue {
+  switch (type) {
+    case "boolean":
+      return Boolean(raw);
+    case "int":
+    case "double":
+      return Number(raw);
+    case "string":
+      return typeof raw === "string" ? raw : String(raw);
+    case "list":
+      if (typeof raw !== "string" || raw === "") return [];
+      return raw.split(",").map((item) => item.trim());
+    case "map":
+      return {};
+  }
+}

--- a/ecosystem-explorer/src/lib/normalize-instrumentation.test.ts
+++ b/ecosystem-explorer/src/lib/normalize-instrumentation.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { InstrumentationData } from "@/types/javaagent";
+import { groupByModule, normalizeRegistryName } from "./normalize-instrumentation";
+
+const REGISTRY_DIR = "public/data/javaagent/instrumentations";
+
+function makeEntry(
+  overrides: Partial<InstrumentationData> & { name: string }
+): InstrumentationData {
+  return {
+    scope: { name: `io.opentelemetry.${overrides.name}` },
+    ...overrides,
+  } as InstrumentationData;
+}
+
+describe("normalizeRegistryName", () => {
+  it("strips a trailing -N.N version suffix", () => {
+    expect(normalizeRegistryName("cassandra-4.4")).toBe("cassandra");
+    expect(normalizeRegistryName("akka-http-10.0")).toBe("akka_http");
+    expect(normalizeRegistryName("kafka-clients-0.11")).toBe("kafka_clients");
+  });
+
+  it("strips a trailing -N (no minor) version suffix", () => {
+    expect(normalizeRegistryName("foo-3")).toBe("foo");
+  });
+
+  it("strips a trailing -N.N.N version suffix", () => {
+    expect(normalizeRegistryName("foo-1.2.3")).toBe("foo");
+  });
+
+  it("keeps names without a trailing version suffix", () => {
+    expect(normalizeRegistryName("jmx-metrics")).toBe("jmx_metrics");
+    expect(normalizeRegistryName("methods")).toBe("methods");
+  });
+
+  it("preserves modules that share a parent dir but are distinct", () => {
+    expect(normalizeRegistryName("armeria-1.3")).toBe("armeria");
+    expect(normalizeRegistryName("armeria-grpc-1.14")).toBe("armeria_grpc");
+  });
+
+  it("replaces dots in embedded version markers (jaxrs/jaxws style)", () => {
+    expect(normalizeRegistryName("jaxrs-2.0-annotations")).toBe("jaxrs_2_0_annotations");
+    expect(normalizeRegistryName("jaxrs-2.0-cxf-3.2")).toBe("jaxrs_2_0_cxf");
+    expect(normalizeRegistryName("jaxrs-3.0-annotations")).toBe("jaxrs_3_0_annotations");
+    expect(normalizeRegistryName("jaxws-2.0-axis2-1.6")).toBe("jaxws_2_0_axis2");
+  });
+});
+
+describe("groupByModule", () => {
+  it("groups entries with the same normalized name", () => {
+    const entries = [
+      makeEntry({ name: "cassandra-3.0" }),
+      makeEntry({ name: "cassandra-4.0" }),
+      makeEntry({ name: "cassandra-4.4" }),
+    ];
+    const modules = groupByModule(entries);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].name).toBe("cassandra");
+    expect(modules[0].coveredEntries.map((e) => e.name)).toEqual([
+      "cassandra-3.0",
+      "cassandra-4.0",
+      "cassandra-4.4",
+    ]);
+  });
+
+  it("aggregates defaultDisabled with `every`", () => {
+    const allDisabled = groupByModule([
+      makeEntry({ name: "jmx-metrics", disabled_by_default: true }),
+    ]);
+    expect(allDisabled[0].defaultDisabled).toBe(true);
+
+    const allEnabled = groupByModule([makeEntry({ name: "cassandra-4.4" })]);
+    expect(allEnabled[0].defaultDisabled).toBe(false);
+
+    const mixed = groupByModule([
+      makeEntry({ name: "x-1.0", disabled_by_default: true }),
+      makeEntry({ name: "x-2.0", disabled_by_default: false }),
+    ]);
+    expect(mixed[0].defaultDisabled).toBe(false);
+  });
+
+  it("sorts modules alphabetically and entries within a module", () => {
+    const entries = [
+      makeEntry({ name: "zookeeper-3.0" }),
+      makeEntry({ name: "armeria-1.3" }),
+      makeEntry({ name: "cassandra-4.4" }),
+      makeEntry({ name: "cassandra-3.0" }),
+    ];
+    const modules = groupByModule(entries);
+    expect(modules.map((m) => m.name)).toEqual(["armeria", "cassandra", "zookeeper"]);
+    expect(modules[1].coveredEntries.map((e) => e.name)).toEqual([
+      "cassandra-3.0",
+      "cassandra-4.4",
+    ]);
+  });
+});
+
+describe("snapshot: full registry", () => {
+  function loadAllEntries(): InstrumentationData[] {
+    const entries: InstrumentationData[] = [];
+    for (const dir of readdirSync(REGISTRY_DIR)) {
+      const dirPath = join(REGISTRY_DIR, dir);
+      if (!statSync(dirPath).isDirectory()) continue;
+      const files = readdirSync(dirPath)
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => ({ f, mtime: statSync(join(dirPath, f)).mtimeMs }))
+        .sort((a, b) => b.mtime - a.mtime);
+      if (files.length === 0) continue;
+      const data = JSON.parse(readFileSync(join(dirPath, files[0].f), "utf8"));
+      entries.push(data);
+    }
+    return entries;
+  }
+
+  it("produces a stable partition with valid module names", () => {
+    const entries = loadAllEntries();
+    expect(entries.length).toBeGreaterThanOrEqual(250);
+    const modules = groupByModule(entries);
+    expect(modules.length).toBeGreaterThanOrEqual(170);
+    expect(modules.length).toBeLessThan(entries.length);
+
+    const totalCovered = modules.reduce((sum, m) => sum + m.coveredEntries.length, 0);
+    expect(totalCovered).toBe(entries.length);
+
+    for (const m of modules) {
+      expect(m.name).toMatch(/^[a-z][a-z0-9_]*$/);
+      const flags = new Set(m.coveredEntries.map((e) => e.disabled_by_default === true));
+      expect(flags.size, `module ${m.name} has mixed disabled_by_default`).toBe(1);
+    }
+  });
+});

--- a/ecosystem-explorer/src/lib/normalize-instrumentation.ts
+++ b/ecosystem-explorer/src/lib/normalize-instrumentation.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { InstrumentationData, InstrumentationModule } from "@/types/javaagent";
+
+const VERSION_SUFFIX_RE = /-\d+(?:\.\d+)*$/;
+
+export function normalizeRegistryName(name: string): string {
+  return name.replace(VERSION_SUFFIX_RE, "").replace(/[-.]/g, "_");
+}
+
+export function groupByModule(entries: InstrumentationData[]): InstrumentationModule[] {
+  const buckets = new Map<string, InstrumentationData[]>();
+  for (const entry of entries) {
+    const key = normalizeRegistryName(entry.name);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+    }
+    bucket.push(entry);
+  }
+
+  const modules: InstrumentationModule[] = [];
+  for (const [name, bucket] of buckets) {
+    const coveredEntries = [...bucket].sort((a, b) => a.name.localeCompare(b.name));
+    const defaultDisabled = coveredEntries.every((e) => e.disabled_by_default === true);
+    modules.push({ name, defaultDisabled, coveredEntries });
+  }
+  modules.sort((a, b) => a.name.localeCompare(b.name));
+  return modules;
+}

--- a/ecosystem-explorer/src/lib/state-hydrate.test.ts
+++ b/ecosystem-explorer/src/lib/state-hydrate.test.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { hasUserValues, hydrateStarterState } from "./state-hydrate";
+import { hasMeaningfulLeaf, hasUserValues, hydrateStarterState } from "./state-hydrate";
 import type { ConfigStarter } from "@/types/configuration";
+import type { ConfigValue } from "@/types/configuration-builder";
 
 describe("hasUserValues", () => {
   it("returns false for undefined and null", () => {
@@ -29,6 +30,38 @@ describe("hasUserValues", () => {
     expect(hasUserValues(false)).toBe(true);
     expect(hasUserValues({})).toBe(true);
     expect(hasUserValues([])).toBe(true);
+  });
+});
+
+describe("hasMeaningfulLeaf", () => {
+  it("returns false for undefined, null, and empty string", () => {
+    expect(hasMeaningfulLeaf(undefined)).toBe(false);
+    expect(hasMeaningfulLeaf(null)).toBe(false);
+    expect(hasMeaningfulLeaf("")).toBe(false);
+  });
+  it("returns true for primitives that carry content", () => {
+    expect(hasMeaningfulLeaf("x")).toBe(true);
+    expect(hasMeaningfulLeaf(0)).toBe(true);
+    expect(hasMeaningfulLeaf(false)).toBe(true);
+  });
+  it("returns false for empty containers and containers of only-empty leaves", () => {
+    expect(hasMeaningfulLeaf({})).toBe(false);
+    expect(hasMeaningfulLeaf([])).toBe(false);
+    // Cast through `unknown` because ConfigValue's record type forbids
+    // `undefined` entries, but we want to assert the predicate's runtime
+    // behavior against the stale shape that JSON-parsed state can carry.
+    expect(hasMeaningfulLeaf({ a: undefined, b: null, c: "" } as unknown as ConfigValue)).toBe(
+      false
+    );
+    expect(
+      hasMeaningfulLeaf({ java: { "cassandra-4.4": undefined } } as unknown as ConfigValue)
+    ).toBe(false);
+    expect(hasMeaningfulLeaf({ java: {} })).toBe(false);
+  });
+  it("returns true when any leaf is meaningful", () => {
+    expect(hasMeaningfulLeaf({ general: { service_name: "x" } })).toBe(true);
+    expect(hasMeaningfulLeaf({ java: { "cassandra-4.4": { enabled: false } } })).toBe(true);
+    expect(hasMeaningfulLeaf([null, "", { a: "x" }])).toBe(true);
   });
 });
 

--- a/ecosystem-explorer/src/lib/state-hydrate.ts
+++ b/ecosystem-explorer/src/lib/state-hydrate.ts
@@ -21,6 +21,22 @@ export function hasUserValues(current: ConfigValue | undefined): boolean {
   return current !== undefined && current !== null;
 }
 
+// Recursive sibling of hasUserValues: walks objects/arrays and returns true
+// only when at least one leaf carries actual content. Treats undefined, null,
+// and empty string as empty (matching yaml-generator's stripEmpties). Use
+// this when "the section/key is empty after edits" matters — e.g. mirroring
+// values-tree presence to enabledSections.
+export function hasMeaningfulLeaf(value: ConfigValue | undefined): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (Array.isArray(value)) {
+    return value.some((v) => hasMeaningfulLeaf(v));
+  }
+  if (typeof value === "object") {
+    return Object.values(value).some((v) => hasMeaningfulLeaf(v));
+  }
+  return true;
+}
+
 export function hydrateStarterState(
   version: string,
   starter: ConfigStarter | null

--- a/ecosystem-explorer/src/types/configuration-builder.ts
+++ b/ecosystem-explorer/src/types/configuration-builder.ts
@@ -55,4 +55,5 @@ export type ConfigurationBuilderAction =
   | { type: "LOAD_STATE"; state: ConfigurationBuilderState }
   | { type: "SET_VALIDATION_ERRORS"; errors: Record<string, string> }
   | { type: "SET_FIELD_ERROR"; path: string; error: string | null }
-  | { type: "ENABLE_ALL_SECTIONS"; defaultsBySection: Record<string, ConfigValues> };
+  | { type: "ENABLE_ALL_SECTIONS"; defaultsBySection: Record<string, ConfigValues> }
+  | { type: "SET_OVERRIDE"; module: string; status: "enabled" | "disabled" | "none" };

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -145,3 +145,9 @@ export interface TelemetryDiffResult {
   metrics: MetricDiff[];
   spans: SpanDiff[];
 }
+
+export interface InstrumentationModule {
+  name: string;
+  defaultDisabled: boolean;
+  coveredEntries: InstrumentationData[];
+}


### PR DESCRIPTION
First of two PRs for #250. Replaces the Instrumentation tab placeholder in the Configuration Builder.

Users can:
- Search and browse the Java instrumentations for the current agent version. Search matches name and description.
- Edit cross-cutting `instrumentation/development.general.*` settings via the existing schema renderer.
- Override a specific instrumentation's enabled state. Output emits only the diff from the agent default.

Reuses the SDK tab's 3-column shell, sidebar, and `PreviewCard`. The sidebar gains a search input and an Overridden filter that appears once there's at least one override. Two new components carry the new behavior: `InstrumentationBrowser` and `InstrumentationRow`.

Small fixes that landed alongside:
- `setValueByPath` on `useConfigurationBuilder`: array-form sibling of `setValue` so paths whose segments contain dots (e.g. `cassandra-4.4`) reach the reducer without going through `parsePath`.
- `BUILDER_GRID` switched to `minmax(0, 1fr)` for the middle column. Long instrumentation IDs were expanding the column past 1fr and pushing the `PreviewCard` off-screen.
- Section-flag mirroring uses a new `hasMeaningfulLeaf` helper from `state-hydrate` so empty-but-non-null subtrees don't keep the section enabled in the YAML.

Out of scope, follow-ups:
- Per-instrumentation \`configurations[]\` form.
- Bulk actions (Override all visible / Clear overrides).
- Multi-version override preservation across version switch.
- Category filter chips.