### PR TITLE
Fix: prevent crash in ConfigurationCard when description is undefined

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -76,7 +76,7 @@ export function ConfigurationCard({ config, format }: ConfigurationCardProps) {
         </div>
 
         <p className="text-muted-foreground text-sm leading-relaxed">
-          {renderWithInlineCode(config.description)}
+          {config.description && renderWithInlineCode(config.description)}
         </p>
 
         <div className="border-border/30 bg-muted/30 flex items-start gap-2 rounded-lg border p-3">


### PR DESCRIPTION
### SUMMARY

Fixes a crash in **ConfigurationCard** when a config item has no `description`. Adds a simple null check before calling `renderWithInlineCode`, keeping it consistent with existing checks in the file.

**File:**

* `ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx`

---

### FIX

The issue occurs because `renderWithInlineCode` assumes it always receives a string and calls `.split()`, but in some cases `config.description` is `undefined` due to incomplete runtime data. This PR adds a guard to ensure the function is only called when `description` exists, preventing the crash. The change follows the same defensive pattern already used for `config.default`, making it consistent and low-risk.

---

### CHECKLIST

* [x] Prevents crash when `description` is missing
* [x] No API or type changes
* [x] Follows existing code patterns
* [x] Small, safe change

---

###  VERIFICATION

* Ran app locally
* Tested config **with and without** `description`
* No crashes, no console errors
* Existing behavior unchanged
