### PR TITLE
fix: avoid empty description rendering and make configuration.description optional

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -75,7 +75,7 @@ export function ConfigurationCard({ config, format }: ConfigurationCardProps) {
           </div>
         </div>
 
-        {config.description && (
+        {config.description?.trim() && (
           <p className="text-muted-foreground text-sm leading-relaxed">
             {renderWithInlineCode(config.description)}
           </p>

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -75,9 +75,11 @@ export function ConfigurationCard({ config, format }: ConfigurationCardProps) {
           </div>
         </div>
 
-        <p className="text-muted-foreground text-sm leading-relaxed">
-          {config.description && renderWithInlineCode(config.description)}
-        </p>
+        {config.description && (
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            {renderWithInlineCode(config.description)}
+          </p>
+        )}
 
         <div className="border-border/30 bg-muted/30 flex items-start gap-2 rounded-lg border p-3">
           <span className="text-muted-foreground shrink-0 text-xs font-medium">Default:</span>

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -56,7 +56,7 @@ export interface InstrumentationScope {
 export interface Configuration {
   name: string;
   declarative_name?: string;
-  description?: string;
+  description: string;
   type: "boolean" | "string" | "list" | "map" | "int" | "double";
   default: string | boolean | number;
   example?: string[];

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -56,7 +56,7 @@ export interface InstrumentationScope {
 export interface Configuration {
   name: string;
   declarative_name?: string;
-  description: string;
+  description?: string;
   type: "boolean" | "string" | "list" | "map" | "int" | "double";
   default: string | boolean | number;
   example?: string[];


### PR DESCRIPTION
## SUMMARY

Fixes extra spacing in `ConfigurationCard` caused by rendering an empty `<p>` when `description` is missing, and updates the type to reflect that `description` isn’t always present.

---

## FIX

Updated `ConfigurationCard` to render the `<p>` only when `config.description` exists, avoiding empty elements in the UI. Also changed the TypeScript type from `description: string` to `description?: string` so it matches real data and enforces proper null checks.

---

## CHECKLIST

* [x] No empty `<p>` rendered
* [x] Type updated to optional
* [x] Consistent with other components
* [x] No breaking changes

---

## VERIFICATION

Open the Configuration tab and check items without a description — they should no longer show extra spacing.
