### PR TITLE
Exclude registry from markdown lint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -7,6 +7,7 @@ ignores:
   - "**/tmp_repos/**"
   - "**/node_modules/**"
   - ".claude/**"
+  - "ecosystem-registry/**"
 
 config:
   default: true


### PR DESCRIPTION
related to #350 where the new readmes are faliing linter