### PR TITLE
fix: correct isCustom flag and deduplicate allIds

### DIFF
--- a/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
@@ -232,6 +232,27 @@ describe("javaagent-data", () => {
         javaagentData.loadInstrumentation("non-existent", "2.10.0", mockVersionManifest)
       ).rejects.toThrow('Instrumentation "non-existent" not found in version 2.10.0');
     });
+
+    it("should prefer library hash and mark as non-custom when id exists in both maps", async () => {
+      const overlapManifest: VersionManifest = {
+        version: "2.10.0",
+        instrumentations: { "akka-actor": "library-hash-abc" },
+        custom_instrumentations: { "akka-actor": "custom-hash-xyz" },
+      };
+
+      vi.spyOn(idbCache, "getCached").mockImplementation(async (key: string) => {
+        if (key === "instrumentation-library-hash-abc") return mockInstrumentationData;
+        return null;
+      });
+
+      const result = await javaagentData.loadInstrumentation(
+        "akka-actor",
+        "2.10.0",
+        overlapManifest
+      );
+
+      expect(result._is_custom).toBe(false);
+    });
   });
 
   describe("loadAllInstrumentations", () => {
@@ -295,6 +316,25 @@ describe("javaagent-data", () => {
       const result = await javaagentData.loadAllInstrumentations("2.10.0");
 
       expect(result).toEqual([]);
+    });
+
+    it("should return one entry and mark as non-custom when id exists in both maps", async () => {
+      const overlapManifest: VersionManifest = {
+        version: "2.10.0",
+        instrumentations: { "akka-actor": "library-hash-abc" },
+        custom_instrumentations: { "akka-actor": "custom-hash-xyz" },
+      };
+
+      vi.spyOn(idbCache, "getCached").mockImplementation(async (key: string) => {
+        if (key === "manifest-2.10.0") return overlapManifest;
+        if (key === "instrumentation-library-hash-abc") return mockInstrumentationData;
+        return null;
+      });
+
+      const result = await javaagentData.loadAllInstrumentations("2.10.0");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]._is_custom).toBe(false);
     });
   });
 });

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -49,7 +49,7 @@ export async function loadInstrumentation(
   const libraryHash = resolvedManifest.instrumentations[id];
   const customHash = resolvedManifest.custom_instrumentations?.[id];
   const hash = libraryHash || customHash;
-  const isCustom = !!customHash;
+  const isCustom = !libraryHash && !!customHash;
 
   if (!hash) {
     throw new Error(`Instrumentation "${id}" not found in version ${version}`);
@@ -71,7 +71,7 @@ export async function loadAllInstrumentations(version: string): Promise<Instrume
   const libraryIds = Object.keys(manifest.instrumentations || {});
   const customIds = Object.keys(manifest.custom_instrumentations || {});
 
-  const allIds = [...libraryIds, ...customIds];
+  const allIds = [...new Set([...libraryIds, ...customIds])];
 
   return Promise.all(
     allIds.map(async (id) => {

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -48,6 +48,7 @@ export async function loadInstrumentation(
 
   const libraryHash = resolvedManifest.instrumentations[id];
   const customHash = resolvedManifest.custom_instrumentations?.[id];
+  // Library takes precedence; isCustom mirrors that same precedence rule.
   const hash = libraryHash || customHash;
   const isCustom = !libraryHash && !!customHash;
 


### PR DESCRIPTION
### SUMMARY

Fixes a logic issue where instrumentations were incorrectly marked as custom and, in some cases, loaded twice when the same ID existed in both `instrumentations` and `custom_instrumentations`. This led to duplicate entries and misleading `_is_custom` flags in the UI.

---

### FIX

This change aligns `_is_custom` with the actual hash resolution logic. Since `libraryHash` takes precedence over `customHash`, `_is_custom` is now set to `true` only when a library hash is not available and the custom hash is used. In addition, the combined list of instrumentation IDs is now deduplicated using a `Set`, ensuring that overlapping IDs are processed only once. Together, these fixes ensure both correct labeling and elimination of duplicate results without altering existing behavior for valid cases.

---

### CHECKLIST

* [x] Minimal and focused fix
* [x] No API or behavior changes beyond bug fix
* [x] Backward compatible
* [x] Matches existing expectations in tests

---

### VERIFICATION

**Before:**

* Duplicate entries returned for overlapping IDs
* `_is_custom` incorrectly set to `true` even when `libraryHash` was used

**After:**

* Each instrumentation is loaded exactly once
* `_is_custom` correctly reflects whether the custom hash was actually used

---
