### PR TITLE
feat(collector): add type descriptions and fix repository URL on detail page

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -27,6 +27,16 @@ import { SectionHeader } from "@/components/ui/section-header";
 import { PageContainer } from "@/components/layout/page-container";
 import { useCollectorComponent } from "@/hooks/use-collector-data";
 
+const COMPONENT_TYPE_DESCRIPTIONS: Record<string, string> = {
+  receiver: "Receivers collect telemetry data from various sources and formats.",
+  processor:
+    "Processors transform, filter, or enrich telemetry data between receivers and exporters.",
+  exporter: "Exporters send telemetry data to one or more backends or destinations.",
+  extension:
+    "Extensions provide additional capabilities to the collector without processing telemetry data.",
+  connector: "Connectors act as both an exporter and a receiver, joining two pipelines together.",
+};
+
 export function CollectorDetailPage() {
   const { version, id } = useParams<{ version: string; id: string }>();
   const navigate = useNavigate();
@@ -96,7 +106,7 @@ export function CollectorDetailPage() {
   }
 
   const repositoryUrl = component.repository
-    ? `https://github.com/${component.repository}`
+    ? `https://github.com/${component.repository.includes("/") ? component.repository : `open-telemetry/${component.repository}`}`
     : "https://github.com/open-telemetry/opentelemetry-collector-contrib";
 
   return (
@@ -179,7 +189,20 @@ export function CollectorDetailPage() {
                       <h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
                         Type
                       </h4>
-                      <p className="mt-1 text-sm font-medium">{component.type}</p>
+                      <div className="mt-1 flex items-start gap-2 text-sm">
+                        <Check
+                          className="text-primary mt-0.5 h-4 w-4 flex-shrink-0"
+                          aria-hidden="true"
+                        />
+                        <div>
+                          <span className="font-medium capitalize">{component.type}</span>
+                          {COMPONENT_TYPE_DESCRIPTIONS[component.type] && (
+                            <p className="text-muted-foreground mt-0.5 text-xs">
+                              {COMPONENT_TYPE_DESCRIPTIONS[component.type]}
+                            </p>
+                          )}
+                        </div>
+                      </div>
                     </div>
                     <div>
                       <h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -105,10 +105,6 @@ export function CollectorDetailPage() {
     );
   }
 
-  const repositoryUrl = component.repository
-    ? `https://github.com/${component.repository}`
-    : "https://github.com/open-telemetry/opentelemetry-collector-contrib";
-
   return (
     <PageContainer>
       <BackButton />
@@ -227,7 +223,7 @@ export function CollectorDetailPage() {
                       Links & Resources
                     </h3>
                     <a
-                      href={`${repositoryUrl}/tree/main/${component.type}/${component.name}`}
+                      href={`https://github.com/open-telemetry/${component.repository}/tree/main/${component.type}/${component.name}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="border-border/50 hover:bg-muted/50 group flex items-center gap-3 rounded-lg border p-3 transition-colors"

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -15,7 +15,7 @@
  */
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Info, ExternalLink, Code, AlertCircle, Loader2, Check, Users } from "lucide-react";
+import { Info, ExternalLink, AlertCircle, Loader2, Check, Users } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github-icon";
 
 import { BackButton } from "@/components/ui/back-button";
@@ -106,7 +106,7 @@ export function CollectorDetailPage() {
   }
 
   const repositoryUrl = component.repository
-    ? `https://github.com/${component.repository.includes("/") ? component.repository : `open-telemetry/${component.repository}`}`
+    ? `https://github.com/${component.repository}`
     : "https://github.com/open-telemetry/opentelemetry-collector-contrib";
 
   return (
@@ -227,7 +227,7 @@ export function CollectorDetailPage() {
                       Links & Resources
                     </h3>
                     <a
-                      href={repositoryUrl}
+                      href={`${repositoryUrl}/tree/main/${component.type}/${component.name}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="border-border/50 hover:bg-muted/50 group flex items-center gap-3 rounded-lg border p-3 transition-colors"
@@ -236,20 +236,6 @@ export function CollectorDetailPage() {
                       <div>
                         <p className="text-sm font-medium">Source Code</p>
                         <p className="text-muted-foreground text-xs">View on GitHub</p>
-                      </div>
-                      <ExternalLink className="text-muted-foreground ml-auto h-4 w-4" />
-                    </a>
-
-                    <a
-                      href={`${repositoryUrl}/tree/main/${component.type}/${component.name}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="border-border/50 hover:bg-muted/50 group flex items-center gap-3 rounded-lg border p-3 transition-colors"
-                    >
-                      <Code className="text-primary h-5 w-5 transition-transform group-hover:scale-110" />
-                      <div>
-                        <p className="text-sm font-medium">Component Documentation</p>
-                        <p className="text-muted-foreground text-xs">Read the README</p>
                       </div>
                       <ExternalLink className="text-muted-foreground ml-auto h-4 w-4" />
                     </a>


### PR DESCRIPTION
**Fixes part of #330**

### Description
This PR addresses the "Detail page" requirements for the Collector components:

* **Component Info:** Added short descriptions underneath the component Type, utilizing the official blurbs from opentelemetry.io.
* **Styling:** Matched the javaagent "Features" styling by implementing the `Check` icon and muted text layout.
* **URL Fix:** Corrected the link generation logic for the "Source Code" and "Component Documentation" links so they properly prepend the `open-telemetry/` organization prefix when necessary.
