### PR TITLE
feat/fixed collector metadata schema versions

### DIFF
--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -79,6 +79,40 @@ jobs:
         run: uv run collector-watcher
         continue-on-error: true
 
+      - name: Detect collector schema drift
+        id: detect_schema_drift
+        if: always()
+        run: |
+          FRESH="tmp_repos/opentelemetry-collector/cmd/mdatagen/metadata-schema.yaml"
+
+          # Find the most recent release version's stored schema snapshot from meta/
+          STORED=$(find ecosystem-registry/collector/meta -name metadata-schema.yaml \
+            -not -path "*SNAPSHOT*" 2>/dev/null | sort -V | tail -1)
+
+          if [ ! -f "$FRESH" ]; then
+            echo "Fresh schema not found in cloned repo, skipping drift detection"
+            echo "schema_changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ ! -f "$STORED" ]; then
+            echo "No stored schema baseline found yet, skipping drift detection"
+            echo "schema_changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if ! diff -q "$FRESH" "$STORED" > /dev/null 2>&1; then
+            echo "schema_changed=true" >> $GITHUB_OUTPUT
+            DIFF_OUTPUT=$(diff "$STORED" "$FRESH" | head -80 || true)
+            {
+              echo "schema_diff<<SCHEMA_DIFF_EOF"
+              echo "$DIFF_OUTPUT"
+              echo "SCHEMA_DIFF_EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "schema_changed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run java-instrumentation-watcher
         id: java_instrumentation_watcher
         if: always()
@@ -104,6 +138,69 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Open or update schema drift issue
+        if: steps.detect_schema_drift.outputs.schema_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCHEMA_DIFF: ${{ steps.detect_schema_drift.outputs.schema_diff }}
+        run: |
+          ISSUE_TITLE="[schema-drift] collector metadata-schema.yaml changed"
+          EXISTING=$(gh issue list \
+            --search "in:title \"$ISSUE_TITLE\"" \
+            --state open \
+            --label schema-drift \
+            --json number \
+            --jq '.[0].number // empty')
+
+          ISSUE_BODY="The upstream \`metadata-schema.yaml\` has changed since the last stored registry snapshot.
+
+          **Action required:** Review the diff below, determine if a new \`MetadataParserV*\` class is needed, and run a backfill if any output fields have changed.
+
+          <details>
+          <summary>Diff (stored → fresh)</summary>
+
+          \`\`\`diff
+          ${SCHEMA_DIFF}
+          \`\`\`
+          </details>
+
+          **To backfill all collector versions after updating the parser:**
+          \`\`\`
+          uv run collector-watcher --backfill
+          \`\`\`
+
+          See [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$ISSUE_BODY"
+            echo "Added comment to existing schema-drift issue #$EXISTING"
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body "$ISSUE_BODY" \
+              --label "schema-drift"
+            echo "Created new schema-drift issue"
+          fi
+
+      - name: Close schema drift issue if schema is stable
+        if: steps.detect_schema_drift.outputs.schema_changed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="[schema-drift] collector metadata-schema.yaml changed"
+          EXISTING=$(gh issue list \
+            --search "in:title \"$ISSUE_TITLE\"" \
+            --state open \
+            --label schema-drift \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" \
+              --comment "Schema drift resolved: stored snapshot now matches the upstream schema."
+            echo "Closed schema-drift issue #$EXISTING"
           fi
 
       - name: Commit and push changes

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     outputs:
       collector_result: ${{ steps.collector_watcher.outcome }}

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -84,10 +84,7 @@ jobs:
         if: always()
         run: |
           FRESH="tmp_repos/opentelemetry-collector/cmd/mdatagen/metadata-schema.yaml"
-
-          # Find the most recent release version's stored schema snapshot from meta/
-          STORED=$(find ecosystem-registry/collector/meta -name metadata-schema.yaml \
-            -not -path "*SNAPSHOT*" 2>/dev/null | sort -V | tail -1)
+          SCHEMAS_DIR="ecosystem-registry/collector/meta/schemas"
 
           if [ ! -f "$FRESH" ]; then
             echo "Fresh schema not found in cloned repo, skipping drift detection"
@@ -95,22 +92,39 @@ jobs:
             exit 0
           fi
 
-          if [ ! -f "$STORED" ]; then
-            echo "No stored schema baseline found yet, skipping drift detection"
+          # Schemas are stored in CAS at meta/schemas/{hash}.yaml. If a file
+          # already exists for the fresh content's hash, we've stored it
+          # before — no drift.
+          FRESH_HASH=$(sha256sum "$FRESH" | cut -c1-12)
+          if [ -f "$SCHEMAS_DIR/$FRESH_HASH.yaml" ]; then
             echo "schema_changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          if ! diff -q "$FRESH" "$STORED" > /dev/null 2>&1; then
-            echo "schema_changed=true" >> $GITHUB_OUTPUT
+          # Drift detected. Diff against the schema referenced by the latest
+          # non-SNAPSHOT release (any component YAML in that version directory
+          # carries the canonical schema_hash) so the issue body shows what
+          # actually changed.
+          LATEST_VERSION=$(ls ecosystem-registry/collector/core 2>/dev/null \
+            | grep -v SNAPSHOT | sort -V | tail -1)
+          STORED=""
+          if [ -n "$LATEST_VERSION" ]; then
+            REF_FILE=$(find "ecosystem-registry/collector/core/$LATEST_VERSION" \
+              -name '*.yaml' 2>/dev/null | head -1)
+            if [ -n "$REF_FILE" ]; then
+              STORED_HASH=$(grep '^schema_hash:' "$REF_FILE" | awk '{print $2}')
+              [ -f "$SCHEMAS_DIR/$STORED_HASH.yaml" ] && STORED="$SCHEMAS_DIR/$STORED_HASH.yaml"
+            fi
+          fi
+
+          echo "schema_changed=true" >> $GITHUB_OUTPUT
+          if [ -n "$STORED" ]; then
             DIFF_OUTPUT=$(diff "$STORED" "$FRESH" | head -80 || true)
             {
               echo "schema_diff<<SCHEMA_DIFF_EOF"
               echo "$DIFF_OUTPUT"
               echo "SCHEMA_DIFF_EOF"
             } >> $GITHUB_OUTPUT
-          else
-            echo "schema_changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Run java-instrumentation-watcher

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -15,6 +15,7 @@
 """Collector metadata synchronization to registry."""
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from semantic_version import Version
@@ -23,6 +24,7 @@ from watcher_common.version_detector import VersionDetector
 from .component_scanner import ComponentScanner
 from .deprecation_detector import DeprecationDetector
 from .inventory_manager import InventoryManager
+from .schema_copier import SCHEMA_RELATIVE_PATH, CollectorSchemaCopier
 from .type_defs import DistributionName
 
 logger = logging.getLogger(__name__)
@@ -163,19 +165,43 @@ class CollectorSync:
         """
         Save scanned components for a specific version.
 
+        Records the schema content hash in every component YAML file for drift
+        detection and parser routing. When saving the core distribution, also
+        copies metadata-schema.yaml into the shared meta/ directory — once per
+        version, since the schema belongs to the opentelemetry-collector core repo
+        and is identical across distributions.
+
+        Registry layout after this call (core example):
+            ecosystem-registry/collector/
+                core/v{version}/*.yaml          (component data, each with schema_hash)
+                meta/v{version}/metadata-schema.yaml  (shared schema copy)
+
         Args:
             distribution: Distribution name
             version: Version being saved
             components: Scanned components
         """
+        repo_path = Path(self.repos[distribution])
+        copier = CollectorSchemaCopier()
+        schema_src = repo_path / SCHEMA_RELATIVE_PATH
+        schema_hash = copier.compute_schema_hash(schema_src)
+
         repository = self.get_repository_name(distribution)
         self.inventory_manager.save_versioned_inventory(
             distribution=distribution,
             version=version,
             components=components,
             repository=repository,
+            schema_hash=schema_hash,
         )
-        logger.info("  Saved %s %s", distribution, version)
+
+        # Copy the schema file once, from core, into the shared meta/ directory.
+        # Contrib does not contain mdatagen; copying from core avoids duplication.
+        if distribution == "core":
+            meta_dir = self.inventory_manager.meta_schema_path(version).parent
+            copier.copy_schema(repo_path, meta_dir)
+
+        logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
 
     def initialize_previous_version(self, distribution: DistributionName) -> None:
         """

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -24,7 +24,7 @@ from watcher_common.version_detector import VersionDetector
 from .component_scanner import ComponentScanner
 from .deprecation_detector import DeprecationDetector
 from .inventory_manager import InventoryManager
-from .schema_copier import SCHEMA_RELATIVE_PATH, CollectorSchemaCopier
+from .schema_copier import CollectorSchemaCopier
 from .type_defs import DistributionName
 
 logger = logging.getLogger(__name__)
@@ -165,16 +165,19 @@ class CollectorSync:
         """
         Save scanned components for a specific version.
 
-        Records the schema content hash in every component YAML file for drift
-        detection and parser routing. When saving the core distribution, also
-        copies metadata-schema.yaml into the shared meta/ directory — once per
-        version, since the schema belongs to the opentelemetry-collector core repo
-        and is identical across distributions.
+        Stores the upstream schema in content-addressable storage at
+        ``meta/schemas/{hash}.yaml`` (deduplicated across versions and
+        distributions) and records that hash in every component YAML for
+        drift detection and parser routing.
 
-        Registry layout after this call (core example):
+        Schema is always read from the core repo: ``mdatagen`` lives only in
+        ``opentelemetry-collector``, and the schema is identical across
+        distributions, so contrib carries the same ``schema_hash`` as core.
+
+        Registry layout after this call:
             ecosystem-registry/collector/
-                core/v{version}/*.yaml          (component data, each with schema_hash)
-                meta/v{version}/metadata-schema.yaml  (shared schema copy)
+                {distribution}/v{version}/*.yaml   (component data, each with schema_hash)
+                meta/schemas/{hash}.yaml           (one file per distinct schema)
 
         Args:
             distribution: Distribution name
@@ -182,11 +185,9 @@ class CollectorSync:
             components: Scanned components
         """
         copier = CollectorSchemaCopier()
-        # Schema lives only in core (mdatagen is not in contrib). Read it from
-        # core regardless of which distribution we're saving so contrib carries
-        # the same schema_hash as the corresponding core checkout.
         core_repo_path = Path(self.repos["core"])
-        schema_hash = copier.compute_schema_hash(core_repo_path / SCHEMA_RELATIVE_PATH)
+        stored_hash = copier.store_schema(core_repo_path, self.inventory_manager.meta_schemas_dir())
+        schema_hash = stored_hash if stored_hash is not None else "unknown"
 
         repository = self.get_repository_name(distribution)
         self.inventory_manager.save_versioned_inventory(
@@ -196,11 +197,6 @@ class CollectorSync:
             repository=repository,
             schema_hash=schema_hash,
         )
-
-        # Copy the schema file once, from core, into the shared meta/ directory.
-        if distribution == "core":
-            meta_dir = self.inventory_manager.meta_schema_path(version).parent
-            copier.copy_schema(core_repo_path, meta_dir)
 
         logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -181,10 +181,12 @@ class CollectorSync:
             version: Version being saved
             components: Scanned components
         """
-        repo_path = Path(self.repos[distribution])
         copier = CollectorSchemaCopier()
-        schema_src = repo_path / SCHEMA_RELATIVE_PATH
-        schema_hash = copier.compute_schema_hash(schema_src)
+        # Schema lives only in core (mdatagen is not in contrib). Read it from
+        # core regardless of which distribution we're saving so contrib carries
+        # the same schema_hash as the corresponding core checkout.
+        core_repo_path = Path(self.repos["core"])
+        schema_hash = copier.compute_schema_hash(core_repo_path / SCHEMA_RELATIVE_PATH)
 
         repository = self.get_repository_name(distribution)
         self.inventory_manager.save_versioned_inventory(
@@ -196,10 +198,9 @@ class CollectorSync:
         )
 
         # Copy the schema file once, from core, into the shared meta/ directory.
-        # Contrib does not contain mdatagen; copying from core avoids duplication.
         if distribution == "core":
             meta_dir = self.inventory_manager.meta_schema_path(version).parent
-            copier.copy_schema(repo_path, meta_dir)
+            copier.copy_schema(core_repo_path, meta_dir)
 
         logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -50,21 +50,60 @@ class InventoryManager:
         """
         return self.inventory_dir / distribution / f"v{version}"
 
-    def meta_schema_path(self, version: Version) -> Path:
+    def meta_schemas_dir(self) -> Path:
         """
-        Return the canonical path for the stored upstream metadata-schema.yaml.
+        Return the content-addressable schema storage directory.
 
-        The schema belongs to the mdatagen tool (opentelemetry-collector core) and
-        is the same file regardless of distribution. It is stored once under a shared
-        meta/ directory rather than duplicated inside each distribution's tree.
+        The schema is stored once per distinct content as ``{hash}.yaml``,
+        not once per version. A component YAML's ``schema_hash`` field
+        directly identifies its schema file at
+        ``meta_schemas_dir() / f"{schema_hash}.yaml"``.
+        """
+        return self.inventory_dir / "meta" / "schemas"
 
-        Args:
-            version: Version object
+    def prune_orphan_schemas(self) -> int:
+        """
+        Delete schema files in ``meta/schemas/`` no longer referenced by any
+        component YAML.
+
+        Walks every distribution's version directories, collects the set of
+        ``schema_hash`` values referenced by component YAMLs, then removes any
+        ``meta/schemas/{hash}.yaml`` whose hash is not in that set. Should be
+        called after deleting a version (release backfill, snapshot cleanup)
+        to reclaim files that lost their last reference.
 
         Returns:
-            Path to ecosystem-registry/collector/meta/v{version}/metadata-schema.yaml
+            Number of orphan schema files deleted.
         """
-        return self.inventory_dir / "meta" / f"v{version}" / "metadata-schema.yaml"
+        schemas_dir = self.meta_schemas_dir()
+        if not schemas_dir.exists():
+            return 0
+
+        referenced: set[str] = set()
+        if self.inventory_dir.exists():
+            for dist_dir in self.inventory_dir.iterdir():
+                if not dist_dir.is_dir() or dist_dir.name == "meta":
+                    continue
+                for version_dir in dist_dir.iterdir():
+                    if not version_dir.is_dir():
+                        continue
+                    for component_file in version_dir.glob("*.yaml"):
+                        try:
+                            with open(component_file, encoding="utf-8") as f:
+                                data = yaml.safe_load(f) or {}
+                        except yaml.YAMLError:
+                            continue
+                        schema_hash = data.get("schema_hash")
+                        if schema_hash and schema_hash != "unknown":
+                            referenced.add(schema_hash)
+
+        removed = 0
+        for stored in schemas_dir.glob("*.yaml"):
+            if stored.stem not in referenced:
+                stored.unlink()
+                removed += 1
+
+        return removed
 
     def save_versioned_inventory(
         self,
@@ -218,6 +257,9 @@ class InventoryManager:
                 shutil.rmtree(snapshot_dir)
                 count += 1
 
+        if count > 0:
+            self.prune_orphan_schemas()
+
         return count
 
     def version_exists(self, distribution: DistributionName, version: Version) -> bool:
@@ -248,6 +290,7 @@ class InventoryManager:
         version_dir = self.get_version_dir(distribution, version)
         if version_dir.exists():
             shutil.rmtree(version_dir)
+            self.prune_orphan_schemas()
             return True
         return False
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -50,12 +50,29 @@ class InventoryManager:
         """
         return self.inventory_dir / distribution / f"v{version}"
 
+    def meta_schema_path(self, version: Version) -> Path:
+        """
+        Return the canonical path for the stored upstream metadata-schema.yaml.
+
+        The schema belongs to the mdatagen tool (opentelemetry-collector core) and
+        is the same file regardless of distribution. It is stored once under a shared
+        meta/ directory rather than duplicated inside each distribution's tree.
+
+        Args:
+            version: Version object
+
+        Returns:
+            Path to ecosystem-registry/collector/meta/v{version}/metadata-schema.yaml
+        """
+        return self.inventory_dir / "meta" / f"v{version}" / "metadata-schema.yaml"
+
     def save_versioned_inventory(
         self,
         distribution: DistributionName,
         version: Version,
         components: dict[str, list[dict[str, Any]]],
         repository: str,
+        schema_hash: str = "unknown",
     ) -> None:
         """
         Save inventory for a specific distribution and version.
@@ -65,6 +82,8 @@ class InventoryManager:
             version: Version object
             components: Dictionary of component type to component list
             repository: Name of the repository being scanned
+            schema_hash: 12-char hex hash of metadata-schema.yaml at scan time,
+                         or "unknown" when the schema file was absent in the repo
         """
         version_dir = self.get_version_dir(distribution, version)
         version_dir.mkdir(parents=True, exist_ok=True)
@@ -78,6 +97,7 @@ class InventoryManager:
                 "version": str(version),
                 "repository": repository,
                 "component_type": component_type,
+                "schema_hash": schema_hash,
                 "components": component_list,
             }
 
@@ -93,15 +113,18 @@ class InventoryManager:
             version: Version object
 
         Returns:
-            Inventory dictionary with all components, or empty structure if it doesn't exist
+            Inventory dictionary with all components, or empty structure if it doesn't exist.
+            Includes schema_hash field (defaults to "unknown" for files written before
+            schema fingerprinting was introduced).
         """
         version_dir = self.get_version_dir(distribution, version)
 
         if not version_dir.exists():
-            return {"distribution": distribution, "version": str(version), "components": {}}
+            return {"distribution": distribution, "version": str(version), "schema_hash": "unknown", "components": {}}
 
         components = {}
         repository = ""
+        schema_hash = "unknown"
 
         for component_type in COMPONENT_TYPES:
             file_path = version_dir / f"{component_type}.yaml"
@@ -112,6 +135,8 @@ class InventoryManager:
                     components[component_type] = data.get("components", [])
                     if not repository:
                         repository = data.get("repository", "")
+                    if schema_hash == "unknown":
+                        schema_hash = data.get("schema_hash", "unknown")
             else:
                 components[component_type] = []
 
@@ -119,6 +144,7 @@ class InventoryManager:
             "distribution": distribution,
             "version": str(version),
             "repository": repository,
+            "schema_hash": schema_hash,
             "components": components,
         }
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
@@ -299,7 +299,7 @@ class MetadataParser:
             return None
 
         try:
-            with open(self.metadata_path) as f:
+            with open(self.metadata_path, encoding="utf-8") as f:
                 raw = yaml.safe_load(f)
         except yaml.YAMLError as e:
             logger.warning("Failed to parse %s: %s", self.metadata_path, e)

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
@@ -231,7 +231,7 @@ class MetadataParserFactory:
     @classmethod
     def get_default_parser(cls) -> BaseMetadataParser:
         """Return the parser for the latest registered schema version."""
-        latest = sorted(cls._parsers.keys())[-1]
+        latest = sorted(cls._parsers.keys(), key=lambda v: int(v[1:]))[-1]
         return cls._parsers[latest]()
 
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/metadata_parser.py
@@ -12,14 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Parses metadata.yaml files from collector components.
+"""Version-aware parser system for collector component metadata.yaml files.
 
-See full schema:
- https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/mdatagen/metadata-schema.yaml
+The upstream schema lives at:
+  https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/mdatagen/metadata-schema.yaml
+
+The upstream schema does not yet carry a file_format/schema_version field.
+Until one is contributed upstream, all files are routed to MetadataParserV1
+(the current schema shape). When a file_format field is added upstream, add
+a new parser class, register it in MetadataParserFactory, and leave V1 untouched.
+
+Adding a required output field to any parser requires re-extracting all
+historical registry versions via: uv run collector-watcher --backfill
 """
 
 import logging
 import re
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
@@ -28,123 +37,94 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-class MetadataParser:
-    def __init__(self, component_path: Path):
-        """
-        Args:
-            component_path: Path to the component directory
-        """
-        self.component_path = Path(component_path)
-        self.metadata_path = self.component_path / "metadata.yaml"
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
 
-    def has_metadata(self) -> bool:
+
+class BaseMetadataParser(ABC):
+    """Base class for version-specific component metadata parsers."""
+
+    @abstractmethod
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any] | None:
         """
-        Check if metadata.yaml exists.
+        Parse and normalise a raw metadata dict into the canonical output shape.
+
+        Args:
+            raw: Parsed YAML content of a metadata.yaml file.
 
         Returns:
-            True if metadata.yaml exists
+            Normalised metadata dict, or None if the input is empty/invalid.
         """
-        return self.metadata_path.exists()
+
+    @abstractmethod
+    def get_schema_version(self) -> str:
+        """Return the schema version string this parser handles."""
+
+
+# ---------------------------------------------------------------------------
+# V1 — current upstream schema (no file_format field present)
+# ---------------------------------------------------------------------------
+
+
+class MetadataParserV1(BaseMetadataParser):
+    """Parser for the current collector metadata schema (pre-file_format era).
+
+    Handles: type, display_name, description, status, attributes, metrics,
+    resource_attributes.
+    """
+
+    def get_schema_version(self) -> str:
+        return "v1"
+
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any] | None:
+        if not raw:
+            return None
+
+        parsed: dict[str, Any] = {}
+
+        if "type" in raw:
+            parsed["type"] = raw["type"]
+
+        if "display_name" in raw:
+            parsed["display_name"] = raw["display_name"]
+
+        if "description" in raw:
+            parsed["description"] = self._sanitize_description(raw["description"])
+
+        if "status" in raw:
+            parsed["status"] = self._parse_status(raw["status"])
+
+        if "attributes" in raw:
+            parsed["attributes"] = self._parse_attributes(raw["attributes"])
+
+        if "metrics" in raw:
+            parsed["metrics"] = self._parse_metrics(raw["metrics"])
+
+        if "resource_attributes" in raw:
+            parsed["resource_attributes"] = self._parse_attributes(raw["resource_attributes"])
+
+        return parsed or None
 
     @staticmethod
     def _sanitize_description(description: str) -> str:
-        """
-        Sanitize description text by removing extra whitespace and normalizing line breaks.
-
-        YAML multi-line strings can contain awkward line breaks and extra whitespace
-        when parsed. This method normalizes them to single-line strings with clean spacing.
-
-        Args:
-            description: Raw description string from YAML
-
-        Returns:
-            Cleaned description string with normalized whitespace
-        """
+        """Normalise multi-line YAML descriptions to a single clean string."""
         if not description:
             return description
-
-        cleaned = description.strip()
-        cleaned = cleaned.replace("\n", " ")
-        cleaned = re.sub(r"\s+", " ", cleaned)
-
-        return cleaned
-
-    def parse(self) -> dict[str, Any] | None:
-        """
-        Parse the metadata.yaml file.
-
-        Returns:
-            Parsed metadata dictionary, or None if file doesn't exist or is invalid
-        """
-        if not self.has_metadata():
-            return None
-
-        try:
-            with open(self.metadata_path) as f:
-                raw_metadata = yaml.safe_load(f)
-
-            if not raw_metadata:
-                return None
-
-            parsed = {}
-
-            if "type" in raw_metadata:
-                parsed["type"] = raw_metadata["type"]
-
-            if "display_name" in raw_metadata:
-                parsed["display_name"] = raw_metadata["display_name"]
-
-            if "description" in raw_metadata:
-                parsed["description"] = self._sanitize_description(raw_metadata["description"])
-
-            # Status field (with nested structure)
-            if "status" in raw_metadata:
-                parsed["status"] = self._parse_status(raw_metadata["status"])
-
-            # Attributes (sorted by key)
-            if "attributes" in raw_metadata:
-                parsed["attributes"] = self._parse_attributes(raw_metadata["attributes"])
-
-            # Metrics (sorted by key)
-            if "metrics" in raw_metadata:
-                parsed["metrics"] = self._parse_metrics(raw_metadata["metrics"])
-
-            # Resource attributes (sorted by key)
-            if "resource_attributes" in raw_metadata:
-                parsed["resource_attributes"] = self._parse_attributes(raw_metadata["resource_attributes"])
-
-            return parsed
-
-        except yaml.YAMLError as e:
-            logger.warning("Failed to parse %s: %s", self.metadata_path, e)
-            return None
-        except Exception as e:
-            logger.warning("Unexpected error parsing %s: %s", self.metadata_path, e)
-            return None
+        cleaned = description.strip().replace("\n", " ")
+        return re.sub(r"\s+", " ", cleaned)
 
     def _parse_status(self, status: dict[str, Any]) -> dict[str, Any]:
-        """
-        Parse the status section with deterministic ordering.
-
-        Args:
-            status: Raw status dictionary
-
-        Returns:
-            Parsed status dictionary
-        """
-        parsed = {}
+        parsed: dict[str, Any] = {}
 
         if "class" in status:
             parsed["class"] = status["class"]
 
         if "stability" in status:
-            stability = {}
+            stability: dict[str, Any] = {}
             for level in sorted(status["stability"].keys()):
                 signals = status["stability"][level]
-                if isinstance(signals, list):
-                    stability[level] = sorted(signals)
-                else:
-                    stability[level] = signals
+                stability[level] = sorted(signals) if isinstance(signals, list) else signals
             parsed["stability"] = stability
 
         if "distributions" in status:
@@ -161,34 +141,22 @@ class MetadataParser:
         return parsed
 
     def _parse_attributes(self, attributes: dict[str, Any]) -> dict[str, Any]:
-        """
-        Parse attributes with deterministic ordering.
-
-        Args:
-            attributes: Raw attributes dictionary
-
-        Returns:
-            Parsed attributes dictionary sorted by key
-        """
         if not attributes:
             return {}
 
-        parsed = {}
+        parsed: dict[str, Any] = {}
         for attr_name in sorted(attributes.keys()):
             attr = attributes[attr_name]
             if isinstance(attr, dict):
-                parsed_attr = {}
-
+                parsed_attr: dict[str, Any] = {}
                 if "description" in attr:
                     parsed_attr["description"] = self._sanitize_description(attr["description"])
                 if "type" in attr:
                     parsed_attr["type"] = attr["type"]
                 if "name_override" in attr:
                     parsed_attr["name_override"] = attr["name_override"]
-
                 if "enum" in attr:
                     parsed_attr["enum"] = sorted(attr["enum"]) if isinstance(attr["enum"], list) else attr["enum"]
-
                 parsed[attr_name] = parsed_attr
             else:
                 parsed[attr_name] = attr
@@ -196,44 +164,164 @@ class MetadataParser:
         return parsed
 
     def _parse_metrics(self, metrics: dict[str, Any]) -> dict[str, Any]:
-        """
-        Parse metrics with deterministic ordering.
-
-        Args:
-            metrics: Raw metrics dictionary
-
-        Returns:
-            Parsed metrics dictionary sorted by key
-        """
         if not metrics:
             return {}
 
-        parsed = {}
+        parsed: dict[str, Any] = {}
         for metric_name in sorted(metrics.keys()):
             metric = metrics[metric_name]
             if isinstance(metric, dict):
-                parsed_metric = {}
-
+                parsed_metric: dict[str, Any] = {}
                 if "description" in metric:
                     parsed_metric["description"] = self._sanitize_description(metric["description"])
                 if "unit" in metric:
                     parsed_metric["unit"] = metric["unit"]
                 if "enabled" in metric:
                     parsed_metric["enabled"] = metric["enabled"]
-
                 for metric_type in ["sum", "gauge", "histogram"]:
                     if metric_type in metric:
                         parsed_metric[metric_type] = metric[metric_type]
-
                 if "attributes" in metric:
                     attrs = metric["attributes"]
                     parsed_metric["attributes"] = sorted(attrs) if isinstance(attrs, list) else attrs
-
                 if "stability" in metric:
                     parsed_metric["stability"] = metric["stability"]
-
                 parsed[metric_name] = parsed_metric
             else:
                 parsed[metric_name] = metric
 
         return parsed
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class MetadataParserFactory:
+    """Routes metadata.yaml content to the correct version-specific parser.
+
+    To add support for a new schema version:
+    1. Create MetadataParserV2(BaseMetadataParser) with the new extraction logic.
+    2. Register it: _parsers["v2"] = MetadataParserV2
+    3. Do NOT modify MetadataParserV1.
+    """
+
+    _parsers: dict[str, type[BaseMetadataParser]] = {
+        "v1": MetadataParserV1,
+    }
+
+    @classmethod
+    def get_parser(cls, schema_version: str) -> BaseMetadataParser:
+        """
+        Return a parser for the given schema version.
+
+        Args:
+            schema_version: Version string, e.g. "v1".
+
+        Raises:
+            ValueError: If schema_version is not registered.
+        """
+        parser_class = cls._parsers.get(schema_version)
+        if parser_class is None:
+            supported = ", ".join(sorted(cls._parsers.keys()))
+            raise ValueError(f"Unsupported schema_version: {schema_version!r}. Supported: {supported}")
+        return parser_class()
+
+    @classmethod
+    def get_default_parser(cls) -> BaseMetadataParser:
+        """Return the parser for the latest registered schema version."""
+        latest = sorted(cls._parsers.keys())[-1]
+        return cls._parsers[latest]()
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+
+def parse_component_metadata(raw: dict[str, Any], schema_version: str | None = None) -> dict[str, Any] | None:
+    """
+    Parse a raw metadata.yaml dict using the appropriate version-specific parser.
+
+    If schema_version is None, the default (latest) parser is used. Once the
+    upstream collector schema gains a file_format field, callers should pass its
+    value here so the factory can route correctly.
+
+    Args:
+        raw: Parsed YAML content of a metadata.yaml file.
+        schema_version: Parser version to use, e.g. "v1". None = default.
+
+    Returns:
+        Normalised metadata dict, or None if the input is empty/unparseable.
+    """
+    if schema_version is not None:
+        parser = MetadataParserFactory.get_parser(schema_version)
+    else:
+        parser = MetadataParserFactory.get_default_parser()
+    return parser.parse(raw)
+
+
+# ---------------------------------------------------------------------------
+# File-I/O wrapper (backward-compatible entry point used by ComponentScanner)
+# ---------------------------------------------------------------------------
+
+
+class MetadataParser:
+    """File-I/O wrapper around the versioned parser infrastructure.
+
+    ComponentScanner uses this class unchanged: MetadataParser(path).parse().
+    Internally it reads metadata.yaml, auto-detects schema_version from the
+    file's own fields (once the upstream gains a file_format field), and
+    delegates to parse_component_metadata().
+    """
+
+    def __init__(self, component_path: Path):
+        self.component_path = Path(component_path)
+        self.metadata_path = self.component_path / "metadata.yaml"
+
+    def has_metadata(self) -> bool:
+        return self.metadata_path.exists()
+
+    def parse(self, schema_version: str | None = None) -> dict[str, Any] | None:
+        """
+        Read and parse metadata.yaml using the appropriate parser version.
+
+        Args:
+            schema_version: Override the parser version. If None, auto-detection
+                is attempted from the file's schema_version / file_format field;
+                if that field is absent the default parser is used.
+
+        Returns:
+            Normalised metadata dict, or None on failure.
+        """
+        if not self.has_metadata():
+            return None
+
+        try:
+            with open(self.metadata_path) as f:
+                raw = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            logger.warning("Failed to parse %s: %s", self.metadata_path, e)
+            return None
+
+        try:
+            if not raw:
+                return None
+
+            if schema_version is None:
+                # Auto-detect from the file itself. The upstream schema does not yet
+                # carry this field; the lookup is a no-op for now and will activate
+                # transparently once the upstream adds file_format or schema_version.
+                schema_version = raw.get("schema_version") or raw.get("file_format")
+
+            return parse_component_metadata(raw, schema_version)
+
+        except ValueError:
+            # Propagate unsupported schema_version as a programming error, not a
+            # data error.  The caller passed (or the file declared) a version string
+            # that has no registered parser.
+            raise
+        except Exception as e:
+            logger.warning("Unexpected error parsing %s: %s", self.metadata_path, e)
+            return None

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Copies and hashes the upstream collector metadata schema file."""
+"""Stores the upstream collector metadata schema in content-addressable storage.
+
+The schema is stored once per distinct content under
+``meta/schemas/{hash}.yaml`` rather than once per release. This means a schema
+that is unchanged across many collector releases occupies a single file, and
+``schema_hash`` recorded on a component YAML directly identifies the file
+holding that schema (no version directory lookup required).
+"""
 
 import logging
 import shutil
@@ -22,54 +29,61 @@ from watcher_common.content_hashing import compute_content_hash
 
 logger = logging.getLogger(__name__)
 
-# Location of the schema file within the upstream opentelemetry-collector repo
 SCHEMA_RELATIVE_PATH = "cmd/mdatagen/metadata-schema.yaml"
-SCHEMA_FILENAME = "metadata-schema.yaml"
 
-# Sentinel returned when the schema file is absent (older tags pre-date the file)
 UNKNOWN_HASH = "unknown"
 
 
 class CollectorSchemaCopier:
-    """Copies and hashes metadata-schema.yaml from a collector repo checkout."""
+    """Stores metadata-schema.yaml from a collector repo into content-addressable storage."""
 
-    def copy_schema(self, repo_path: Path, target_dir: Path) -> str | None:
+    def store_schema(self, repo_path: Path, schemas_dir: Path) -> str | None:
         """
-        Copy metadata-schema.yaml from the upstream repository to target_dir.
+        Copy metadata-schema.yaml from the upstream repo into a hash-named file.
+
+        The destination is ``schemas_dir / f"{schema_hash}.yaml"``. If a file
+        with that name already exists (because the same schema content was
+        stored previously), the copy is skipped — the existing file is the
+        canonical record. Returns the schema hash on success.
 
         Args:
             repo_path: Path to the checked-out collector repository.
-            target_dir: Directory to copy the schema file into.
+            schemas_dir: Content-addressable storage directory (typically
+                ``ecosystem-registry/collector/meta/schemas``).
 
         Returns:
-            The destination filename on success, None if the schema file is
-            absent in the repository (graceful degradation for older tags).
+            The 12-char schema hash on success, or None if the upstream repo
+            does not contain ``cmd/mdatagen/metadata-schema.yaml`` (older tags
+            pre-date the file).
         """
         src = repo_path / SCHEMA_RELATIVE_PATH
         if not src.exists():
-            logger.debug("Schema file not found in repo at %s, skipping copy", src)
+            logger.debug("Schema file not found in repo at %s, skipping store", src)
             return None
 
-        target_dir.mkdir(parents=True, exist_ok=True)
-        dst = target_dir / SCHEMA_FILENAME
+        schema_hash = compute_content_hash(src.read_bytes())
+        dst = schemas_dir / f"{schema_hash}.yaml"
+        if dst.exists():
+            logger.debug("Schema %s already stored at %s, skipping copy", schema_hash, dst)
+            return schema_hash
+
+        schemas_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
-        logger.debug("Copied schema to %s", dst)
-        return SCHEMA_FILENAME
+        logger.debug("Stored schema %s at %s", schema_hash, dst)
+        return schema_hash
 
     def compute_schema_hash(self, schema_path: Path) -> str:
         """
-        Compute a stable content hash of the schema file.
+        Compute the content hash of a schema file.
 
-        Uses SHA-256 of the raw file bytes, truncated to 12 hex characters.
-        Returns the sentinel UNKNOWN_HASH if the file does not exist, so
-        registry files written against older tags that lack the schema file
-        carry an explicit marker rather than a missing field.
+        Returns ``UNKNOWN_HASH`` when the file is absent — used by component
+        YAMLs scanned from older collector tags that pre-date the schema file.
 
         Args:
             schema_path: Path to the schema file.
 
         Returns:
-            12-character hex hash string, or UNKNOWN_HASH.
+            12-character hex hash, or ``UNKNOWN_HASH``.
         """
         if not schema_path.exists():
             return UNKNOWN_HASH

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
@@ -14,10 +14,11 @@
 #
 """Copies and hashes the upstream collector metadata schema file."""
 
-import hashlib
 import logging
 import shutil
 from pathlib import Path
+
+from watcher_common.content_hashing import compute_content_hash
 
 logger = logging.getLogger(__name__)
 
@@ -72,5 +73,4 @@ class CollectorSchemaCopier:
         """
         if not schema_path.exists():
             return UNKNOWN_HASH
-        digest = hashlib.sha256(schema_path.read_bytes()).hexdigest()
-        return digest[:12]
+        return compute_content_hash(schema_path.read_bytes())

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
@@ -1,0 +1,76 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Copies and hashes the upstream collector metadata schema file."""
+
+import hashlib
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Location of the schema file within the upstream opentelemetry-collector repo
+SCHEMA_RELATIVE_PATH = "cmd/mdatagen/metadata-schema.yaml"
+SCHEMA_FILENAME = "metadata-schema.yaml"
+
+# Sentinel returned when the schema file is absent (older tags pre-date the file)
+UNKNOWN_HASH = "unknown"
+
+
+class CollectorSchemaCopier:
+    """Copies and hashes metadata-schema.yaml from a collector repo checkout."""
+
+    def copy_schema(self, repo_path: Path, target_dir: Path) -> str | None:
+        """
+        Copy metadata-schema.yaml from the upstream repository to target_dir.
+
+        Args:
+            repo_path: Path to the checked-out collector repository.
+            target_dir: Directory to copy the schema file into.
+
+        Returns:
+            The destination filename on success, None if the schema file is
+            absent in the repository (graceful degradation for older tags).
+        """
+        src = repo_path / SCHEMA_RELATIVE_PATH
+        if not src.exists():
+            logger.debug("Schema file not found in repo at %s, skipping copy", src)
+            return None
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        dst = target_dir / SCHEMA_FILENAME
+        shutil.copy2(src, dst)
+        logger.debug("Copied schema to %s", dst)
+        return SCHEMA_FILENAME
+
+    def compute_schema_hash(self, schema_path: Path) -> str:
+        """
+        Compute a stable content hash of the schema file.
+
+        Uses SHA-256 of the raw file bytes, truncated to 12 hex characters.
+        Returns the sentinel UNKNOWN_HASH if the file does not exist, so
+        registry files written against older tags that lack the schema file
+        carry an explicit marker rather than a missing field.
+
+        Args:
+            schema_path: Path to the schema file.
+
+        Returns:
+            12-character hex hash string, or UNKNOWN_HASH.
+        """
+        if not schema_path.exists():
+            return UNKNOWN_HASH
+        digest = hashlib.sha256(schema_path.read_bytes()).hexdigest()
+        return digest[:12]

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -162,6 +162,28 @@ def test_save_version_writes_schema_hash_when_schema_present(
     assert all(c in "0123456789abcdef" for c in schema_hash)
 
 
+def test_save_version_contrib_reads_schema_hash_from_core(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """Contrib has no mdatagen — its schema_hash must come from the core repo."""
+    # Plant a schema file in core only. Contrib intentionally has none.
+    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+
+    version = Version("0.112.0")
+    collector_sync.save_version("core", version, sample_components)
+    collector_sync.save_version("contrib", version, sample_components)
+
+    with open(temp_inventory_dir / "core" / "v0.112.0" / "receiver.yaml") as f:
+        core_hash = yaml.safe_load(f)["schema_hash"]
+    with open(temp_inventory_dir / "contrib" / "v0.112.0" / "receiver.yaml") as f:
+        contrib_hash = yaml.safe_load(f)["schema_hash"]
+
+    assert contrib_hash != "unknown"
+    assert contrib_hash == core_hash
+
+
 def test_save_version_copies_schema_to_meta_dir_when_present(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -21,6 +21,7 @@ from unittest.mock import Mock, patch
 
 import git
 import pytest
+import yaml
 from collector_watcher.collector_sync import CollectorSync
 from collector_watcher.inventory_manager import InventoryManager
 from semantic_version import Version
@@ -124,6 +125,92 @@ def test_save_version(collector_sync, sample_components, temp_inventory_dir):
     assert (version_dir / "receiver.yaml").exists()
     assert (version_dir / "processor.yaml").exists()
     assert (version_dir / "exporter.yaml").exists()
+
+
+def test_save_version_writes_schema_hash_unknown_when_schema_absent(
+    collector_sync, sample_components, temp_inventory_dir
+):
+    """When the upstream repo has no metadata-schema.yaml, schema_hash is 'unknown'."""
+    version = Version("0.112.0")
+    collector_sync.save_version("core", version, sample_components)
+
+    version_dir = temp_inventory_dir / "core" / "v0.112.0"
+    with open(version_dir / "receiver.yaml") as f:
+        data = yaml.safe_load(f)
+    assert data["schema_hash"] == "unknown"
+
+
+def test_save_version_writes_schema_hash_when_schema_present(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """When the upstream repo has metadata-schema.yaml, schema_hash is a 12-char hex."""
+    # Plant a fake schema file in the repo the sync uses for "core"
+    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+
+    version = Version("0.112.0")
+    collector_sync.save_version("core", version, sample_components)
+
+    version_dir = temp_inventory_dir / "core" / "v0.112.0"
+    with open(version_dir / "receiver.yaml") as f:
+        data = yaml.safe_load(f)
+
+    schema_hash = data["schema_hash"]
+    assert schema_hash != "unknown"
+    assert len(schema_hash) == 12
+    assert all(c in "0123456789abcdef" for c in schema_hash)
+
+
+def test_save_version_copies_schema_to_meta_dir_when_present(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """metadata-schema.yaml is copied into the shared meta/ directory, not the distribution dir."""
+    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+
+    version = Version("0.112.0")
+    collector_sync.save_version("core", version, sample_components)
+
+    # Schema is in the shared meta/ directory
+    meta_path = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
+    assert meta_path.exists()
+    assert meta_path.read_text() == "type: object\n"
+
+    # Schema is NOT duplicated inside the distribution directory
+    assert not (temp_inventory_dir / "core" / "v0.112.0" / "metadata-schema.yaml").exists()
+
+
+def test_save_version_schema_only_copied_for_core_not_contrib(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """Schema file is written to meta/ when saving core, not when saving contrib."""
+    for dist in ["core", "contrib"]:
+        schema_dir = Path(temp_git_repos[dist]) / "cmd" / "mdatagen"
+        schema_dir.mkdir(parents=True, exist_ok=True)
+        (schema_dir / "metadata-schema.yaml").write_text(f"type: {dist}\n")
+
+    version = Version("0.112.0")
+
+    # Save contrib first — should NOT create meta/ schema
+    collector_sync.save_version("contrib", version, sample_components)
+    assert not (temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml").exists()
+
+    # Save core — should create meta/ schema (from core repo)
+    collector_sync.save_version("core", version, sample_components)
+    meta_path = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
+    assert meta_path.exists()
+    assert meta_path.read_text() == "type: core\n"
+
+
+def test_save_version_does_not_create_schema_file_when_absent(collector_sync, sample_components, temp_inventory_dir):
+    """When the upstream repo has no schema file, no metadata-schema.yaml is written anywhere."""
+    version = Version("0.112.0")
+    collector_sync.save_version("core", version, sample_components)
+
+    assert not (temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml").exists()
+    assert not (temp_inventory_dir / "core" / "v0.112.0" / "metadata-schema.yaml").exists()
 
 
 def test_process_latest_release_already_exists(collector_sync, sample_components, temp_inventory_dir):

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -184,10 +184,10 @@ def test_save_version_contrib_reads_schema_hash_from_core(
     assert contrib_hash == core_hash
 
 
-def test_save_version_copies_schema_to_meta_dir_when_present(
+def test_save_version_stores_schema_in_cas_when_present(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
-    """metadata-schema.yaml is copied into the shared meta/ directory, not the distribution dir."""
+    """The schema is stored at meta/schemas/{hash}.yaml, not under a distribution directory."""
     schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
     schema_dir.mkdir(parents=True, exist_ok=True)
     (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
@@ -195,43 +195,42 @@ def test_save_version_copies_schema_to_meta_dir_when_present(
     version = Version("0.112.0")
     collector_sync.save_version("core", version, sample_components)
 
-    # Schema is in the shared meta/ directory
-    meta_path = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
-    assert meta_path.exists()
-    assert meta_path.read_text() == "type: object\n"
+    with open(temp_inventory_dir / "core" / "v0.112.0" / "receiver.yaml") as f:
+        schema_hash = yaml.safe_load(f)["schema_hash"]
+
+    schemas_dir = temp_inventory_dir / "meta" / "schemas"
+    stored = schemas_dir / f"{schema_hash}.yaml"
+    assert stored.exists()
+    assert stored.read_text() == "type: object\n"
 
     # Schema is NOT duplicated inside the distribution directory
     assert not (temp_inventory_dir / "core" / "v0.112.0" / "metadata-schema.yaml").exists()
 
 
-def test_save_version_schema_only_copied_for_core_not_contrib(
+def test_save_version_cas_dedupes_across_distributions(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
-    """Schema file is written to meta/ when saving core, not when saving contrib."""
-    for dist in ["core", "contrib"]:
-        schema_dir = Path(temp_git_repos[dist]) / "cmd" / "mdatagen"
-        schema_dir.mkdir(parents=True, exist_ok=True)
-        (schema_dir / "metadata-schema.yaml").write_text(f"type: {dist}\n")
+    """Saving core and contrib at the same schema content yields a single CAS file."""
+    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
 
     version = Version("0.112.0")
-
-    # Save contrib first — should NOT create meta/ schema
     collector_sync.save_version("contrib", version, sample_components)
-    assert not (temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml").exists()
-
-    # Save core — should create meta/ schema (from core repo)
     collector_sync.save_version("core", version, sample_components)
-    meta_path = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
-    assert meta_path.exists()
-    assert meta_path.read_text() == "type: core\n"
+
+    schemas_dir = temp_inventory_dir / "meta" / "schemas"
+    stored_files = list(schemas_dir.glob("*.yaml"))
+    assert len(stored_files) == 1
 
 
 def test_save_version_does_not_create_schema_file_when_absent(collector_sync, sample_components, temp_inventory_dir):
-    """When the upstream repo has no schema file, no metadata-schema.yaml is written anywhere."""
+    """When core has no schema, nothing is written to meta/schemas/ and schema_hash is 'unknown'."""
     version = Version("0.112.0")
     collector_sync.save_version("core", version, sample_components)
 
-    assert not (temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml").exists()
+    schemas_dir = temp_inventory_dir / "meta" / "schemas"
+    assert not schemas_dir.exists() or not any(schemas_dir.iterdir())
     assert not (temp_inventory_dir / "core" / "v0.112.0" / "metadata-schema.yaml").exists()
 
 

--- a/ecosystem-automation/collector-watcher/tests/test_inventory.py
+++ b/ecosystem-automation/collector-watcher/tests/test_inventory.py
@@ -84,6 +84,39 @@ def test_save_versioned_inventory(temp_inventory_dir, sample_components, sample_
     assert len(loaded["components"]) == 2
 
 
+def test_save_versioned_inventory_includes_schema_hash(temp_inventory_dir, sample_components, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="abc123def456",
+    )
+
+    with open(temp_inventory_dir / "core" / "v0.112.0" / "receiver.yaml") as f:
+        loaded = yaml.safe_load(f)
+
+    assert loaded["schema_hash"] == "abc123def456"
+
+
+def test_save_versioned_inventory_default_schema_hash(temp_inventory_dir, sample_components, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+    )
+
+    with open(temp_inventory_dir / "core" / "v0.112.0" / "receiver.yaml") as f:
+        loaded = yaml.safe_load(f)
+
+    assert loaded["schema_hash"] == "unknown"
+
+
 def test_load_versioned_inventory(temp_inventory_dir, sample_components, sample_version):
     manager = InventoryManager(str(temp_inventory_dir))
 
@@ -92,6 +125,7 @@ def test_load_versioned_inventory(temp_inventory_dir, sample_components, sample_
         version=sample_version,
         components=sample_components,
         repository="opentelemetry-collector-contrib",
+        schema_hash="aabbccddeeff",
     )
 
     loaded = manager.load_versioned_inventory("contrib", sample_version)
@@ -99,7 +133,36 @@ def test_load_versioned_inventory(temp_inventory_dir, sample_components, sample_
     assert loaded["distribution"] == "contrib"
     assert loaded["version"] == "0.112.0"
     assert loaded["repository"] == "opentelemetry-collector-contrib"
+    assert loaded["schema_hash"] == "aabbccddeeff"
     assert loaded["components"] == sample_components
+
+
+def test_load_versioned_inventory_backward_compat_missing_schema_hash(
+    temp_inventory_dir, sample_components, sample_version
+):
+    """Files written before schema_hash was added should load with 'unknown'."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    # Write a YAML file without schema_hash to simulate old registry files
+    version_dir = temp_inventory_dir / "core" / "v0.112.0"
+    version_dir.mkdir(parents=True)
+    legacy_data = {
+        "distribution": "core",
+        "version": "0.112.0",
+        "repository": "opentelemetry-collector",
+        "component_type": "receiver",
+        "components": [],
+    }
+    with open(version_dir / "receiver.yaml", "w") as f:
+        yaml.dump(legacy_data, f)
+    # Write stubs for the other component types
+    for ct in ["connector", "exporter", "extension", "processor"]:
+        stub = {**legacy_data, "component_type": ct}
+        with open(version_dir / f"{ct}.yaml", "w") as f:
+            yaml.dump(stub, f)
+
+    loaded = manager.load_versioned_inventory("core", sample_version)
+    assert loaded["schema_hash"] == "unknown"
 
 
 def test_load_nonexistent_versioned_inventory(temp_inventory_dir, sample_version):
@@ -109,7 +172,22 @@ def test_load_nonexistent_versioned_inventory(temp_inventory_dir, sample_version
 
     assert loaded["distribution"] == "contrib"
     assert loaded["version"] == "0.112.0"
+    assert loaded["schema_hash"] == "unknown"
     assert loaded["components"] == {}
+
+
+def test_meta_schema_path_helper(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    path = manager.meta_schema_path(sample_version)
+
+    expected = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
+    assert path == expected
+
+
+def test_meta_schema_path_is_distribution_independent(temp_inventory_dir, sample_version):
+    """The meta schema path must not depend on distribution."""
+    manager = InventoryManager(str(temp_inventory_dir))
+    assert manager.meta_schema_path(sample_version) == manager.meta_schema_path(sample_version)
 
 
 def test_list_versions(temp_inventory_dir, sample_components):

--- a/ecosystem-automation/collector-watcher/tests/test_inventory.py
+++ b/ecosystem-automation/collector-watcher/tests/test_inventory.py
@@ -176,18 +176,106 @@ def test_load_nonexistent_versioned_inventory(temp_inventory_dir, sample_version
     assert loaded["components"] == {}
 
 
-def test_meta_schema_path_helper(temp_inventory_dir, sample_version):
+def test_meta_schemas_dir_helper(temp_inventory_dir):
     manager = InventoryManager(str(temp_inventory_dir))
-    path = manager.meta_schema_path(sample_version)
-
-    expected = temp_inventory_dir / "meta" / "v0.112.0" / "metadata-schema.yaml"
-    assert path == expected
+    expected = temp_inventory_dir / "meta" / "schemas"
+    assert manager.meta_schemas_dir() == expected
 
 
-def test_meta_schema_path_is_distribution_independent(temp_inventory_dir, sample_version):
-    """The meta schema path must not depend on distribution."""
+def test_prune_orphan_schemas_removes_unreferenced_files(temp_inventory_dir, sample_components, sample_version):
+    """Schema files in meta/schemas not referenced by any component YAML are deleted."""
     manager = InventoryManager(str(temp_inventory_dir))
-    assert manager.meta_schema_path(sample_version) == manager.meta_schema_path(sample_version)
+
+    # Register one inventory referencing schema_hash "abc123def456"
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="abc123def456",
+    )
+
+    # Plant two schema files: one referenced, one orphan
+    schemas_dir = manager.meta_schemas_dir()
+    schemas_dir.mkdir(parents=True)
+    (schemas_dir / "abc123def456.yaml").write_text("type: object\n")
+    (schemas_dir / "deadbeefcafe.yaml").write_text("type: orphan\n")
+
+    removed = manager.prune_orphan_schemas()
+
+    assert removed == 1
+    assert (schemas_dir / "abc123def456.yaml").exists()
+    assert not (schemas_dir / "deadbeefcafe.yaml").exists()
+
+
+def test_prune_orphan_schemas_noop_when_meta_dir_absent(temp_inventory_dir):
+    manager = InventoryManager(str(temp_inventory_dir))
+    assert manager.prune_orphan_schemas() == 0
+
+
+def test_prune_orphan_schemas_treats_unknown_as_unreferenced(temp_inventory_dir, sample_components, sample_version):
+    """A 'unknown' schema_hash does not protect any file from pruning."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="unknown",
+    )
+
+    schemas_dir = manager.meta_schemas_dir()
+    schemas_dir.mkdir(parents=True)
+    (schemas_dir / "abc123def456.yaml").write_text("type: object\n")
+
+    removed = manager.prune_orphan_schemas()
+
+    assert removed == 1
+    assert not (schemas_dir / "abc123def456.yaml").exists()
+
+
+def test_delete_version_prunes_orphan_schemas(temp_inventory_dir, sample_components, sample_version):
+    """Deleting the last version that referenced a schema removes the schema file."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="abc123def456",
+    )
+
+    schemas_dir = manager.meta_schemas_dir()
+    schemas_dir.mkdir(parents=True)
+    (schemas_dir / "abc123def456.yaml").write_text("type: object\n")
+
+    manager.delete_version("core", sample_version)
+
+    assert not (schemas_dir / "abc123def456.yaml").exists()
+
+
+def test_cleanup_snapshots_prunes_orphan_schemas(temp_inventory_dir, sample_components):
+    """Removing the only snapshot that referenced a schema removes the schema file."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    snapshot = Version(major=0, minor=113, patch=0, prerelease=("SNAPSHOT",))
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=snapshot,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="abc123def456",
+    )
+
+    schemas_dir = manager.meta_schemas_dir()
+    schemas_dir.mkdir(parents=True)
+    (schemas_dir / "abc123def456.yaml").write_text("type: object\n")
+
+    manager.cleanup_snapshots("core")
+
+    assert not (schemas_dir / "abc123def456.yaml").exists()
 
 
 def test_list_versions(temp_inventory_dir, sample_components):

--- a/ecosystem-automation/collector-watcher/tests/test_metadata_parser.py
+++ b/ecosystem-automation/collector-watcher/tests/test_metadata_parser.py
@@ -19,7 +19,12 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from collector_watcher.metadata_parser import MetadataParser
+from collector_watcher.metadata_parser import (
+    MetadataParser,
+    MetadataParserFactory,
+    MetadataParserV1,
+    parse_component_metadata,
+)
 
 
 @pytest.fixture
@@ -357,3 +362,150 @@ resource_attributes:
         metadata["resource_attributes"]["service.name"]["description"]
         == "The name of the service running the collector."
     )
+
+
+# ---------------------------------------------------------------------------
+# MetadataParserV1 — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parser_v1_schema_version():
+    assert MetadataParserV1().get_schema_version() == "v1"
+
+
+def test_parser_v1_parse_returns_none_for_empty():
+    assert MetadataParserV1().parse({}) is None
+    assert MetadataParserV1().parse(None) is None  # type: ignore[arg-type]
+
+
+def test_parser_v1_parse_type_field():
+    result = MetadataParserV1().parse({"type": "otlp"})
+    assert result is not None
+    assert result["type"] == "otlp"
+
+
+def test_parser_v1_parse_status():
+    raw = {
+        "type": "test",
+        "status": {
+            "class": "receiver",
+            "stability": {"stable": ["metrics", "traces"], "beta": ["logs"]},
+            "distributions": ["contrib", "core"],
+        },
+    }
+    result = MetadataParserV1().parse(raw)
+    assert result["status"]["class"] == "receiver"
+    assert result["status"]["stability"]["stable"] == ["metrics", "traces"]
+    assert result["status"]["distributions"] == ["contrib", "core"]
+
+
+def test_parser_v1_sorted_attributes():
+    raw = {
+        "type": "test",
+        "attributes": {
+            "z_attr": {"type": "string"},
+            "a_attr": {"type": "int"},
+        },
+    }
+    result = MetadataParserV1().parse(raw)
+    assert list(result["attributes"].keys()) == ["a_attr", "z_attr"]
+
+
+def test_parser_v1_ignores_unknown_top_level_fields():
+    """Unknown fields (e.g. future schema additions) are silently dropped."""
+    raw = {"type": "test", "future_field": "some_value"}
+    result = MetadataParserV1().parse(raw)
+    assert "future_field" not in result
+
+
+# ---------------------------------------------------------------------------
+# MetadataParserFactory
+# ---------------------------------------------------------------------------
+
+
+def test_factory_get_parser_v1():
+    parser = MetadataParserFactory.get_parser("v1")
+    assert isinstance(parser, MetadataParserV1)
+
+
+def test_factory_get_default_parser_returns_latest():
+    parser = MetadataParserFactory.get_default_parser()
+    assert isinstance(parser, MetadataParserV1)
+
+
+def test_factory_raises_on_unknown_version():
+    with pytest.raises(ValueError, match="Unsupported schema_version"):
+        MetadataParserFactory.get_parser("v99")
+
+
+def test_factory_error_message_lists_supported_versions():
+    with pytest.raises(ValueError, match="v1"):
+        MetadataParserFactory.get_parser("v_unknown")
+
+
+# ---------------------------------------------------------------------------
+# parse_component_metadata convenience function
+# ---------------------------------------------------------------------------
+
+
+def test_parse_component_metadata_none_version_uses_default():
+    raw = {"type": "otlp"}
+    result = parse_component_metadata(raw, schema_version=None)
+    assert result is not None
+    assert result["type"] == "otlp"
+
+
+def test_parse_component_metadata_explicit_v1():
+    raw = {"type": "batch"}
+    result = parse_component_metadata(raw, schema_version="v1")
+    assert result["type"] == "batch"
+
+
+def test_parse_component_metadata_raises_on_bad_version():
+    with pytest.raises(ValueError):
+        parse_component_metadata({"type": "test"}, schema_version="v_bad")
+
+
+def test_parse_component_metadata_returns_none_for_empty():
+    assert parse_component_metadata({}) is None
+
+
+# ---------------------------------------------------------------------------
+# MetadataParser file-I/O wrapper — schema_version auto-detection
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_parser_accepts_schema_version_override(temp_component_dir):
+    """Explicit schema_version is forwarded to the factory."""
+    create_metadata_file(temp_component_dir, "type: otlp")
+    parser = MetadataParser(temp_component_dir)
+    result = parser.parse(schema_version="v1")
+    assert result is not None
+    assert result["type"] == "otlp"
+
+
+def test_metadata_parser_raises_on_unsupported_schema_version(temp_component_dir):
+    """Unsupported explicit schema_version propagates as ValueError."""
+    create_metadata_file(temp_component_dir, "type: otlp")
+    parser = MetadataParser(temp_component_dir)
+    with pytest.raises(ValueError, match="Unsupported schema_version"):
+        parser.parse(schema_version="v_bad")
+
+
+def test_metadata_parser_auto_detects_schema_version_field(temp_component_dir):
+    """If metadata.yaml carries a schema_version field matching a known version, it is used."""
+    content = "type: test\nschema_version: v1\n"
+    create_metadata_file(temp_component_dir, content)
+    parser = MetadataParser(temp_component_dir)
+    result = parser.parse()
+    assert result is not None
+    assert result["type"] == "test"
+
+
+def test_metadata_parser_unknown_schema_version_in_file_raises(temp_component_dir):
+    """An unknown schema_version declared inside metadata.yaml is propagated as ValueError."""
+    content = "type: test\nschema_version: v_future\n"
+    create_metadata_file(temp_component_dir, content)
+    parser = MetadataParser(temp_component_dir)
+    with pytest.raises(ValueError, match="Unsupported schema_version"):
+        parser.parse()

--- a/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
+++ b/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 import pytest
 from collector_watcher.schema_copier import (
-    SCHEMA_FILENAME,
     SCHEMA_RELATIVE_PATH,
     UNKNOWN_HASH,
     CollectorSchemaCopier,
@@ -53,61 +52,101 @@ def fake_repo_no_schema(temp_dir):
 
 
 @pytest.fixture
-def target_dir(temp_dir):
-    d = temp_dir / "target"
-    d.mkdir()
-    return d
+def schemas_dir(temp_dir):
+    return temp_dir / "meta" / "schemas"
 
 
 # ---------------------------------------------------------------------------
-# copy_schema
+# store_schema
 # ---------------------------------------------------------------------------
 
 
-def test_copy_schema_copies_file(fake_repo, target_dir):
+def test_store_schema_writes_hash_named_file(fake_repo, schemas_dir):
     copier = CollectorSchemaCopier()
-    result = copier.copy_schema(fake_repo, target_dir)
+    schema_hash = copier.store_schema(fake_repo, schemas_dir)
 
-    assert result == SCHEMA_FILENAME
-    assert (target_dir / SCHEMA_FILENAME).exists()
+    assert schema_hash is not None
+    assert len(schema_hash) == 12
+    assert (schemas_dir / f"{schema_hash}.yaml").exists()
 
 
-def test_copy_schema_content_is_identical(fake_repo, target_dir):
+def test_store_schema_returns_hash_matching_content(fake_repo, schemas_dir):
     copier = CollectorSchemaCopier()
-    copier.copy_schema(fake_repo, target_dir)
+    schema_hash = copier.store_schema(fake_repo, schemas_dir)
 
     src = fake_repo / SCHEMA_RELATIVE_PATH
-    dst = target_dir / SCHEMA_FILENAME
+    expected = hashlib.sha256(src.read_bytes()).hexdigest()[:12]
+    assert schema_hash == expected
+
+
+def test_store_schema_content_is_identical(fake_repo, schemas_dir):
+    copier = CollectorSchemaCopier()
+    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+
+    src = fake_repo / SCHEMA_RELATIVE_PATH
+    dst = schemas_dir / f"{schema_hash}.yaml"
     assert dst.read_bytes() == src.read_bytes()
 
 
-def test_copy_schema_creates_target_dir_if_missing(fake_repo, temp_dir):
-    target = temp_dir / "nested" / "newdir"
+def test_store_schema_creates_schemas_dir_if_missing(fake_repo, temp_dir):
+    target = temp_dir / "deeply" / "nested" / "schemas"
     assert not target.exists()
 
     copier = CollectorSchemaCopier()
-    copier.copy_schema(fake_repo, target)
+    schema_hash = copier.store_schema(fake_repo, target)
 
-    assert (target / SCHEMA_FILENAME).exists()
+    assert schema_hash is not None
+    assert (target / f"{schema_hash}.yaml").exists()
 
 
-def test_copy_schema_returns_none_when_schema_absent(fake_repo_no_schema, target_dir):
+def test_store_schema_returns_none_when_schema_absent(fake_repo_no_schema, schemas_dir):
     copier = CollectorSchemaCopier()
-    result = copier.copy_schema(fake_repo_no_schema, target_dir)
+    result = copier.store_schema(fake_repo_no_schema, schemas_dir)
 
     assert result is None
-    assert not (target_dir / SCHEMA_FILENAME).exists()
+    # No file should be created when source is absent
+    assert not schemas_dir.exists() or not any(schemas_dir.iterdir())
 
 
-def test_copy_schema_overwrites_existing_file(fake_repo, target_dir):
-    old_content = "old content"
-    (target_dir / SCHEMA_FILENAME).write_text(old_content)
-
+def test_store_schema_is_idempotent(fake_repo, schemas_dir):
+    """Calling store_schema twice with identical source produces one file."""
     copier = CollectorSchemaCopier()
-    copier.copy_schema(fake_repo, target_dir)
+    h1 = copier.store_schema(fake_repo, schemas_dir)
+    h2 = copier.store_schema(fake_repo, schemas_dir)
 
-    new_content = (target_dir / SCHEMA_FILENAME).read_text()
-    assert new_content != old_content
+    assert h1 == h2
+    files = list(schemas_dir.glob("*.yaml"))
+    assert len(files) == 1
+
+
+def test_store_schema_does_not_overwrite_existing_file(fake_repo, schemas_dir):
+    """The first stored content wins; later calls must not modify the existing file."""
+    copier = CollectorSchemaCopier()
+    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+
+    stored_path = schemas_dir / f"{schema_hash}.yaml"
+    mtime_before = stored_path.stat().st_mtime_ns
+
+    # A second call with the same source must skip the copy entirely
+    copier.store_schema(fake_repo, schemas_dir)
+    assert stored_path.stat().st_mtime_ns == mtime_before
+
+
+def test_store_schema_distinct_contents_produce_distinct_files(fake_repo, schemas_dir, temp_dir):
+    """Two repos with different schemas yield two files in CAS."""
+    copier = CollectorSchemaCopier()
+    h1 = copier.store_schema(fake_repo, schemas_dir)
+
+    other_repo = temp_dir / "other"
+    other_schema_dir = other_repo / "cmd" / "mdatagen"
+    other_schema_dir.mkdir(parents=True)
+    (other_schema_dir / "metadata-schema.yaml").write_text("type: different\n")
+
+    h2 = copier.store_schema(other_repo, schemas_dir)
+
+    assert h1 != h2
+    assert (schemas_dir / f"{h1}.yaml").exists()
+    assert (schemas_dir / f"{h2}.yaml").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -163,16 +202,15 @@ def test_compute_schema_hash_returns_unknown_when_absent(temp_dir):
 
 
 # ---------------------------------------------------------------------------
-# Round-trip: copy then hash the copy
+# Round-trip: store then hash the stored copy
 # ---------------------------------------------------------------------------
 
 
-def test_hash_of_copy_matches_hash_of_source(fake_repo, target_dir):
-    """The hash of the copied file must equal the hash of the source."""
+def test_hash_of_stored_file_matches_computed_hash(fake_repo, schemas_dir):
+    """The filename of the stored copy must equal the source hash."""
     copier = CollectorSchemaCopier()
-    copier.copy_schema(fake_repo, target_dir)
+    schema_hash = copier.store_schema(fake_repo, schemas_dir)
 
     src_hash = copier.compute_schema_hash(fake_repo / SCHEMA_RELATIVE_PATH)
-    dst_hash = copier.compute_schema_hash(target_dir / SCHEMA_FILENAME)
-
-    assert src_hash == dst_hash
+    assert schema_hash == src_hash
+    assert (schemas_dir / f"{src_hash}.yaml").exists()

--- a/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
+++ b/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
@@ -1,0 +1,178 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for CollectorSchemaCopier."""
+
+import hashlib
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from collector_watcher.schema_copier import (
+    SCHEMA_FILENAME,
+    SCHEMA_RELATIVE_PATH,
+    UNKNOWN_HASH,
+    CollectorSchemaCopier,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp()
+    yield Path(d)
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def fake_repo(temp_dir):
+    """Fake repo directory with a metadata-schema.yaml at the expected location."""
+    schema_dir = temp_dir / "cmd" / "mdatagen"
+    schema_dir.mkdir(parents=True)
+    schema_file = schema_dir / "metadata-schema.yaml"
+    schema_file.write_text("type: object\nproperties:\n  type:\n    type: string\n")
+    return temp_dir
+
+
+@pytest.fixture
+def fake_repo_no_schema(temp_dir):
+    """Fake repo directory without a metadata-schema.yaml."""
+    (temp_dir / "cmd" / "mdatagen").mkdir(parents=True)
+    return temp_dir
+
+
+@pytest.fixture
+def target_dir(temp_dir):
+    d = temp_dir / "target"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# copy_schema
+# ---------------------------------------------------------------------------
+
+
+def test_copy_schema_copies_file(fake_repo, target_dir):
+    copier = CollectorSchemaCopier()
+    result = copier.copy_schema(fake_repo, target_dir)
+
+    assert result == SCHEMA_FILENAME
+    assert (target_dir / SCHEMA_FILENAME).exists()
+
+
+def test_copy_schema_content_is_identical(fake_repo, target_dir):
+    copier = CollectorSchemaCopier()
+    copier.copy_schema(fake_repo, target_dir)
+
+    src = fake_repo / SCHEMA_RELATIVE_PATH
+    dst = target_dir / SCHEMA_FILENAME
+    assert dst.read_bytes() == src.read_bytes()
+
+
+def test_copy_schema_creates_target_dir_if_missing(fake_repo, temp_dir):
+    target = temp_dir / "nested" / "newdir"
+    assert not target.exists()
+
+    copier = CollectorSchemaCopier()
+    copier.copy_schema(fake_repo, target)
+
+    assert (target / SCHEMA_FILENAME).exists()
+
+
+def test_copy_schema_returns_none_when_schema_absent(fake_repo_no_schema, target_dir):
+    copier = CollectorSchemaCopier()
+    result = copier.copy_schema(fake_repo_no_schema, target_dir)
+
+    assert result is None
+    assert not (target_dir / SCHEMA_FILENAME).exists()
+
+
+def test_copy_schema_overwrites_existing_file(fake_repo, target_dir):
+    old_content = "old content"
+    (target_dir / SCHEMA_FILENAME).write_text(old_content)
+
+    copier = CollectorSchemaCopier()
+    copier.copy_schema(fake_repo, target_dir)
+
+    new_content = (target_dir / SCHEMA_FILENAME).read_text()
+    assert new_content != old_content
+
+
+# ---------------------------------------------------------------------------
+# compute_schema_hash
+# ---------------------------------------------------------------------------
+
+
+def test_compute_schema_hash_returns_12_char_hex(fake_repo):
+    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+    copier = CollectorSchemaCopier()
+    result = copier.compute_schema_hash(schema_path)
+
+    assert isinstance(result, str)
+    assert len(result) == 12
+    assert all(c in "0123456789abcdef" for c in result)
+
+
+def test_compute_schema_hash_matches_sha256(fake_repo):
+    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+    copier = CollectorSchemaCopier()
+    result = copier.compute_schema_hash(schema_path)
+
+    expected = hashlib.sha256(schema_path.read_bytes()).hexdigest()[:12]
+    assert result == expected
+
+
+def test_compute_schema_hash_is_deterministic(fake_repo):
+    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+    copier = CollectorSchemaCopier()
+
+    h1 = copier.compute_schema_hash(schema_path)
+    h2 = copier.compute_schema_hash(schema_path)
+    assert h1 == h2
+
+
+def test_compute_schema_hash_changes_with_content(fake_repo):
+    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+    copier = CollectorSchemaCopier()
+
+    h1 = copier.compute_schema_hash(schema_path)
+    schema_path.write_text("type: object\nnewfield: added\n")
+    h2 = copier.compute_schema_hash(schema_path)
+
+    assert h1 != h2
+
+
+def test_compute_schema_hash_returns_unknown_when_absent(temp_dir):
+    missing = temp_dir / "does_not_exist.yaml"
+    copier = CollectorSchemaCopier()
+    result = copier.compute_schema_hash(missing)
+
+    assert result == UNKNOWN_HASH
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: copy then hash the copy
+# ---------------------------------------------------------------------------
+
+
+def test_hash_of_copy_matches_hash_of_source(fake_repo, target_dir):
+    """The hash of the copied file must equal the hash of the source."""
+    copier = CollectorSchemaCopier()
+    copier.copy_schema(fake_repo, target_dir)
+
+    src_hash = copier.compute_schema_hash(fake_repo / SCHEMA_RELATIVE_PATH)
+    dst_hash = copier.compute_schema_hash(target_dir / SCHEMA_FILENAME)
+
+    assert src_hash == dst_hash


### PR DESCRIPTION
**Motivation**
The collector watcher ingests `metadata.yaml` files from upstream with no version identifier on the schema. When the upstream schema evolves; the parser silently drops new fields or misreads restructured data. There is no local copy of the upstream schema stored, so drift is undetectable without manually diffing the live URL, and no automated alert exists when it happens.

**Issue Resolved**:
- #40 

**Approach**
1. Schema snapshot: copy `metadata-schema.yaml` from the cloned opentelemetry-collector repo into ecosystem-registry/collector/meta/v{version}/ once per release. Stored distribution-independently since the file lives in the core repo and applies to both core and contrib.
2. Schema fingerprinting: annotate every generated component YAML with a schema_hash field (12-char SHA-256 of the raw schema bytes). This let backfill jobs and future consumers identify which schema generation produced a given file without inspecting the schema itself.

**Changes**
File: collector_watcher/schema_copier.py
Change: `CollectorSchemaCopier.copy_schema()` and `compute_schema_hash()`

File: collector_watcher/collector_sync.py
Change: `save_version()` computes hash, passes it to inventory, copies schema to `meta/` for core only

File: collector_watcher/inventory_manager.py
Change: Added meta_schema_path(version); `save_versioned_inventory()` writes `schema_hash`; `load_versioned_inventory()` defaults to "unknown" for backward compat

File: collector_watcher/metadata_parser.py
Change: `BaseMetadataParser`, `MetadataParserV1`, `MetadataParserFactory`, `parse_component_metadata()`; `MetadataParser` wrapper unchanged from the caller's perspective

File: .github/workflows/nightly-registry-update.yml
Added Detect collector schema drift, Open or update schema drift issue, Close schema drift issue if schema is stable steps

File: tests/test_schema_copier.py: 11 tests
File: tests/test_metadata_parser.py: Extended: factory, V1, convenience function, auto-detection    
File: tests/test_inventory.py: Extended: `schema_hash` round-trip, backward compat, `meta_schema_path` 
File: tests/test_collector_sync.py: Extended: hash absent/present, schema copied to `meta/`, not duplicated in distribution dir 

**Testing**
- 135 tests pass 
- Verify `schema-drift` label exists in the repository 
- Trigger a manual `workflow_dispatch` run of the nightly workflow to confirm drift detection runs without error
- Confirm `ecosystem-registry/collector/meta/` is populated after the next nightly run