### PR TITLE
chore(projects): add planning workspace scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tmp_repos/
 metadata-issues.md
 
 *.DS_Store
+
+# Personal Claude session context — never committed
+CLAUDE.local.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,6 @@
   "trailingComma": "es5",
   "printWidth": 100,
   "arrowParens": "always",
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "proseWrap": "always"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,16 @@ Python watchers and the database builder that populate the registry. See `ecosys
 
 React 19 + Vite + TypeScript frontend. See `ecosystem-explorer/AGENTS.md` for the command palette, project structure, styling, accessibility rules, and footguns. For design system specifics (colors, typography, spacing, component patterns) see `ecosystem-explorer/DESIGN.md`.
 
+### projects (Project planning artifacts)
+
+Cross-phase initiatives that span multiple PRs keep their planning artifacts (rolling roadmaps, audits, per-phase plans, design briefs) under `projects/<issue-number>-<slug>/`. 
+
+Each initiative folder follows a shared frontmatter convention validated by `projects/frontmatter.schema.json`.
+
+See `projects/_index.md` for the full conventions, current initiatives, and the checklist for starting a new initiative.
+
+For the *current state of work* on a specific initiative, open that initiative's `NEXT-STEPS.md`.
+
 ## GitHub Actions
 
 When working with GitHub Actions in this repository:

--- a/projects/_index.md
+++ b/projects/_index.md
@@ -1,10 +1,12 @@
 # `projects/` — Initiative workspace
 
-> Top-level index for planning workspaces. Each significant initiative gets its own subfolder here.
-> This file is the meta-index — for the _current state of work_ on a specific initiative, open that
-> initiative's own `_index.md`.
+Top-level index for planning workspaces. Each significant initiative gets its own subfolder here.
+This file is the meta-index — for the _current state of work_ on a specific initiative, open that
+initiative's own `_index.md`.
 
-> **Note on frontmatter.** This file is intentionally outside the scope of
+> [!NOTE] Note on frontmatter
+>
+> This file is intentionally outside the scope of
 > [`frontmatter.schema.json`](./frontmatter.schema.json), which validates docs under
 > `projects/<issue-number>-<slug>/`. Top-level meta files (this one) don't carry issue / phase /
 > status fields because they aren't tied to any single initiative.

--- a/projects/_index.md
+++ b/projects/_index.md
@@ -1,0 +1,106 @@
+# `projects/` — Initiative workspace
+
+> Top-level index for planning workspaces. Each significant initiative gets its own subfolder here.
+> This file is the meta-index — for the _current state of work_ on a specific initiative, open that
+> initiative's own `_index.md`.
+
+> **Note on frontmatter.** This file is intentionally outside the scope of
+> [`frontmatter.schema.json`](./frontmatter.schema.json), which validates docs under
+> `projects/<issue-number>-<slug>/`. Top-level meta files (this one) don't carry issue / phase /
+> status fields because they aren't tied to any single initiative.
+
+---
+
+## What lives here
+
+```text
+projects/
+├── _index.md                  ← this file
+├── frontmatter.schema.json    ← validates per-initiative doc frontmatter
+└── <issue-number>-<slug>/     ← one folder per initiative (see "Current initiatives" below)
+```
+
+---
+
+## Folder convention
+
+Each significant initiative gets its own subfolder, named after the GitHub issue that tracks it:
+
+```text
+projects/<issue-number>-<slug>/
+```
+
+Examples (real and hypothetical):
+
+- `projects/84-ui-ux-design/` — issue
+  [#84](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/issues/84), the explorer
+  redesign.
+- `projects/123-search-backend/` — would track a hypothetical search backend initiative.
+
+The slug is short, kebab-case, and describes the initiative in 2–4 words.
+
+---
+
+## Frontmatter convention
+
+Every markdown file inside an initiative folder ships with YAML frontmatter validated by
+[`frontmatter.schema.json`](./frontmatter.schema.json):
+
+```yaml
+---
+title: "Phase 1 — Foundation" # human-readable; mirrors the H1
+issue: 84 # GitHub issue number; matches parent folder
+type: plan # plan | audit | brief | roadmap | index
+phase: 1 # 1-N or "meta" for cross-phase docs
+status: planning # planning | in-progress | complete | archived
+last_updated: "2026-05-06" # ISO date as quoted string (bare YAML dates fail validation)
+---
+```
+
+`type` distinguishes:
+
+- **`plan`** — forward-looking work plan for a phase.
+- **`audit`** — current-state analysis or codebase delta.
+- **`brief`** — design rationale or direction document.
+- **`roadmap`** — rolling state-of-work index, updated continuously. One per folder, conventionally
+  `NEXT-STEPS.md`.
+- **`index`** — stable folder landing page describing what lives in the folder and where to start.
+  One per folder, conventionally `_index.md`.
+
+When updating substantive content, bump `last_updated`. When work moves forward, update `status`
+(`planning` → `in-progress` when the first PR opens; `in-progress` → `complete` when the cleanup PR
+merges).
+
+---
+
+## Cross-link rules
+
+- **Within an initiative folder**, cross-link with relative paths: `./NEXT-STEPS.md`,
+  `./00-foundation.md`.
+- **From an initiative to repo files**, use `../../`: e.g., `../../ecosystem-explorer/DESIGN.md`.
+- **Across initiatives**, prefer linking to the other initiative's `_index.md` rather than to
+  individual files inside it; the index is the stable contract, individual files may be renamed or
+  split.
+
+---
+
+## Don't-delete rule
+
+Don't delete files inside an initiative folder without an explicit reason. Even superseded plans are
+useful as historical context — readers can see what was tried and why it was changed. Mark docs as
+`status: archived` instead of removing them.
+
+---
+
+## Starting a new initiative
+
+When kicking off a significant cross-phase effort:
+
+1. Open (or pick) a GitHub issue that tracks the initiative.
+2. Create `projects/<issue-number>-<slug>/`.
+3. Drop in `_index.md` (folder landing page) and `NEXT-STEPS.md` (rolling roadmap) using the
+   structure of [`84-ui-ux-design/`](./84-ui-ux-design/) as a template.
+4. Add per-phase plan docs (`00-…`, `01-…`, etc.) as the work crystallizes.
+5. Add a row to the **Current initiatives** table above so this index stays accurate.
+6. Every doc inside the new folder must satisfy
+   [`frontmatter.schema.json`](./frontmatter.schema.json).

--- a/projects/frontmatter.schema.json
+++ b/projects/frontmatter.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/projects/frontmatter.schema.json",
+  "title": "Project document frontmatter",
+  "description": "YAML frontmatter shape for markdown files under projects/<issue-number>-<slug>/. Validates planning, audit, brief, roadmap, and index documents tied to a single GitHub issue. Top-level meta files (e.g., projects/_index.md) are intentionally outside this schema's scope — they don't carry issue/phase/status fields because they aren't tied to any one initiative.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["title", "issue", "type", "phase", "status", "last_updated"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable title. Should be the same as or a close paraphrase of the H1 in the document body."
+    },
+    "issue": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub issue number that tracks this initiative. Must match the parent folder name (e.g., projects/84-ui-ux-design/ → issue: 84)."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["plan", "audit", "brief", "roadmap", "index"],
+      "description": "Document kind. plan = forward-looking work plan for a phase. audit = current-state analysis or codebase delta. brief = design rationale or direction document. roadmap = rolling state-of-work index, updated continuously (one per folder, conventionally NEXT-STEPS.md). index = stable folder landing page describing what lives here and where to start (one per folder, conventionally _index.md)."
+    },
+    "phase": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Numbered work phase (e.g., 1 for foundation, 2-5 for pages)."
+        },
+        {
+          "type": "string",
+          "const": "meta",
+          "description": "Cross-phase document (roadmap, brief) that doesn't belong to a single phase."
+        }
+      ],
+      "description": "Which phase of the initiative this document covers. Use \"meta\" for documents that span phases."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["planning", "in-progress", "complete", "archived"],
+      "description": "Status of the work the document describes (not the document itself). planning = not started. in-progress = PRs in flight. complete = all relevant PRs merged. archived = superseded."
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "ISO 8601 date (YYYY-MM-DD) of the last meaningful edit. Bump when content changes substantively, not for typo fixes."
+    }
+  },
+  "examples": [
+    {
+      "title": "Phase 1 — Foundation",
+      "issue": 84,
+      "type": "plan",
+      "phase": 1,
+      "status": "planning",
+      "last_updated": "2026-05-06"
+    },
+    {
+      "title": "Roadmap — explorer redesign",
+      "issue": 84,
+      "type": "roadmap",
+      "phase": "meta",
+      "status": "planning",
+      "last_updated": "2026-05-06"
+    },
+    {
+      "title": "v1 design proposal — Ecosystem Explorer",
+      "issue": 84,
+      "type": "brief",
+      "phase": "meta",
+      "status": "complete",
+      "last_updated": "2026-05-06"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- Sets up a `projects/` workspace to keep planning artifacts in one place, separately from the codebase or the issue thread.
- Contributes to #84 by preparing the workspace where the layout refactoring documents will live.

### What's new

- **`projects/_index.md`**: top-level meta index. Documents the per-issue subfolder convention (`projects/<issue-number>-<slug>/`), the frontmatter contract, cross-link rules, the don't-delete rule, and a "current initiatives" table. Outside the schema's scope by design (not tied to a single issue).
- **`projects/frontmatter.schema.json`**: JSON schema to validate YAML frontmatter on every per-initiative markdown file.