### PR TITLE
fix(search): include raw instrumentation name in search matching

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
@@ -192,6 +192,18 @@ describe("JavaInstrumentationListPage - Filtering", () => {
     expect(screen.getByText("Showing 1 of 4 instrumentations")).toBeInTheDocument();
   });
 
+  it("filters by raw instrumentation id", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const searchInput = await screen.findByPlaceholderText("Search instrumentations...");
+    await user.type(searchInput, "http-client");
+
+    expect(screen.getByText("HTTP Client")).toBeInTheDocument();
+    expect(screen.queryByText("Kafka Client")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 4 instrumentations")).toBeInTheDocument();
+  });
+
   it("searches by formatted name when display_name is absent", async () => {
     const user = userEvent.setup();
     vi.mocked(useInstrumentations).mockReturnValue({

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -65,9 +65,14 @@ export function JavaInstrumentationListPage() {
       if (filters.search) {
         const searchLower = filters.search.toLowerCase();
         const name = getInstrumentationDisplayName(instr).toLowerCase();
+        const rawName = instr.name.toLowerCase();
         const description = (instr.description || "").toLowerCase();
 
-        if (!name.includes(searchLower) && !description.includes(searchLower)) {
+        if (
+          !name.includes(searchLower) &&
+          !rawName.includes(searchLower) &&
+          !description.includes(searchLower)
+        ) {
           return false;
         }
       }


### PR DESCRIPTION
Searching for an instrumentation by its raw id (e.g. `aws-sdk-2.2`, `http-client`) returned no results because the search only matched against the derived display name and description. The display name strips hyphens and version suffixes, so `aws-sdk-2.2` was compared against `"Aws Sdk"` and never matched.

The fix adds `instr.name` as a third match field alongside the display name and description. The change is additive and does not affect any existing search behavior.

A test covering raw-id search is included alongside the existing name and description search tests.

|before|after|
|------|-----|
|<img width="1536" height="1510" alt="image" src="https://github.com/user-attachments/assets/808fb172-25e1-4836-893b-d1c5afe1c46c" />|<img width="1536" height="1510" alt="image" src="https://github.com/user-attachments/assets/564023ce-1003-46bd-ab8d-48b13aaff6ac" />
