### PR TITLE
fix: use numeric sort for coveredEntries version order

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.test.ts
@@ -96,7 +96,7 @@ describe("groupInstrumentationsByDisplayName", () => {
     expect(groups.map((g) => g.displayName)).toEqual(["Akka Actors", "JDBC", "Zookeeper"]);
   });
 
-  it("sorts instrumentations within a group alphabetically by name", () => {
+  it("sorts instrumentations within a group by numeric version order", () => {
     const instrumentations: InstrumentationData[] = [
       makeInstr({ name: "mongo-4.0", display_name: "MongoDB Driver" }),
       makeInstr({ name: "mongo-3.1", display_name: "MongoDB Driver" }),
@@ -109,6 +109,22 @@ describe("groupInstrumentationsByDisplayName", () => {
       "mongo-3.1",
       "mongo-3.7",
       "mongo-4.0",
+    ]);
+  });
+
+  it("sorts multi-digit version suffixes in numeric not lexicographic order", () => {
+    const instrumentations: InstrumentationData[] = [
+      makeInstr({ name: "jetty-12.0", display_name: "Eclipse Jetty" }),
+      makeInstr({ name: "jetty-8.0", display_name: "Eclipse Jetty" }),
+      makeInstr({ name: "jetty-11.0", display_name: "Eclipse Jetty" }),
+    ];
+
+    const groups = groupInstrumentationsByDisplayName(instrumentations);
+
+    expect(groups[0].instrumentations.map((i) => i.name)).toEqual([
+      "jetty-8.0",
+      "jetty-11.0",
+      "jetty-12.0",
     ]);
   });
 

--- a/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.ts
@@ -48,7 +48,9 @@ export function groupInstrumentationsByDisplayName(
   for (const [displayName, members] of groupMap) {
     groups.push({
       displayName,
-      instrumentations: members.sort((a, b) => a.name.localeCompare(b.name)),
+      instrumentations: members.sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { numeric: true })
+      ),
     });
   }
 

--- a/ecosystem-explorer/src/lib/normalize-instrumentation.test.ts
+++ b/ecosystem-explorer/src/lib/normalize-instrumentation.test.ts
@@ -110,6 +110,28 @@ describe("groupByModule", () => {
       "cassandra-4.4",
     ]);
   });
+
+  it("sorts entries by semantic version order, placing double-digit versions after single-digit ones", () => {
+    const entries = [
+      makeEntry({ name: "jetty-httpclient-12.0" }),
+      makeEntry({ name: "jetty-httpclient-9.2" }),
+      makeEntry({ name: "jetty-8.0" }),
+      makeEntry({ name: "jetty-11.0" }),
+      makeEntry({ name: "jetty-12.0" }),
+    ];
+    const modules = groupByModule(entries);
+    const httpclient = modules.find((m) => m.name === "jetty_httpclient")!;
+    expect(httpclient.coveredEntries.map((e) => e.name)).toEqual([
+      "jetty-httpclient-9.2",
+      "jetty-httpclient-12.0",
+    ]);
+    const jetty = modules.find((m) => m.name === "jetty")!;
+    expect(jetty.coveredEntries.map((e) => e.name)).toEqual([
+      "jetty-8.0",
+      "jetty-11.0",
+      "jetty-12.0",
+    ]);
+  });
 });
 
 describe("snapshot: full registry", () => {

--- a/ecosystem-explorer/src/lib/normalize-instrumentation.ts
+++ b/ecosystem-explorer/src/lib/normalize-instrumentation.ts
@@ -35,7 +35,9 @@ export function groupByModule(entries: InstrumentationData[]): InstrumentationMo
 
   const modules: InstrumentationModule[] = [];
   for (const [name, bucket] of buckets) {
-    const coveredEntries = [...bucket].sort((a, b) => a.name.localeCompare(b.name));
+    const coveredEntries = [...bucket].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { numeric: true })
+    );
     const defaultDisabled = coveredEntries.every((e) => e.disabled_by_default === true);
     modules.push({ name, defaultDisabled, coveredEntries });
   }


### PR DESCRIPTION
## SUMMARY

Fix incorrect version ordering in `groupByModule()` where versions like `12.0` were sorted before `9.2`. 

---

## FIX

Updated sorting in `normalize-instrumentation.ts` to use numeric-aware comparison:

```ts id="r2tw1j"
a.name.localeCompare(b.name, undefined, { numeric: true })
```

Also added a regression test to prevent future ordering issues.

---

## CHECKLIST

* [x] Fixed version sorting
* [x] Added regression test
* [x] Verified tests pass
* [x] No breaking changes