### PR TITLE
fix(explorer): improve mobile responsiveness of Java instrumentation detail pages

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/attribute-table.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/attribute-table.tsx
@@ -25,19 +25,19 @@ export function AttributeTable({ attributes }: AttributeTableProps) {
   }
 
   return (
-    <div className="border-border/30 overflow-hidden rounded-lg border">
-      <table aria-label="Attributes" className="w-full border-collapse">
+    <div className="border-border/30 overflow-x-auto rounded-lg border">
+      <table aria-label="Attributes" className="w-full min-w-[260px] border-collapse">
         <thead>
           <tr className="bg-white/5">
             <th
               scope="col"
-              className="text-muted-foreground p-3 text-left text-[10px] font-bold tracking-widest uppercase"
+              className="text-muted-foreground p-2 text-left text-[10px] font-bold tracking-widest uppercase sm:p-3"
             >
               Key
             </th>
             <th
               scope="col"
-              className="text-muted-foreground p-3 text-left text-[10px] font-bold tracking-widest uppercase"
+              className="text-muted-foreground p-2 text-left text-[10px] font-bold tracking-widest uppercase sm:p-3"
             >
               Type
             </th>
@@ -49,8 +49,8 @@ export function AttributeTable({ attributes }: AttributeTableProps) {
               key={attr.name}
               className={`attribute-row ${index % 2 === 1 ? "bg-white/[0.03]" : ""}`}
             >
-              <td className="p-4 font-mono text-sm md:text-[12px]">{attr.name}</td>
-              <td className="p-4">
+              <td className="p-2 font-mono text-xs sm:p-4 sm:text-sm">{attr.name}</td>
+              <td className="p-2 sm:p-4">
                 <span className="border-border/30 bg-card/80 text-muted-foreground inline-block w-fit rounded border px-2 py-1 text-xs font-bold tracking-wider uppercase">
                   {attr.type}
                 </span>

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-selector.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-selector.tsx
@@ -46,10 +46,10 @@ export function ConfigurationSelector({
         </div>
 
         {/* Right: Label + Select */}
-        <div className="flex items-center gap-3">
+        <div className="flex w-full items-center gap-3 sm:w-auto">
           <label
             htmlFor="config-select"
-            className="bg-muted/50 text-foreground/70 rounded-md px-3 py-1.5 text-[10px] font-bold tracking-widest uppercase"
+            className="bg-muted/50 text-foreground/70 shrink-0 rounded-md px-3 py-1.5 text-[10px] font-bold tracking-widest uppercase"
           >
             Configuration
           </label>
@@ -57,7 +57,7 @@ export function ConfigurationSelector({
             id="config-select"
             value={selectedWhen}
             onChange={(e) => onWhenChange(e.target.value)}
-            className="border-primary/20 bg-primary/5 text-foreground hover:border-primary/40 hover:bg-primary/10 focus:ring-primary/50 focus:border-primary/50 min-w-[200px] cursor-pointer rounded-lg border-2 px-4 py-2.5 text-sm font-medium shadow-sm transition-all duration-200 hover:shadow-md focus:ring-2 focus:outline-none"
+            className="border-primary/20 bg-primary/5 text-foreground hover:border-primary/40 hover:bg-primary/10 focus:ring-primary/50 focus:border-primary/50 min-w-0 flex-1 cursor-pointer rounded-lg border-2 px-4 py-2.5 text-sm font-medium shadow-sm transition-all duration-200 hover:shadow-md focus:ring-2 focus:outline-none sm:min-w-[200px] sm:flex-none"
           >
             {telemetry.map((t) => (
               <option key={t.when} value={t.when}>

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-configuration-tab.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-configuration-tab.tsx
@@ -65,7 +65,7 @@ export function InstrumentationConfigurationTab({
       value={format}
       onValueChange={(v) => setFormat(v as ConfigurationFormat)}
     >
-      <SegmentedTabList tabs={FORMAT_TABS} value={format} />
+      <SegmentedTabList tabs={FORMAT_TABS} value={format} fullWidth />
       <TabsContent value="declarative">{grid("declarative")}</TabsContent>
       <TabsContent value="system-property">{grid("system-property")}</TabsContent>
     </Tabs>

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-section.tsx
@@ -60,15 +60,15 @@ export function TelemetrySection({ telemetry }: TelemetrySectionProps) {
                 currentTelemetry.metrics.map((metric) => (
                   <div
                     key={metric.name}
-                    className="border-border/30 bg-card/30 rounded-2xl border p-6 md:p-10"
+                    className="border-border/30 bg-card/30 rounded-2xl border p-4 sm:p-6 md:p-10"
                   >
                     <div className="space-y-6">
                       {/* Metric name and type badge */}
-                      <div className="flex items-start justify-between gap-4">
-                        <code className="text-foreground flex-1 font-mono text-lg font-semibold break-all">
+                      <div className="flex flex-wrap items-start gap-x-4 gap-y-2">
+                        <code className="text-foreground min-w-0 flex-1 font-mono text-base font-semibold break-all sm:text-lg">
                           {metric.name}
                         </code>
-                        <GlowBadge variant="success" withGlow className="text-[10px]">
+                        <GlowBadge variant="success" withGlow className="flex-shrink-0 text-[10px]">
                           {metric.instrument}
                         </GlowBadge>
                       </div>
@@ -113,15 +113,15 @@ export function TelemetrySection({ telemetry }: TelemetrySectionProps) {
                 currentTelemetry.spans.map((span, index) => (
                   <div
                     key={`${span.span_kind}-${index}`}
-                    className="border-border/30 bg-card/30 rounded-2xl border p-6 md:p-10"
+                    className="border-border/30 bg-card/30 rounded-2xl border p-4 sm:p-6 md:p-10"
                   >
                     <div className="space-y-6">
                       {/* Span kind badge */}
-                      <div className="flex items-center justify-between">
-                        <h3 className="text-foreground text-lg font-bold md:text-xl">
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                        <h3 className="text-foreground flex-1 text-base font-bold sm:text-lg md:text-xl">
                           {span.span_kind} Span
                         </h3>
-                        <GlowBadge variant="info" withGlow className="text-xs">
+                        <GlowBadge variant="info" withGlow className="flex-shrink-0 text-xs">
                           {span.span_kind}
                         </GlowBadge>
                       </div>

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -162,7 +162,7 @@ export function InstrumentationDetailPage() {
       <BackButton />
 
       <div className="mt-3 space-y-6">
-        <header className="border-border/60 bg-card/80 relative overflow-hidden rounded-lg border p-8">
+        <header className="border-border/60 bg-card/80 relative overflow-hidden rounded-lg border p-5 sm:p-8">
           <div
             className="absolute inset-0"
             style={{
@@ -183,9 +183,9 @@ export function InstrumentationDetailPage() {
           </div>
 
           <div className="relative z-10 space-y-4">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1 space-y-3">
-                <h1 className="text-3xl leading-tight font-bold md:text-4xl">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1 space-y-2">
+                <h1 className="text-2xl leading-tight font-bold sm:text-3xl md:text-4xl">
                   <span className="bg-gradient-to-r from-[hsl(var(--secondary-hsl))] to-[hsl(var(--primary-hsl))] bg-clip-text text-transparent">
                     {displayName}
                   </span>
@@ -198,8 +198,7 @@ export function InstrumentationDetailPage() {
                   </p>
                 )}
               </div>
-
-              <div className="flex flex-shrink-0 items-center gap-3">
+              <div className="flex flex-shrink-0 flex-wrap items-center gap-3">
                 {versionsData &&
                   versionsData.versions.length > 0 &&
                   version &&
@@ -251,7 +250,7 @@ export function InstrumentationDetailPage() {
           </div>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="relative z-10">
-            <div className="px-6 pt-4 pb-0">
+            <div className="overflow-x-auto px-4 pt-4 pb-0 sm:px-6">
               <SegmentedTabList
                 value={activeTab}
                 tabs={[
@@ -274,7 +273,7 @@ export function InstrumentationDetailPage() {
               />
             </div>
 
-            <TabsContent value="details" className="mt-0 p-6">
+            <TabsContent value="details" className="mt-0 p-4 sm:p-6">
               <div className="space-y-8">
                 {((instrumentation.features && instrumentation.features.length > 0) ||
                   (instrumentation.semantic_conventions &&
@@ -492,19 +491,19 @@ export function InstrumentationDetailPage() {
               </div>
             </TabsContent>
 
-            <TabsContent value="telemetry" className="mt-0 p-6">
+            <TabsContent value="telemetry" className="mt-0 p-4 sm:p-6">
               {instrumentation.telemetry && instrumentation.telemetry.length > 0 ? (
                 <div className="space-y-8">
                   <div className="flex justify-center">
                     <div
-                      className="border-border inline-flex rounded-lg border bg-transparent p-1"
+                      className="border-border inline-flex w-full rounded-lg border bg-transparent p-1 sm:w-auto"
                       role="group"
                     >
                       <button
                         type="button"
                         onClick={() => setShowComparison(false)}
                         aria-pressed={!showComparison}
-                        className={`rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out ${
+                        className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out sm:flex-none ${
                           !showComparison
                             ? "bg-card text-foreground shadow-sm"
                             : "text-muted-foreground hover:text-foreground"
@@ -516,7 +515,7 @@ export function InstrumentationDetailPage() {
                         type="button"
                         onClick={() => setShowComparison(true)}
                         aria-pressed={showComparison}
-                        className={`rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out ${
+                        className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out sm:flex-none ${
                           showComparison
                             ? "bg-card text-foreground shadow-sm"
                             : "text-muted-foreground hover:text-foreground"
@@ -554,7 +553,7 @@ export function InstrumentationDetailPage() {
               )}
             </TabsContent>
 
-            <TabsContent value="configuration" className="mt-0 p-6">
+            <TabsContent value="configuration" className="mt-0 p-4 sm:p-6">
               <InstrumentationConfigurationTab
                 configurations={instrumentation.configurations ?? []}
               />


### PR DESCRIPTION
Fixes #339

## Summary

- **Header**: title and controls (version selector + badge) stack on mobile, restore side-by-side at `sm+`
- **Tab navigation**: `overflow-x-auto` wrapper keeps tabs naturally sized and visually distinct; scrolls on very narrow screens
- **Metric/span cards**: type badge wraps below signal name on narrow screens; padding scales down on mobile
- **Attribute table**: TYPE column was clipped by `overflow-hidden` — switched to `overflow-x-auto`, tightened mobile padding
- **Configuration selector**: dropdown fills available width on mobile

<img width="505" height="892" alt="image" src="https://github.com/user-attachments/assets/ffe94e20-731d-4ace-9c5c-90c74f529f17" />

<img width="506" height="891" alt="image" src="https://github.com/user-attachments/assets/28a814d6-e9fd-47c2-acae-46288b5a096c" />

<img width="393" height="886" alt="image" src="https://github.com/user-attachments/assets/2ff12701-195b-4a62-812c-9c046de56195" />
