### PR TITLE
docs: add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+# Copilot code review instructions
+
+OpenTelemetry Ecosystem Explorer is a CNCF public repo with three components plus a planning
+workspace.
+
+- `ecosystem-registry/` — versioned upstream metadata. **Never edited by hand**; written by
+  automation, immutable history.
+- `ecosystem-automation/` — Python 3.11+ watchers (uv + Ruff + pytest).
+- `ecosystem-explorer/` — React 19 + Vite + TypeScript + Tailwind v4 frontend (Bun, Vitest for both
+  unit and integration tests).
+- `projects/<issue>-<slug>/` — planning artifacts validated by `projects/frontmatter.schema.json`.
+
+Path-scoped rules live in `.github/instructions/`. Read the matching one alongside this file when
+reviewing.
+
+## Glossary
+
+- **watcher** — Python pipeline that reads upstream and writes versioned YAML to
+  `ecosystem-registry/`.
+- **inventory** — directory layout under
+  `ecosystem-registry/{ecosystem}/{distribution}/v{version}/`.
+- **explorer-db-builder** — converts the registry into JSON under `ecosystem-explorer/public/data/`.
+- **DB_VERSION** — IndexedDB schema version constant in
+  `ecosystem-explorer/src/lib/api/idb-cache.ts`. Auto-bumped by
+  `.github/workflows/build-explorer-database.yml`.
+- **`[automated]` PR** — bot-authored PR by `app/otelbot` (or `app/renovate`). The diff is
+  regenerated output, not human-written code.
+- **`DataState<T>`** — canonical async hook return shape (`{ data, loading, error }`) in
+  `src/hooks/data-state.ts`.
+- **wrapped Radix primitive** — re-export under `src/components/ui/` adding Tailwind classes and
+  accessibility defaults.
+- **javaagent / declarative configuration / configuration builder** — Java auto-instrumentation
+  domain. Field names are snake_case end-to-end.
+
+## Review priorities
+
+- Stay on the diff. Do not propose refactors of code outside the change.
+- One concern per PR. If the PR is gated by a feature flag (e.g. `JAVA_CONFIG_BUILDER`,
+  `COLLECTOR_PAGE`, `V1_REDESIGN`), only flag bugs in the changed lines. Followup work belongs in a
+  separate PR.
+- Use `bun`, not `node`, for scripts and docs in `ecosystem-explorer/`.
+- Imports go at the top of the file. A local import is acceptable only when a circular dependency
+  forces it, and the workaround must be explained inline.
+- Comments explain WHY (invariant, footgun, workaround). Flag comments that restate the code.
+- Flag added TODOs, dead code, or commented-out blocks introduced by the diff.
+- Flag drive-by formatting changes in files unrelated to the PR.
+
+## Things you should NOT flag
+
+- Style enforced by Ruff, ESLint, Prettier, or markdownlint — all four run in CI.
+- Existing patterns adjacent to the change. Stay focused on the diff.
+- Missing PR template fields, screenshots, or changelog entries.
+- Lockfile churn (`bun.lock`, `package-lock.json`, `uv.lock`) when the `package.json` or
+  `pyproject.toml` change is justified.
+- Anything in PRs whose title starts with `[automated]` or whose author is `app/otelbot` /
+  `app/renovate`. The diff is regenerated output.
+- Hypothetical race conditions or edge cases without concrete evidence (e.g. multi-tab IndexedDB
+  races, empty-map combinations).
+- Memoization suggestions (`useMemo`, `useCallback`) without measurable evidence of a render
+  hotspot.
+- Manual `type="button"` on every `<button>` in WIP UI gated by a feature flag.
+- `^` semver ranges in `package.json` — the lockfile is the pin.
+- Two-blank-lines or other Python whitespace — Ruff format enforces it.
+- Schema URI scheme (`http://` vs `https://`) on JSON Schema meta-schemas.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,52 @@
+---
+applyTo: ".github/workflows/**/*.{yml,yaml}"
+---
+
+# GitHub Actions review rules
+
+## Action pinning (security-critical)
+
+- **Pin third-party actions to a full commit SHA**, not to a tag or branch. Floating tags can be
+  re-pointed by a compromised maintainer.
+- Add a version comment after the SHA for readability.
+- Format: `uses: owner/action@<full-40-char-sha> # vX.Y.Z`
+
+Examples to flag:
+
+- `uses: actions/checkout@v4` — unpinned, flag.
+- `uses: actions/checkout@main` — floating ref, flag.
+- `uses: actions/checkout@abc1234` — short SHA, flag.
+
+The current canonical pin in this repo is
+`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`. When updating an action
+version, update all callers together.
+
+## Permissions
+
+- Workflows must declare a top-level `permissions:` block.
+- Default to `contents: read` (top-level or per-job) and escalate per-job only when needed.
+- Flag escalations to `contents: write`, `pull-requests: write`, or `id-token: write` in **net-new**
+  workflows. Established workflows (nightly registry update, screenshots, db-builder) legitimately
+  need write access; do not re-litigate them.
+
+## Secrets and inputs
+
+- Flag `${{ secrets.* }}` interpolated directly into a `run:` shell script. Pass via `env:` so the
+  value is masked and not subject to shell expansion.
+- Flag `${{ github.event.* }}` (PR titles, branch names, issue bodies) interpolated into shell.
+  Treat event payload as untrusted; pass via `env:` and reference as a shell variable.
+
+## Triggers
+
+- Flag `pull_request_target` workflows that check out PR head code. That combination grants secrets
+  to untrusted code.
+- Scheduled or nightly workflows must gate on
+  `if: github.repository == 'open-telemetry/opentelemetry-ecosystem-explorer'` so forks don't
+  accidentally run them.
+
+## Repo-specific gotchas
+
+- `build-explorer-database.yml` auto-bumps `DB_VERSION` via
+  `sed -i "s/const DB_VERSION = ${CURRENT};/const DB_VERSION = ${NEW};/"`. The `grep` pattern is
+  `const DB_VERSION = \K[0-9]+`. Renaming the constant in `idb-cache.ts` breaks this workflow
+  silently.

--- a/.github/instructions/python-watchers.instructions.md
+++ b/.github/instructions/python-watchers.instructions.md
@@ -1,0 +1,64 @@
+---
+applyTo: "ecosystem-automation/**/*.py"
+---
+
+# Python watcher review rules
+
+Python 3.11+ in a `uv` workspace. Ruff for lint and format, pytest for tests. Each watcher inherits
+from base classes in `ecosystem-automation/watcher-common/src/watcher_common/`.
+
+## Watcher contract
+
+- **Idempotency.** The check is `inventory_manager.version_exists(version)` (defined in
+  `watcher-common/src/watcher_common/inventory_manager.py`). Flag any sync path that processes a
+  version without first calling it. Flag refactors that remove or short-circuit this check.
+- **Mark a version "exists" AFTER all writes succeed**, not before. Marking before sync makes
+  transient failures permanently skip backfill on the next run.
+- **Inventory layout.** Versions are written under
+  `ecosystem-registry/{ecosystem}/{distribution}/v{version}/`. Flag writes that bypass the helpers
+  in `BaseInventoryManager.get_version_dir(...)`.
+- **Reuse shared helpers.** Content hashing goes through `watcher_common.content_hashing`
+  (`compute_content_hash`, `UNKNOWN_HASH`). Flag per-watcher hash reimplementations.
+
+## Schema discipline (registry output)
+
+Old registry files are immutable history. Breaking the schema breaks history.
+
+- **No timestamps in output.** Output must be deterministic so the same input produces the same
+  content hash. Flag `datetime.now()`, `time.time()`, or any wallclock value embedded in serialized
+  output.
+- **Stable ordering.** Arrays in YAML must be sorted by a stable key. Flag iteration over `set()` or
+  unordered `dict` whose result is serialized without an explicit `sorted(...)`.
+- **Aggregated YAML per component type per version.** All expected files must be written together,
+  even if some are empty:
+  - Collector versions ship 5 component-type files (connector, exporter, extension, processor,
+    receiver).
+  - Configuration versions ship 12 schema files.
+  - Java javaagent ships `instrumentation.yaml` plus `library_readmes/`.
+- **Schema evolution is versioned, not in place.** Flag mutations to existing parsers when an input
+  format changes; expect a new version-specific parser and re-extraction of historical versions.
+
+## Conventions
+
+- Every module under `watcher_common/` starts with the Apache 2.0 copyright header (managed by
+  `scripts/add_copyright.py`) followed by a module docstring. New modules must follow.
+- Type hints on public functions and watcher contract methods.
+- Prefer `pathlib.Path` over `os.path`.
+- Use explicit exception types. Flag bare `except:` and `except Exception:` without a re-raise or
+  logged reason.
+- Flag mutable default arguments (`def f(x=[])`).
+- Flag direct `requests.get` / `httpx.get` calls in watchers — go through the shared HTTP client in
+  `watcher-common` so retry, backoff, and timeout are uniform.
+
+## Tests
+
+- Tests must not hit real external APIs (sandboxed CI fails). Use existing fixtures or mocked
+  clients.
+
+## Footguns
+
+- Manually deleting a `v{version}/` directory shifts the deprecation baseline for the collector
+  watcher and produces false-positive deprecations on the next sync. Flag tests or scripts that
+  `rmtree` registry paths without going through the watcher helpers.
+- Snapshot cleanup must be paired with writing a replacement, otherwise the snapshot is missing on
+  the frontend until the next sync. Flag cleanup logic that runs without a corresponding write.

--- a/.github/instructions/registry.instructions.md
+++ b/.github/instructions/registry.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: "ecosystem-registry/**"
+---
+
+# Registry review rules
+
+`ecosystem-registry/` stores versioned upstream metadata. **Files here are written by automation
+only.**
+
+## Bot-authored vs human PRs
+
+- If the PR title starts with `[automated]` or the author is `app/otelbot` or `app/renovate`, the
+  diff IS the regenerated output. Do not flag style, schema validity, redundancy, missing tests, or
+  documentation. The watchers produced this content.
+- If a non-automation PR touches files under `ecosystem-registry/`, that is the suspicious case.
+  Flag and request the change come from a watcher run.
+
+## Hand edits
+
+The only acceptable hand-touched changes are:
+
+- Re-extractions performed by running a watcher locally.
+- Schema migrations explicitly coordinated with the watcher change in the same PR.
+
+## Immutability
+
+- Old `v{version}/` directories are committed as historical record. Flag deletions of existing
+  version directories.
+- Flag renames or in-place rewrites of historical files. Schema evolution must add new
+  version-specific output, not rewrite past versions.
+
+## Per-version completeness
+
+Each version directory ships a fixed set of files. Flag partial writes:
+
+- **Collector** (`collector/{core,contrib}/v.../`): 5 files — `connector.yaml`, `exporter.yaml`,
+  `extension.yaml`, `processor.yaml`, `receiver.yaml`.
+- **Configuration** (`configuration/v.../`): 12 schema YAML files
+  (`opentelemetry_configuration.yaml`, `tracer_provider.yaml`, etc.).
+- **Java javaagent** (`java/javaagent/v.../`): `instrumentation.yaml` plus `library_readmes/`.
+
+## Determinism
+
+All output must be deterministic. Flag diffs that show timestamp churn, reordered arrays, or
+whitespace-only changes — these usually indicate a watcher producing non-deterministic output rather
+than a real change.

--- a/.github/instructions/typescript-frontend.instructions.md
+++ b/.github/instructions/typescript-frontend.instructions.md
@@ -1,0 +1,72 @@
+---
+applyTo: "ecosystem-explorer/**/*.{ts,tsx}"
+---
+
+# Frontend review rules
+
+React 19 + Vite + TS, Tailwind v4, Radix UI. Vitest for unit AND integration tests
+(`vitest.integration.config.ts` runs `src/test/integration/*.integration.test.ts(x)`). Playwright is
+only for `scripts/take-screenshots.mjs`. Design system: `ecosystem-explorer/DESIGN.md`.
+
+## Project structure
+
+- `src/features/{feature}/` — feature pages, components, hooks. Tests alongside source.
+- `src/components/ui/` — wrapped Radix primitives. Flag direct `@radix-ui/*` imports outside here.
+- `src/components/layout/` — shared layout.
+- `src/hooks/` — cross-feature hooks. Kebab-case `use-<thing>.ts(x)`.
+- `src/lib/` — utilities, feature flags, theme tokens.
+- `src/types/` — TS interfaces mirroring registry YAML. Snake_case fields (`display_name`,
+  `disabled_by_default`, `_is_custom`). Flag camelCase additions.
+
+`@/` alias maps to `src/`. Sibling `./` imports are common and fine. Flag deep relatives
+(`../../lib/...`); ask for `@/`.
+
+Routes register in `App.tsx`. Flag `<Route>` elsewhere or pages re-rendering header/footer locally.
+
+## Comments and styling
+
+- New explorer code ships **without comments**. Names, types, tests carry meaning. Flag added
+  comments that restate code. Comments are only for non-obvious invariants, framework footguns, or
+  workarounds — the "why" must be specific.
+- Color tokens live in `src/themes.ts`. Flag hex or `rgb()` literals in component code.
+
+## Data fetching
+
+- Async hooks return `DataState<T>` from `src/hooks/data-state.ts` (`{ data, loading, error }`).
+  Flag ad-hoc return shapes.
+- Wrap fetching in a custom hook. Flag `fetch()` or `useEffect`-based fetching in components.
+- Sanitize external URLs before binding to `href`. Reject non-`http(s)` schemes; user-facing fields
+  like `library_link` or `repository` can carry `javascript:` URLs.
+
+## State and IndexedDB
+
+- Flag `setState` in render bodies — StrictMode double-invocation has bitten this codebase. Move to
+  `useEffect` or event handlers.
+- **Do NOT bump `DB_VERSION` in `src/lib/api/idb-cache.ts` in feature PRs.** It is auto-bumped by
+  `.github/workflows/build-explorer-database.yml` when `public/data/` changes. Manual bumps are
+  correct only when the IDB schema actually changes (`STORES`, `CACHE_EXPIRATION_MS`, upgrade
+  logic).
+- The destructive upgrade handler in `initDB` is intentional. Don't propose preserving stores across
+  version changes.
+
+## Feature flags
+
+- `src/lib/feature-flags.ts` defines `FEATURE_FLAGS` as a const tuple. Adding a flag requires
+  extending the tuple AND adding the env var to both `.env.development` and `.env.test`.
+- Flag runtime toggling attempts. Flags are baked at build time from `VITE_FEATURE_FLAG_*`.
+
+## Accessibility
+
+- Semantic HTML (`<nav>`, `<main>`, `<button>`). Flag click handlers on non-interactive elements.
+- Icon-only buttons need `aria-label`. Toggle/filter/favorite buttons need `aria-pressed`.
+- Decorative SVGs need `role="img"` + `aria-label`, or `aria-hidden="true"` if purely decorative.
+- Form inputs need `<label htmlFor>` linked to the input `id`. Use `aria-invalid` for errors.
+
+## TypeScript and tests
+
+- Strict TS: `bun run build` runs typecheck and blocks on unused locals. Flag `any` without
+  justification, and `// @ts-ignore` / `// @ts-expect-error` without an explanation.
+- Route params are unvalidated. Flag pages reading a URL param without checking for missing values.
+- Mock `navigator.clipboard` via `Object.defineProperty(navigator, "clipboard", ...)` — jsdom method
+  spies return `undefined`.
+- Flag changes to non-trivial logic without test updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ When working with GitHub Actions in this repository:
 Example:
 
 ```yaml
-- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 ```
 
 ## Code Style

--- a/ecosystem-explorer/AGENTS.md
+++ b/ecosystem-explorer/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS.md — ecosystem-explorer
 
 React 19 + Vite + TypeScript frontend that provides search and exploration for the OpenTelemetry
-ecosystem. Tailwind CSS v4 for styling, Radix UI primitives, Vitest for unit tests, Playwright for
-integration tests.
+ecosystem. Tailwind CSS v4 for styling, Radix UI primitives, Vitest for both unit and integration
+tests (Playwright is used only by `scripts/take-screenshots.mjs`).
 
 For design system reference (colors, typography, spacing, component patterns) see `DESIGN.md` in
 this directory.
@@ -18,7 +18,7 @@ All commands run from `ecosystem-explorer/` with `bun`:
 - `bun run format` — Prettier write
 - `bun run test` — Unit tests (Vitest with jsdom)
 - `bun run test -t "<name>"` — Run a single unit test by name
-- `bun run test:integration` — Playwright-based integration tests
+- `bun run test:integration` — Vitest integration tests (config: `vitest.integration.config.ts`)
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

Add Copilot code review configuration. The repo-wide rules live in
`.github/copilot-instructions.md` and four path-scoped files under
`.github/instructions/` cover the frontend, Python watchers, GitHub Actions,
and the registry. All files stay under the 4000 char limit Copilot reads.

Includes a couple of small doc fixes spotted while preparing this.