### PR TITLE
Move netlify edge function location

### DIFF
--- a/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
+++ b/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
@@ -79,7 +79,7 @@ export default async (request: Request, context: Context) => {
     "/agent/javaagent/versions/": "/agent/javaagent/versions.md",
   };
 
-  let resolvedPath = agentPathMap[pathname] || pathname;
+  const resolvedPath = agentPathMap[pathname] || pathname;
   if (resolvedPath.endsWith(".md") || resolvedPath.startsWith("/agent/")) {
     if (resolvedPath.endsWith(".md")) {
       const response = await context.rewrite(resolvedPath);


### PR DESCRIPTION
I noticed that the edge functions are not showing up in the netlify console. The netlify.toml sets base = "ecosystem-explorer", which means Netlify looks for edge functions at ecosystem-explorer/netlify/edge-functions/.

Trying to move it to see if that solves it