### PR TITLE
fix(screenshots): use otelbot for commits, rename branch, make script resilient

### DIFF
--- a/.github/workflows/screenshots-cleanup.yml
+++ b/.github/workflows/screenshots-cleanup.yml
@@ -1,9 +1,9 @@
 name: PR Screenshots - Cleanup
 
 # Deletes the screenshots subfolder for a closed PR from the upstream
-# `screenshots` orphan branch. Uses pull_request_target (not pull_request)
+# `otelbot/screenshots` orphan branch. Uses pull_request_target (not pull_request)
 # so the token has contents: write even when the PR comes from a fork.
-# No PR code is checked out here — only the upstream screenshots branch.
+# No PR code is checked out here — only the upstream otelbot/screenshots branch.
 
 on:
   pull_request_target:
@@ -27,25 +27,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Use CLA approved github bot
+        run: .github/scripts/use-cla-approved-bot.sh
+
       - name: Delete PR screenshots
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if ! git ls-remote --exit-code --heads origin screenshots > /dev/null 2>&1; then
-            echo "No screenshots branch found, nothing to clean up."
+          if ! git ls-remote --exit-code --heads origin otelbot/screenshots > /dev/null 2>&1; then
+            echo "No otelbot/screenshots branch found, nothing to clean up."
             exit 0
           fi
 
-          git fetch origin screenshots
-          git checkout -B screenshots FETCH_HEAD
+          git fetch origin otelbot/screenshots
+          git checkout -B otelbot/screenshots FETCH_HEAD
 
           if [ ! -d "${PR_NUMBER}" ]; then
             echo "No screenshots for PR #${PR_NUMBER}, nothing to clean up."
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git rm -rf "${PR_NUMBER}/"
           git commit -m "chore: remove screenshots for PR #${PR_NUMBER}"
-          git push origin screenshots
+          git push origin otelbot/screenshots

--- a/.github/workflows/screenshots-cleanup.yml
+++ b/.github/workflows/screenshots-cleanup.yml
@@ -21,10 +21,17 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Get otelbot token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.otelbot-token.outputs.token }}
           fetch-depth: 0
 
       - name: Use CLA approved github bot

--- a/.github/workflows/screenshots-commit.yml
+++ b/.github/workflows/screenshots-commit.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-bot.sh
 
-      - name: Commit screenshots to screenshots branch
+      - name: Commit screenshots to otelbot/screenshots branch
         env:
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           jq -n --rawfile body /tmp/comment_body.txt '{body: $body}' > /tmp/comment_payload.json
 
           EXISTING_ID=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | contains("<!-- screenshots-bot -->")) | .id] | first // empty')
+            --jq '[.[] | select(.user.login == "otelbot[bot]") | select(.body | contains("<!-- screenshots-bot -->")) | .id] | first // empty')
 
           if [ -n "$EXISTING_ID" ]; then
             gh api "/repos/${REPO}/issues/comments/${EXISTING_ID}" -X PATCH --input /tmp/comment_payload.json

--- a/.github/workflows/screenshots-commit.yml
+++ b/.github/workflows/screenshots-commit.yml
@@ -42,10 +42,17 @@ jobs:
           echo "head_repo=$(cat /tmp/pr-metadata/head_repo.txt)" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(cat /tmp/pr-metadata/head_sha.txt)"   >> "$GITHUB_OUTPUT"
 
+      - name: Get otelbot token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.otelbot-token.outputs.token }}
           fetch-depth: 0
 
       - name: Download screenshots artifact
@@ -56,22 +63,22 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Use CLA approved github bot
+        run: .github/scripts/use-cla-approved-bot.sh
+
       - name: Commit screenshots to screenshots branch
         env:
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git ls-remote --exit-code --heads origin screenshots > /dev/null 2>&1; then
-            git fetch origin screenshots
-            git checkout -B screenshots FETCH_HEAD
+          if git ls-remote --exit-code --heads origin otelbot/screenshots > /dev/null 2>&1; then
+            git fetch origin otelbot/screenshots
+            git checkout -B otelbot/screenshots FETCH_HEAD
           else
-            git checkout --orphan screenshots
+            git checkout --orphan otelbot/screenshots
             git rm -rf . --quiet 2>/dev/null || true
             git clean -fd --quiet
             git commit --allow-empty -m "chore: initialize screenshots branch"
-            git push origin screenshots
+            git push origin otelbot/screenshots
           fi
 
           rm -rf -- "${PR_NUMBER}"
@@ -94,7 +101,7 @@ jobs:
           find /tmp/screenshots -mindepth 1 -maxdepth 1 -type f -name "*.png" -exec cp -- {} "${PR_NUMBER}/" \;
           git add -A -- "${PR_NUMBER}/"
           git diff --quiet --exit-code --cached || git commit -m "docs: update screenshots for PR #${PR_NUMBER}"
-          git push origin screenshots
+          git push origin otelbot/screenshots
 
       - name: Build comment body
         env:
@@ -119,7 +126,7 @@ jobs:
           short_sha  = head_sha[:7]
           commit_url = f"https://github.com/{head_repo}/commit/{head_sha}"
           run_url    = f"https://github.com/{repo}/actions/runs/{run_id}"
-          base_url   = f"https://raw.githubusercontent.com/{repo}/screenshots/{pr_number}"
+          base_url   = f"https://raw.githubusercontent.com/{repo}/otelbot/screenshots/{pr_number}"
           timestamp  = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
           def table(slug):
@@ -161,12 +168,12 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
           REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           jq -n --rawfile body /tmp/comment_body.txt '{body: $body}' > /tmp/comment_payload.json
 
           EXISTING_ID=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- screenshots-bot -->")) | .id] | first // empty')
+            --jq '[.[] | select(.body | contains("<!-- screenshots-bot -->")) | .id] | first // empty')
 
           if [ -n "$EXISTING_ID" ]; then
             gh api "/repos/${REPO}/issues/comments/${EXISTING_ID}" -X PATCH --input /tmp/comment_payload.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,8 +221,9 @@ Add the `add-screenshots` label to your PR. A GitHub Actions workflow will:
 
 1. Build the frontend
 2. Launch a local server and use Playwright to capture screenshots of key pages (home,
-   instrumentation list, and instrumentation detail tabs)
-3. Commit the screenshots to `ecosystem-explorer/screenshots/` on your PR branch
+   instrumentation list, instrumentation detail tabs, collector list, and collector detail) at
+   desktop, tablet, and mobile viewports
+3. Commit the screenshots to the `otelbot/screenshots` branch and post them as an inline PR comment
 
 The workflow re-runs automatically on new commits while the label is present.
 

--- a/docs/screenshots-workflow.md
+++ b/docs/screenshots-workflow.md
@@ -7,9 +7,9 @@ as an inline PR comment.
 
 The workflow is split across three files to support fork PRs safely:
 
-| File                      | Trigger                          | Token                                     | Responsibility                                                         |
-| ------------------------- | -------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
-| `screenshots-capture.yml` | `pull_request`                   | `contents: read`                          | Builds the app, captures screenshots, uploads artifacts                |
+| File                      | Trigger                          | Token                                     | Responsibility                                                                 |
+| ------------------------- | -------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------ |
+| `screenshots-capture.yml` | `pull_request`                   | `contents: read`                          | Builds the app, captures screenshots, uploads artifacts                        |
 | `screenshots-commit.yml`  | `workflow_run` (after capture)   | `contents: write`, `pull-requests: write` | Downloads artifacts, commits to `otelbot/screenshots` branch, posts PR comment |
 | `screenshots-cleanup.yml` | `pull_request_target` (on close) | `contents: write`                         | Deletes the PR's subfolder from the `otelbot/screenshots` branch               |
 
@@ -19,9 +19,9 @@ via `workflow_run`, not `pull_request`) means fork code never runs with elevated
 classic defense against the "Pwn Requests" attack.
 
 **Why `pull_request_target` for cleanup?** The `pull_request` event from a fork gets a read-only
-token, which can't push to the `otelbot/screenshots` branch. `pull_request_target` always runs with write
-access even for fork PRs. The cleanup job only touches the `otelbot/screenshots` branch — it never checks
-out any PR code.
+token, which can't push to the `otelbot/screenshots` branch. `pull_request_target` always runs with
+write access even for fork PRs. The cleanup job only touches the `otelbot/screenshots` branch — it
+never checks out any PR code.
 
 ## The `otelbot/screenshots` branch
 
@@ -41,8 +41,8 @@ screenshots (branch)
 └── ...
 ```
 
-The commit workflow creates the `otelbot/screenshots` branch automatically on first run. When a PR closes,
-the cleanup workflow deletes its subfolder and commits the removal.
+The commit workflow creates the `otelbot/screenshots` branch automatically on first run. When a PR
+closes, the cleanup workflow deletes its subfolder and commits the removal.
 
 Raw content URLs follow the pattern:
 
@@ -83,7 +83,7 @@ The PR comment table is built from a hardcoded `pages` list in the `Build commen
 
 ## Fork PR limitations
 
-For PRs from forks, the workflow still writes screenshots to the upstream `otelbot/screenshots` branch and
-updates the PR comment there. In practice, that means the `add-screenshots` label is generally
-applied by a maintainer or other trusted collaborator, since the screenshots are stored in the
-upstream repo rather than in the contributor's fork.
+For PRs from forks, the workflow still writes screenshots to the upstream `otelbot/screenshots`
+branch and updates the PR comment there. In practice, that means the `add-screenshots` label is
+generally applied by a maintainer or other trusted collaborator, since the screenshots are stored in
+the upstream repo rather than in the contributor's fork.

--- a/docs/screenshots-workflow.md
+++ b/docs/screenshots-workflow.md
@@ -10,8 +10,8 @@ The workflow is split across three files to support fork PRs safely:
 | File                      | Trigger                          | Token                                     | Responsibility                                                         |
 | ------------------------- | -------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
 | `screenshots-capture.yml` | `pull_request`                   | `contents: read`                          | Builds the app, captures screenshots, uploads artifacts                |
-| `screenshots-commit.yml`  | `workflow_run` (after capture)   | `contents: write`, `pull-requests: write` | Downloads artifacts, commits to `screenshots` branch, posts PR comment |
-| `screenshots-cleanup.yml` | `pull_request_target` (on close) | `contents: write`                         | Deletes the PR's subfolder from the `screenshots` branch               |
+| `screenshots-commit.yml`  | `workflow_run` (after capture)   | `contents: write`, `pull-requests: write` | Downloads artifacts, commits to `otelbot/screenshots` branch, posts PR comment |
+| `screenshots-cleanup.yml` | `pull_request_target` (on close) | `contents: write`                         | Deletes the PR's subfolder from the `otelbot/screenshots` branch               |
 
 **Why two workflows for capture + commit?** GitHub restricts fork PRs from running workflows with
 write access. Splitting into a read-only capture phase and a write-capable commit phase (triggered
@@ -19,11 +19,11 @@ via `workflow_run`, not `pull_request`) means fork code never runs with elevated
 classic defense against the "Pwn Requests" attack.
 
 **Why `pull_request_target` for cleanup?** The `pull_request` event from a fork gets a read-only
-token, which can't push to the `screenshots` branch. `pull_request_target` always runs with write
-access even for fork PRs. The cleanup job only touches the `screenshots` branch — it never checks
+token, which can't push to the `otelbot/screenshots` branch. `pull_request_target` always runs with write
+access even for fork PRs. The cleanup job only touches the `otelbot/screenshots` branch — it never checks
 out any PR code.
 
-## The `screenshots` branch
+## The `otelbot/screenshots` branch
 
 Screenshots live on a dedicated orphan branch named `screenshots`, separate from the main history.
 The layout is flat:
@@ -41,13 +41,13 @@ screenshots (branch)
 └── ...
 ```
 
-The commit workflow creates the `screenshots` branch automatically on first run. When a PR closes,
+The commit workflow creates the `otelbot/screenshots` branch automatically on first run. When a PR closes,
 the cleanup workflow deletes its subfolder and commits the removal.
 
 Raw content URLs follow the pattern:
 
 ```text
-https://raw.githubusercontent.com/open-telemetry/opentelemetry-ecosystem-explorer/screenshots/<pr>/<viewport>-<page>.png
+https://raw.githubusercontent.com/open-telemetry/opentelemetry-ecosystem-explorer/otelbot/screenshots/<pr>/<viewport>-<page>.png
 ```
 
 These URLs are embedded directly in the PR comment as inline images.
@@ -83,7 +83,7 @@ The PR comment table is built from a hardcoded `pages` list in the `Build commen
 
 ## Fork PR limitations
 
-For PRs from forks, the workflow still writes screenshots to the upstream `screenshots` branch and
+For PRs from forks, the workflow still writes screenshots to the upstream `otelbot/screenshots` branch and
 updates the PR comment there. In practice, that means the `add-screenshots` label is generally
 applied by a maintainer or other trusted collaborator, since the screenshots are stored in the
 upstream repo rather than in the contributor's fork.

--- a/ecosystem-explorer/scripts/take-screenshots.mjs
+++ b/ecosystem-explorer/scripts/take-screenshots.mjs
@@ -84,6 +84,26 @@ async function startServer() {
   });
 }
 
+async function settle(page, timeout = 10000) {
+  await page.waitForLoadState("networkidle", { timeout }).catch(() => {});
+}
+
+async function clickTab(page, name) {
+  try {
+    const tab = page.getByRole("tab", { name });
+    await tab.waitFor({ state: "visible", timeout: 5000 });
+    await tab.click();
+    await page.waitForSelector('[role="tabpanel"][data-state="active"]', {
+      state: "visible",
+      timeout: 5000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function takeScreenshots() {
   const server = await startServer();
   let browser;
@@ -137,33 +157,21 @@ async function takeScreenshots() {
         waitUntil: "domcontentloaded",
         timeout: 10000,
       });
-      await page.waitForFunction(() => document.body.textContent.includes("Showing"), {
-        timeout: 15000,
-      });
+      await settle(page);
       await page.screenshot({ path: p("instrumentation-list") });
 
       // 3. Java agent instrumentation detail - Details tab
       const detailUrl = `${BASE_URL}/java-agent/instrumentation/${DETAIL_VERSION}/${DETAIL_NAME}`;
       await page.goto(detailUrl, { waitUntil: "domcontentloaded", timeout: 10000 });
-      await page.waitForSelector('[role="tablist"]', { state: "visible", timeout: 20000 });
+      await settle(page);
       await page.screenshot({ path: p("detail-details"), fullPage: true });
 
-      // 4. Telemetry tab
-      await page.getByRole("tab", { name: "Telemetry" }).click();
-      await page.waitForSelector('[role="tabpanel"][data-state="active"]', {
-        state: "visible",
-        timeout: 5000,
-      });
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // 4. Telemetry tab (skipped gracefully if tabs aren't present in this branch)
+      await clickTab(page, "Telemetry");
       await page.screenshot({ path: p("detail-telemetry"), fullPage: true });
 
-      // 5. Configuration tab
-      await page.getByRole("tab", { name: "Configuration" }).click();
-      await page.waitForSelector('[role="tabpanel"][data-state="active"]', {
-        state: "visible",
-        timeout: 5000,
-      });
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // 5. Configuration tab (skipped gracefully if tabs aren't present in this branch)
+      await clickTab(page, "Configuration");
       await page.screenshot({ path: p("detail-configuration"), fullPage: true });
 
       // 6. Collector list
@@ -171,9 +179,7 @@ async function takeScreenshots() {
         waitUntil: "domcontentloaded",
         timeout: 10000,
       });
-      await page.waitForFunction(() => document.body.textContent.includes("Showing"), {
-        timeout: 15000,
-      });
+      await settle(page);
       await page.screenshot({ path: p("collector-list") });
 
       // 7. Collector detail
@@ -181,7 +187,7 @@ async function takeScreenshots() {
         waitUntil: "domcontentloaded",
         timeout: 10000,
       });
-      await page.waitForSelector('[role="tablist"]', { state: "visible", timeout: 20000 });
+      await settle(page);
       await page.screenshot({ path: p("collector-detail"), fullPage: true });
 
       logTime(`${viewport.name} done`);


### PR DESCRIPTION
The screenshot workflows were failing with `GH013: Repository rule violations` when pushing to the `screenshots` branch because `github-actions[bot]` is not CLA-approved (see [this workflow run](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/actions/runs/25516808734/job/74890045765)). This PR fixes the auth, aligns the branch naming with the rest of the repo's otelbot conventions, and makes the capture script resilient to partially-implemented UIs.

- Add `actions/create-github-app-token` step using `OTELBOT_APP_ID` / `OTELBOT_PRIVATE_KEY` (same secrets used by `nightly-registry-update.yml`)
- Rename storage branch from `screenshots` to `otelbot/screenshots` to follow the same naming convention as other otelbot-managed branches
- Replace hard `waitForSelector('[role="tablist"]')` and `waitForFunction("Showing")` calls with `settle()` and conditional `clickTab()`, so the script succeeds on any branch regardless of which pages are implemented