### PR TITLE
fix: resolve permanent loading state in useConfigSchema and useConfigStarter when version is empty

### DIFF
--- a/ecosystem-explorer/src/hooks/use-configuration-data.test.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-data.test.ts
@@ -129,11 +129,12 @@ describe("useConfigSchema", () => {
     expect(configData.loadConfigSchema).toHaveBeenCalledWith("1.0.0");
   });
 
-  it("should stay loading when version is empty", () => {
+  it("should set loading to false when version is empty", () => {
     const { result } = renderHook(() => useConfigSchema(""));
 
-    expect(result.current.loading).toBe(true);
+    expect(result.current.loading).toBe(false);
     expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
     expect(configData.loadConfigSchema).not.toHaveBeenCalled();
   });
 
@@ -203,10 +204,11 @@ describe("useConfigStarter", () => {
     expect(result.current.error).toBeNull();
   });
 
-  it("stays loading when version is empty", () => {
+  it("sets loading to false when version is empty", () => {
     const { result } = renderHook(() => useConfigStarter(""));
-    expect(result.current.loading).toBe(true);
+    expect(result.current.loading).toBe(false);
     expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
     expect(configData.loadConfigStarter).not.toHaveBeenCalled();
   });
 

--- a/ecosystem-explorer/src/hooks/use-configuration-data.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-data.ts
@@ -66,7 +66,10 @@ export function useConfigSchema(version: string): DataState<ConfigNode> {
     let cancelled = false;
 
     async function loadData() {
-      if (!version) return;
+      if (!version) {
+        setState({ data: null, loading: false, error: null });
+        return;
+      }
 
       setState({ data: null, loading: true, error: null });
 
@@ -106,7 +109,10 @@ export function useConfigStarter(version: string): DataState<ConfigStarter | nul
   useEffect(() => {
     let cancelled = false;
     async function loadData() {
-      if (!version) return;
+      if (!version) {
+        setState({ data: null, loading: false, error: null });
+        return;
+      }
       setState({ data: null, loading: true, error: null });
       try {
         const data = await configData.loadConfigStarter(version);


### PR DESCRIPTION
Fixes #393

Both useConfigSchema and useConfigStarter in use-configuration-data.ts had a bare return statement when the version argument was empty. Because the initial state has loading: true, this caused any component consuming these hooks to stay in a permanent loading state whenever version was not yet available (for example while the version index is still being fetched).

The fix follows the same pattern already used in use-collector-data.ts for useCollectorComponents and useCollectorComponent, which both call setState({ data: null, loading: false, error: null }) before returning early on an empty version.

Changes made:

In useConfigSchema, replaced the bare return with a proper setState call that sets loading to false before returning
In useConfigStarter, same change applied
Updated the two existing tests that were asserting the old broken behavior (loading: true on empty version) to now assert the correct behavior (loading: false on empty version)
All existing tests pass. No API changes, no type changes.