### PR TITLE
fix(faro): skip initialization when VITE_FARO_URL is not set

### DIFF
--- a/ecosystem-explorer/src/faro.ts
+++ b/ecosystem-explorer/src/faro.ts
@@ -16,19 +16,23 @@
 import { getWebInstrumentations, initializeFaro } from "@grafana/faro-react";
 import { TracingInstrumentation } from "@grafana/faro-web-tracing";
 
-initializeFaro({
-  url: "https://faro-collector-prod-us-east-2.grafana.net/collect/e587d17d38a90612e9dbedd3a3146b77",
-  app: {
-    name: "ecosystem-explorer",
-    version: "0.0.0",
-    environment: import.meta.env.MODE,
-  },
-  instrumentations: [...getWebInstrumentations(), new TracingInstrumentation()],
-  ignoreErrors: [
-    /^ResizeObserver loop limit exceeded$/,
-    /^ResizeObserver loop completed with undelivered notifications$/,
-    /^Script error\.$/,
-    /chrome-extension:\/\//,
-    /moz-extension:\/\//,
-  ],
-});
+const faroUrl = import.meta.env.VITE_FARO_URL;
+
+if (faroUrl) {
+  initializeFaro({
+    url: faroUrl,
+    app: {
+      name: "ecosystem-explorer",
+      version: "0.0.0",
+      environment: import.meta.env.MODE,
+    },
+    instrumentations: [...getWebInstrumentations(), new TracingInstrumentation()],
+    ignoreErrors: [
+      /^ResizeObserver loop limit exceeded$/,
+      /^ResizeObserver loop completed with undelivered notifications$/,
+      /^Script error\.$/,
+      /chrome-extension:\/\//,
+      /moz-extension:\/\//,
+    ],
+  });
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,9 @@ command = """
 [context.production]
 command = "npm run netlify-build:production"
 
+[context.production.environment]
+VITE_FARO_URL = "https://faro-collector-prod-us-east-2.grafana.net/collect/e587d17d38a90612e9dbedd3a3146b77"
+
 [context.deploy-preview.environment]
 VITE_FEATURE_FLAG_JAVA_CONFIG_BUILDER = "true"
 VITE_FEATURE_FLAG_COLLECTOR_PAGE = "true"


### PR DESCRIPTION
## What

Fixes Faro unconditionally initializing with a hardcoded production collector URL in local development, causing repeated CORS failures on every route.

## Changes

### 1. `src/faro.ts`

Wrapped `initializeFaro()` in a `VITE_FARO_URL` env var check. If the var is not set, Faro is a no-op. The hardcoded production URL is removed from source.

**Before:** ~11+ failed CORS requests on every page load in dev
<img width="1863" height="1049" alt="Screenshot from 2026-05-09 11-07-12" src="https://github.com/user-attachments/assets/74971b0c-2a4e-4bac-b90a-348a9c7d487a" />

**After:** Zero Faro network requests in dev
<img width="1863" height="1049" alt="Screenshot from 2026-05-09 11-22-31" src="https://github.com/user-attachments/assets/21cbf313-786e-4d1c-aeb6-3a06d341d821" />

**Verified by:**
```bash
# Start dev server and filter network tab by "faro"
bun run serve
# Before: CORS errors flooding the network tab
# After: only faro.ts script load, no fetch requests
```

### 2. `netlify.toml`

Added `VITE_FARO_URL` to `[context.production.environment]` so production deploys continue sending telemetry. Dev and branch deploys omit the var, so Faro stays silent in those environments.

This follows the same pattern as the existing `VITE_FEATURE_FLAG_*` vars.

| Environment | Faro active? |
|---|---|
| Local dev | ❌ |
| Branch deploy | ❌ |
| Deploy preview | ❌ |
| Production | ✅ |

## Type of change

- [x] Bug fix

Closes #404 