### PR TITLE
fix(collector): added min-w-0 to card links to prevent mobile overflow

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.tsx
@@ -198,7 +198,7 @@ function CollectorPageInner({ urlVersion }: { urlVersion?: string }) {
                 <Link
                   key={comp.id}
                   to={`/collector/components/${currentVersion}/${comp.id}`}
-                  className="group focus-visible:ring-primary block rounded-xl outline-none focus-visible:ring-2"
+                  className="group focus-visible:ring-primary block min-w-0 rounded-xl outline-none focus-visible:ring-2"
                 >
                   <DetailCard
                     withHoverEffect


### PR DESCRIPTION
## What

Fixes collector component cards overflowing horizontally on mobile viewports (375px).

## Changes

Added `min-w-0` to the `<Link>` wrapping each collector card in `collector-page.tsx`. Without it, the `block` element inside a CSS grid cell ignores the cell boundary and expands to fit its content.

## Verified by

Before: `document.documentElement.scrollWidth` -> 545px at 375px viewport
<img width="1859" height="1009" alt="Screenshot from 2026-05-09 15-13-43" src="https://github.com/user-attachments/assets/bf4e7515-e7a2-403b-a63f-6c4950fd8cb0" />

After: `document.documentElement.scrollWidth` -> 375px at 375px viewport
<img width="1859" height="1009" alt="Screenshot from 2026-05-09 15-15-15" src="https://github.com/user-attachments/assets/cfb8d75e-3cee-422d-b758-8cf820020aff" />

## Type of change

- [x] Bug fix

Closes #406 