### PR TITLE
test: Collector error and invalid-version paths lack test coverage

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/feature-flags", () => ({
 }));
 
 import { useCollectorVersions, useCollectorComponents } from "@/hooks/use-collector-data";
+import type { CollectorComponent } from "@/types/collector";
 
 const mockVersionsData = {
   versions: [
@@ -36,7 +37,7 @@ const mockVersionsData = {
   ],
 };
 
-const mockComponents = [
+const mockComponents: CollectorComponent[] = [
   {
     id: "receiver-otlp",
     name: "otlpreceiver",

--- a/ecosystem-explorer/src/features/collector/collector-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.test.tsx
@@ -46,7 +46,11 @@ const mockComponents: CollectorComponent[] = [
     ecosystem: "collector",
     type: "receiver",
     distribution: "core",
-    status: { stability: { stable: ["traces", "metrics", "logs"] } },
+    status: {
+      class: "receiver",
+      stability: { stable: ["traces", "metrics", "logs"] },
+      distributions: ["core"],
+    },
   },
   {
     id: "processor-batch",
@@ -56,7 +60,11 @@ const mockComponents: CollectorComponent[] = [
     ecosystem: "collector",
     type: "processor",
     distribution: "core",
-    status: { stability: { stable: ["traces", "metrics", "logs"] } },
+    status: {
+      class: "processor",
+      stability: { stable: ["traces", "metrics", "logs"] },
+      distributions: ["core"],
+    },
   },
 ];
 

--- a/ecosystem-explorer/src/features/collector/collector-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.test.tsx
@@ -164,8 +164,14 @@ describe("CollectorPage", () => {
 
     renderAtRoute("/collector/components/9.9.9");
 
+    expect(useCollectorComponents).toHaveBeenCalledWith("9.9.9");
     expect(screen.getByRole("heading", { name: "Error loading data" })).toBeInTheDocument();
-    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText((_content, element) =>
+        element?.textContent?.replace(/\s+/g, " ").trim() === "Showing 0 components"
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("No components found")).not.toBeInTheDocument();
   });
 
   it("renders component cards when data loads successfully", () => {

--- a/ecosystem-explorer/src/features/collector/collector-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.test.tsx
@@ -14,19 +14,194 @@
  * limitations under the License.
  */
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CollectorPage } from "@/features/collector/collector-page.tsx";
 
+vi.mock("@/hooks/use-collector-data", () => ({
+  useCollectorVersions: vi.fn(),
+  useCollectorComponents: vi.fn(),
+}));
+
+vi.mock("@/lib/feature-flags", () => ({
+  isEnabled: vi.fn(() => true),
+}));
+
+import { useCollectorVersions, useCollectorComponents } from "@/hooks/use-collector-data";
+
+const mockVersionsData = {
+  versions: [
+    { version: "0.100.0", is_latest: true },
+    { version: "0.99.0", is_latest: false },
+  ],
+};
+
+const mockComponents = [
+  {
+    id: "receiver-otlp",
+    name: "otlpreceiver",
+    display_name: "OTLP Receiver",
+    description: "Receives data via OTLP.",
+    ecosystem: "collector",
+    type: "receiver",
+    distribution: "core",
+    status: { stability: { stable: ["traces", "metrics", "logs"] } },
+  },
+  {
+    id: "processor-batch",
+    name: "batchprocessor",
+    display_name: "Batch Processor",
+    description: "Batches telemetry data.",
+    ecosystem: "collector",
+    type: "processor",
+    distribution: "core",
+    status: { stability: { stable: ["traces", "metrics", "logs"] } },
+  },
+];
+
+function renderAtRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/collector/components" element={<CollectorPage />} />
+        <Route path="/collector/components/:version" element={<CollectorPage />} />
+        <Route path="/collector/components/:version/:id" element={<CollectorPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe("CollectorPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders the page title", () => {
-    render(
-      <MemoryRouter>
-        <CollectorPage />
-      </MemoryRouter>
-    );
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: mockVersionsData,
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: mockComponents,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components");
+
     const heading = screen.getByRole("heading", { level: 1 });
     expect(heading).toHaveTextContent(/Collector/);
     expect(heading).toHaveTextContent(/Components/);
+  });
+
+  it("shows loading state while versions are loading", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components");
+
+    expect(screen.getByText("Loading components...")).toBeInTheDocument();
+  });
+
+  it("shows error state when versions fail to load", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error("Network error"),
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components");
+
+    expect(screen.getByRole("heading", { name: "Error loading data" })).toBeInTheDocument();
+    expect(screen.getByText("Please try refreshing the page.")).toBeInTheDocument();
+  });
+
+  it("shows error state when components fail to load", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: mockVersionsData,
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error("Failed to load collector-manifest-0.100.0: 404 Not Found"),
+    });
+
+    renderAtRoute("/collector/components");
+
+    expect(screen.getByRole("heading", { name: "Error loading data" })).toBeInTheDocument();
+    expect(screen.getByText("Please try refreshing the page.")).toBeInTheDocument();
+  });
+
+  it("shows error state for an invalid version route instead of a misleading empty list", () => {
+    // Regression guard: /collector/components/9.9.9 must show an error,
+    // not "Showing 0 components" which implies a valid but empty filter result.
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: mockVersionsData,
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error("Failed to load collector-manifest-9.9.9: 404 Not Found"),
+    });
+
+    renderAtRoute("/collector/components/9.9.9");
+
+    expect(screen.getByRole("heading", { name: "Error loading data" })).toBeInTheDocument();
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+  });
+
+  it("renders component cards when data loads successfully", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: mockVersionsData,
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: mockComponents,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components");
+
+    expect(screen.getByText("OTLP Receiver")).toBeInTheDocument();
+    expect(screen.getByText("Batch Processor")).toBeInTheDocument();
+    expect(screen.getByText(/Showing/)).toHaveTextContent("Showing 2 components");
+  });
+
+  it("renders version selector with available versions", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: mockVersionsData,
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: mockComponents,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components");
+
+    expect(screen.getByRole("option", { name: /0\.100\.0/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /0\.99\.0/ })).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/collector/collector-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.test.tsx
@@ -167,8 +167,9 @@ describe("CollectorPage", () => {
     expect(useCollectorComponents).toHaveBeenCalledWith("9.9.9");
     expect(screen.getByRole("heading", { name: "Error loading data" })).toBeInTheDocument();
     expect(
-      screen.queryByText((_content, element) =>
-        element?.textContent?.replace(/\s+/g, " ").trim() === "Showing 0 components"
+      screen.queryByText(
+        (_content, element) =>
+          element?.textContent?.replace(/\s+/g, " ").trim() === "Showing 0 components"
       )
     ).not.toBeInTheDocument();
     expect(screen.queryByText("No components found")).not.toBeInTheDocument();


### PR DESCRIPTION
## What

Expands `collector-page.test.tsx` from a single smoke test to a full suite covering error states, loading states, and invalid version routes.

---

## Changes

- Added 6 new tests to `src/features/collector/collector-page.test.tsx`:
  - **Loading state** - asserts "Loading components..." renders while hooks are loading
  - **Versions error** - asserts "Error loading data" renders when `useCollectorVersions` fails
  - **Components error** - asserts "Error loading data" renders when `useCollectorComponents` fails
  - **Invalid version regression** - renders at `/collector/components/9.9.9`, asserts error UI is shown, "Showing 0 components" is absent, and `useCollectorComponents` was called with "9.9.9"`
  - **Successful render** - asserts component cards and "Showing 2 components" render correctly
  - **Version selector** - asserts available versions are rendered in the dropdown

- Tightened the invalid-version regression assertion to use a `textContent` matcher to correctly handle the nested components

---

## Verified By

- `npx vitest run src/features/collector/collector-page.test.tsx` - 7 tests pass
- Full suite run before and after +6 passing tests
- Confirmed `/collector/components/9.9.9` shows "Error loading data" in the browser

---

## Type of Change

- [x] Test

Closes #410 
