### PR TITLE
chore(javaagent): remove unused tags field

### DIFF
--- a/ecosystem-explorer/public/schemas/javaagent-instrumentation.schema.json
+++ b/ecosystem-explorer/public/schemas/javaagent-instrumentation.schema.json
@@ -30,13 +30,6 @@
       "description": "Minimum Java version required by this instrumentation.",
       "type": "number"
     },
-    "tags": {
-      "description": "Searchable tags associated with this instrumentation.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "semantic_conventions": {
       "description": "List of semantic conventions followed by this instrumentation.",
       "type": "array",
@@ -277,7 +270,6 @@
     "library_link",
     "source_path",
     "minimum_java_version",
-    "tags",
     "semantic_conventions",
     "features",
     "scope",

--- a/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/group-instrumentations.test.ts
@@ -167,7 +167,6 @@ describe("groupInstrumentationsByDisplayName", () => {
       display_name: "Apache Kafka Client",
       description: "Kafka instrumentation",
       scope: { name: "io.opentelemetry.kafka-clients-0.11" },
-      tags: ["kafka"],
       has_javaagent: true,
       javaagent_target_versions: ["Java 8+"],
       has_standalone_library: true,

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -46,8 +46,6 @@ export interface InstrumentationData {
   source_path?: string;
   /** Minimum Java version required by this instrumentation. */
   minimum_java_version?: number;
-  /** Searchable tags associated with this instrumentation. */
-  tags?: string[];
   /** List of semantic conventions followed by this instrumentation. */
   semantic_conventions?: string[];
   /** List of telemetry features provided (e.g., TRACING, METRICS). */


### PR DESCRIPTION
Closes #398.

The `tags` field was an artifact of `_flatten_libraries()` in the watcher and stopped being populated when ParserV05 dropped that step. Per discussion in #398 we agreed to remove it rather than re-derive a grouping key.

This removes the field from the TS type and the JSON schema. PR #390 already removed the UI usage. Older registry JSON files (e.g. 2.26.1) still contain `tags` but they're silently ignored when parsed.