### PR TITLE
fix: parse key=value pairs for map type in parseDefault

### DIFF
--- a/ecosystem-explorer/src/lib/declarative-name.test.ts
+++ b/ecosystem-explorer/src/lib/declarative-name.test.ts
@@ -102,8 +102,29 @@ describe("parseDefault", () => {
     expect(parseDefault("list", "")).toEqual([]);
   });
 
-  it("returns an empty object for map default", () => {
+  it("returns an empty object for empty map default", () => {
     expect(parseDefault("map", "")).toEqual({});
+  });
+
+  it("parses key=value pairs for map default", () => {
+    expect(parseDefault("map", "host1=serviceA,host2=serviceB")).toEqual({
+      host1: "serviceA",
+      host2: "serviceB",
+    });
+  });
+
+  it("trims whitespace around keys and values in map default", () => {
+    expect(parseDefault("map", " host1 = serviceA , host2 = serviceB ")).toEqual({
+      host1: "serviceA",
+      host2: "serviceB",
+    });
+  });
+
+  it("skips pairs with no equals sign in map default", () => {
+    expect(parseDefault("map", "host1=serviceA,invalidentry,host2=serviceB")).toEqual({
+      host1: "serviceA",
+      host2: "serviceB",
+    });
   });
 
   it("trims whitespace inside list CSV", () => {

--- a/ecosystem-explorer/src/lib/declarative-name.ts
+++ b/ecosystem-explorer/src/lib/declarative-name.ts
@@ -46,6 +46,13 @@ export function parseDefault(
       if (typeof raw !== "string" || raw === "") return [];
       return raw.split(",").map((item) => item.trim());
     case "map":
-      return {};
+      if (typeof raw !== "string" || raw === "") return {};
+      return Object.fromEntries(
+        raw.split(",").flatMap((pair) => {
+          const eq = pair.indexOf("=");
+          if (eq === -1) return [];
+          return [[pair.slice(0, eq).trim(), pair.slice(eq + 1).trim()]];
+        })
+      );
   }
 }


### PR DESCRIPTION
Fixes #408

The parseDefault function in declarative-name.ts was not parsing map type defaults correctly. When the type was "map", the function always returned an empty object regardless of what the raw value was. This means that any instrumentation configuration with a map type default like "host1=serviceA,host2=serviceB" would be silently ignored and the user would see no pre-filled values.

The fix adds proper CSV parsing for map types. Each comma-separated token is split on the first equals sign to produce a key and value pair. Tokens without an equals sign are skipped. Whitespace around keys and values is trimmed. Empty string input still returns an empty object as before.

New test cases cover:
- Parsing a standard key=value CSV string
- Trimming whitespace around keys and values
- Skipping invalid tokens that have no equals sign
- Empty string still returns empty object (existing behavior preserved)

The implementation mirrors the existing list type handling already present in the same switch statement.


https://github.com/user-attachments/assets/aab73319-d84b-4dac-92d5-fee098ce8b5b
