### PR TITLE
fix: handle versions load failure and bypass stale IDB cache

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -77,7 +77,7 @@ export function InstrumentationDetailPage() {
   const [showComparison, setShowComparison] = useState(false);
   const [activeTab, setActiveTab] = useState("details");
 
-  const { data: versionsData, loading: versionsLoading } = useVersions();
+  const { data: versionsData, loading: versionsLoading, error: versionsError } = useVersions();
 
   const shouldFetchInstrumentation = version !== "latest";
   const {
@@ -122,6 +122,32 @@ export function InstrumentationDetailPage() {
               <div className="text-muted-foreground text-sm">This may take a moment</div>
             </div>
           </div>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (versionsError) {
+    return (
+      <PageContainer>
+        <BackButton />
+        <div className="mt-3">
+          <DetailCard className="border-red-500/50 bg-red-500/5">
+            <div className="flex gap-4">
+              <AlertCircle
+                className="h-6 w-6 flex-shrink-0 text-red-600 dark:text-red-400"
+                aria-hidden="true"
+              />
+              <div className="flex-1 space-y-2">
+                <h3 className="font-semibold text-red-600 dark:text-red-400">
+                  Error loading versions
+                </h3>
+                <p className="text-sm text-red-600/90 dark:text-red-400/90">
+                  {versionsError.message}
+                </p>
+              </div>
+            </div>
+          </DetailCard>
         </div>
       </PageContainer>
     );

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -166,7 +166,9 @@ export function JavaInstrumentationListPage() {
       <PageContainer>
         <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-6 text-red-600 dark:text-red-400">
           <h3 className="mb-2 font-semibold">No version available</h3>
-          <p className="text-sm">Could not determine the latest Java agent version. Please try refreshing the page.</p>
+          <p className="text-sm">
+            Could not determine the latest Java agent version. Please try refreshing the page.
+          </p>
         </div>
       </PageContainer>
     );

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -31,7 +31,7 @@ export function JavaInstrumentationListPage() {
   const { version: versionParam } = useParams<{ version?: string }>();
   const navigate = useNavigate();
 
-  const { data: versionsData, loading: versionsLoading } = useVersions();
+  const { data: versionsData, loading: versionsLoading, error: versionsError } = useVersions();
 
   const latestVersion = versionsData?.versions.find((v) => v.is_latest)?.version ?? "";
 
@@ -139,6 +139,17 @@ export function JavaInstrumentationListPage() {
     );
   }
 
+  if (versionsError) {
+    return (
+      <PageContainer>
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-6 text-red-600 dark:text-red-400">
+          <h3 className="mb-2 font-semibold">Error loading versions</h3>
+          <p className="text-sm">{versionsError.message}</p>
+        </div>
+      </PageContainer>
+    );
+  }
+
   if (error) {
     return (
       <PageContainer>
@@ -153,8 +164,9 @@ export function JavaInstrumentationListPage() {
   if (!resolvedVersion) {
     return (
       <PageContainer>
-        <div className="rounded-lg border border-yellow-500/50 bg-yellow-500/10 p-6 text-yellow-600 dark:text-yellow-400">
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-6 text-red-600 dark:text-red-400">
           <h3 className="mb-2 font-semibold">No version available</h3>
+          <p className="text-sm">Could not determine the latest Java agent version. Please try refreshing the page.</p>
         </div>
       </PageContainer>
     );

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
@@ -151,4 +151,56 @@ describe("fetchWithCache", () => {
       fetchWithCache("test-500-soft", "/broken.json", STORES.CONFIGURATION, { allow404: true })
     ).rejects.toThrow(/500/);
   });
+
+  describe("validate option", () => {
+    it("returns cached data when validate passes", async () => {
+      const data = { versions: [{ version: "1.0.0", is_latest: true }] };
+      vi.spyOn(idbCache, "getCached").mockResolvedValue(data);
+
+      const result = await fetchWithCache("key", "/url", STORES.METADATA, {
+        validate: (d: unknown) => Array.isArray((d as typeof data).versions) && (d as typeof data).versions.length > 0,
+      });
+
+      expect(result).toEqual(data);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("bypasses cache and re-fetches when validate fails", async () => {
+      const staleData = { versions: [] };
+      const freshData = { versions: [{ version: "1.0.0", is_latest: true }] };
+
+      vi.spyOn(idbCache, "getCached").mockResolvedValue(staleData);
+      vi.spyOn(idbCache, "setCached").mockResolvedValue();
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => freshData,
+      });
+
+      const result = await fetchWithCache("key", "/url", STORES.METADATA, {
+        validate: (d: unknown) => Array.isArray((d as typeof staleData).versions) && (d as typeof staleData).versions.length > 0,
+      });
+
+      expect(result).toEqual(freshData);
+      expect(global.fetch).toHaveBeenCalledWith("/url");
+    });
+
+    it("fetches from network when no cached data exists and validate is provided", async () => {
+      const freshData = { versions: [{ version: "2.0.0", is_latest: true }] };
+      vi.spyOn(idbCache, "getCached").mockResolvedValue(null);
+      vi.spyOn(idbCache, "setCached").mockResolvedValue();
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => freshData,
+      });
+
+      const result = await fetchWithCache("key", "/url", STORES.METADATA, {
+        validate: (d: unknown) => Array.isArray((d as typeof freshData).versions),
+      });
+
+      expect(result).toEqual(freshData);
+      expect(global.fetch).toHaveBeenCalledWith("/url");
+    });
+  });
 });

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
@@ -158,7 +158,8 @@ describe("fetchWithCache", () => {
       vi.spyOn(idbCache, "getCached").mockResolvedValue(data);
 
       const result = await fetchWithCache("key", "/url", STORES.METADATA, {
-        validate: (d: unknown) => Array.isArray((d as typeof data).versions) && (d as typeof data).versions.length > 0,
+        validate: (d: unknown) =>
+          Array.isArray((d as typeof data).versions) && (d as typeof data).versions.length > 0,
       });
 
       expect(result).toEqual(data);
@@ -178,7 +179,9 @@ describe("fetchWithCache", () => {
       });
 
       const result = await fetchWithCache("key", "/url", STORES.METADATA, {
-        validate: (d: unknown) => Array.isArray((d as typeof staleData).versions) && (d as typeof staleData).versions.length > 0,
+        validate: (d: unknown) =>
+          Array.isArray((d as typeof staleData).versions) &&
+          (d as typeof staleData).versions.length > 0,
       });
 
       expect(result).toEqual(freshData);

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
@@ -21,9 +21,9 @@ export interface FetchWithCacheOptions<T = unknown> {
   allow404?: boolean;
   /**
    * Optional validator for cached data. When provided, cached data that fails
-   * validation is discarded and a fresh network request is made. This prevents
-   * stale or logically-empty cached responses (e.g. `{ versions: [] }`) from
-   * being served to the caller.
+   * validation is ignored for the current request and a fresh network request
+   * is made. This prevents stale or logically-empty cached responses (e.g.
+   * `{ versions: [] }`) from being served to the caller.
    */
   validate?: (data: T) => boolean;
 }
@@ -43,8 +43,15 @@ export async function fetchWithCache<T>(
       if (isIDBAvailable()) {
         const cachedData = await getCached<T>(cacheKey, storeType);
         if (cachedData !== null) {
-          if (!options?.validate || options.validate(cachedData)) {
+          if (!options?.validate) {
             return cachedData;
+          }
+          try {
+            if (options.validate(cachedData)) {
+              return cachedData;
+            }
+          } catch {
+            // treat validator exceptions as validation failures and fall back to network fetch
           }
         }
       }

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
@@ -17,15 +17,22 @@ import { getCached, setCached, isIDBAvailable, type StoreName } from "./idb-cach
 
 const inflightRequests = new Map<string, Promise<unknown>>();
 
-export interface FetchWithCacheOptions {
+export interface FetchWithCacheOptions<T = unknown> {
   allow404?: boolean;
+  /**
+   * Optional validator for cached data. When provided, cached data that fails
+   * validation is discarded and a fresh network request is made. This prevents
+   * stale or logically-empty cached responses (e.g. `{ versions: [] }`) from
+   * being served to the caller.
+   */
+  validate?: (data: T) => boolean;
 }
 
 export async function fetchWithCache<T>(
   cacheKey: string,
   url: string,
   storeType: StoreName,
-  options?: FetchWithCacheOptions
+  options?: FetchWithCacheOptions<T>
 ): Promise<T | null> {
   if (inflightRequests.has(cacheKey)) {
     return inflightRequests.get(cacheKey) as Promise<T | null>;
@@ -36,7 +43,9 @@ export async function fetchWithCache<T>(
       if (isIDBAvailable()) {
         const cachedData = await getCached<T>(cacheKey, storeType);
         if (cachedData !== null) {
-          return cachedData;
+          if (!options?.validate || options.validate(cachedData)) {
+            return cachedData;
+          }
         }
       }
 

--- a/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
@@ -114,6 +114,26 @@ describe("javaagent-data", () => {
       await expect(javaagentData.loadVersions()).rejects.toThrow("Network error");
     });
 
+    it("should bypass cache and re-fetch when cached versions list is empty", async () => {
+      const staleData: VersionsIndex = { versions: [] };
+      const freshData: VersionsIndex = {
+        versions: [{ version: "2.10.0", is_latest: true }],
+      };
+
+      vi.spyOn(idbCache, "getCached").mockResolvedValue(staleData);
+      vi.spyOn(idbCache, "setCached").mockResolvedValue();
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => freshData,
+      });
+
+      const result = await javaagentData.loadVersions();
+
+      expect(result).toEqual(freshData);
+      expect(global.fetch).toHaveBeenCalledWith("/data/javaagent/versions-index.json");
+    });
+
     it("should deduplicate concurrent requests to the same resource", async () => {
       vi.spyOn(idbCache, "getCached").mockResolvedValue(null);
       vi.spyOn(idbCache, "setCached").mockResolvedValue();

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -23,7 +23,8 @@ export async function loadVersions(): Promise<VersionsIndex> {
   const data = await fetchWithCache<VersionsIndex>(
     "versions-index",
     `${BASE_PATH}/versions-index.json`,
-    STORES.METADATA
+    STORES.METADATA,
+    { validate: (d) => Array.isArray(d.versions) && d.versions.length > 0 }
   );
   if (!data) throw new Error("Versions index returned null unexpectedly");
   return data;


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/issues/409

I was looking into why the Java agent instrumentation page sometimes shows "No version available" and traced it down to two things happening together.

The first problem is that both java-instrumentation-list-page.tsx and instrumentation-detail-page.tsx were calling useVersions() but never reading the error it returns. So when versions-index.json failed to load (like a 404), versionsData just stayed null, the redirect to the latest version never fired, and the page silently fell through to show "No version available" with no clue what actually went wrong. Both pages now properly catch and display the versions error as a red error card.

The second problem is in fetchWithCache. If IndexedDB had a stale entry like { versions: [] } from a previous bad response, it would just return that without making any network request. There was no way to say "this cached data is not valid, go fetch fresh". I added an optional validate callback to FetchWithCacheOptions so callers can define when cached data should be rejected. loadVersions() uses this to require at least one version in the array before trusting the cache.

Changes:
- fetch-with-cache.ts: added optional validate option that bypasses cache on failure
- javaagent-data.ts: loadVersions now validates cached versions are non-empty
- java-instrumentation-list-page.tsx: surfaces versionsError instead of swallowing it
- instrumentation-detail-page.tsx: same fix
- fetch-with-cache.test.ts: 3 new tests for the validate option
- javaagent-data.test.ts: 1 new test for empty cached versions triggering a re-fetch
