### PR TITLE
docs(contrib): uv pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ CLAUDE.local.md
 
 # Local Netlify folder
 .netlify
+
+# dotenv
+.envrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ bun install
 cd ecosystem-explorer && bun install && cd ..
 
 # Set up pre-commit hooks (recommended)
-pre-commit install
+uv run pre-commit install
 ```
 
 ### Create a Branch


### PR DESCRIPTION
going through the setup quickstart and it worked quite smoothly. since we're already installing the other deps via `uv` this tweak install pre-commit the same way vs a competing `pip install pre-commit`.

dithered on adding dotenv support but I think that's a personal preference so adding it to the `.gitignore`