### PR TITLE
fix: add python-version-file to setup-python step in nightly workflow

### DIFF
--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: .python-version
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
The nightly-registry-update workflow was calling actions/setup-python without 
a with block, so it was not pinning to any specific Python version. This means 
the runner picks up whatever default Python version GitHub Actions provides at 
runtime, which can vary between runs and may not match the version the project 
actually expects.

Every other workflow in this repository that uses actions/setup-python correctly 
passes python-version-file: .python-version to read the pinned version from the 
.python-version file at the root of the repo. The nightly workflow was the only 
one missing this configuration, making it inconsistent with the rest of CI.

This inconsistency matters because the nightly workflow runs real Python code 
through uv to update the registry. If the Python version used at runtime is 
different from what is declared in .python-version, it could lead to subtle 
compatibility issues that are hard to debug, especially since nightly runs happen 
automatically and failures are not always caught right away.

The fix is straightforward. Adding the with block with python-version-file: 
.python-version ensures the nightly workflow always uses the same Python version 
as every other workflow in the repository, keeping the environment consistent 
and predictable across all CI runs.

Fixes #418
