### PR TITLE
Fix configuration builder text inputs missing accessible name when label is visually hidden

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/controls/control-wrapper.tsx
@@ -97,6 +97,11 @@ export function ControlWrapper({
 
   return (
     <div className="space-y-2">
+      {labelHidden && inputId && (
+        <label htmlFor={inputId} className="sr-only">
+          {node.label}
+        </label>
+      )}
       {!labelHidden && (
         <div className="flex items-center gap-2">
           {inputId ? (


### PR DESCRIPTION
## What

Fixes text inputs in the Configuration Builder having no accessible name when `hideLabel: true` is set. Screen readers now have a proper label to announce for every input field.

---

## Changes

**`src/features/java-agent/configuration/components/controls/control-wrapper.tsx`**
- Added a visually hidden `<label>` (using `sr-only`) rendered when `labelHidden` is true and `inputId` is provided
- The `sr-only` label is connected to the input via `htmlFor={inputId}`, giving screen readers a proper accessible name without affecting the visual layout
- The `FieldSection` heading remains the only visible label, no visual change

---

## Before / After

**Before** (console output on `/java-agent/configuration/builder`):
{ id: 'r_a6', type: 'text', hasLabel: false, ariaLabel: null, ariaLabelledBy: null, accessibleName: 'NONE' }

**After:** (console output on `/java-agent/configuration/builder`):
{ id: 'r_4e', type: 'text', hasLabel: true, ariaLabel: null, ariaLabelledBy: null, accessibleName: 'Text' }
<img width="1855" height="1010" alt="Screenshot from 2026-05-11 01-02-47" src="https://github.com/user-attachments/assets/a8eb8ca4-b3a6-4234-8d1f-f6c27b510d47" />

---

## Verified By

- Ran console script on `/java-agent/configuration/builder` SDK tab, all inputs now show `hasLabel: true` and a non-empty `accessibleName`
- Visually confirmed the page looks unchanged, no visible labels appeared
- `npx tsc --noEmit` - no TypeScript errors

---

## Type of Change

- [x] Bug fix
- [x] Accessibility

Closes #430 