### PR TITLE
Added a back navigation button to the Collector page

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 
 import { PageContainer } from "@/components/layout/page-container";
+import { BackButton } from "@/components/ui/back-button";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { useCollectorVersions, useCollectorComponents } from "@/hooks/use-collector-data";
@@ -84,7 +85,8 @@ export function CollectorPage() {
 
   return (
     <PageContainer>
-      <div className="space-y-8">
+      <div className="space-y-6">
+        <BackButton />
         <header className="space-y-4">
           <h1 className="text-foreground text-4xl font-bold tracking-tight sm:text-5xl">
             Collector{" "}


### PR DESCRIPTION
Issue : https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/issues/436
Summary
Adds a back navigation button to the Collector page to maintain consistent navigation behavior across the application.

Changes
Added a back button to the Collector page
Matched existing navigation styling and behavior used in other pages
Improved navigation consistency and overall user experience
Why
Most pages already provide an easy way for users to navigate back. The Collector page was missing this behavior, creating an inconsistent UX pattern and requiring users to rely on the browser back button.