### PR TITLE
fix: add python-version-file to setup-python in nightly workflow

### DIFF
--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## What's wrong

The `nightly-registry-update.yml` workflow sets up Python without pinning it to the
project's declared version. This means the nightly job — the one that actually runs
the watchers and writes to the registry — runs on a different Python version than
the one tested in CI.

Fixes #418 

The `setup-python` step in `nightly-registry-update.yml` has no `with` block:

```yaml
- name: Set up Python
  uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

