### PR TITLE
Fix mobile scrolling in instrumentation detail tabs

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -276,9 +276,12 @@ export function InstrumentationDetailPage() {
           </div>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="relative z-10">
-            <div className="overflow-x-auto px-4 pt-4 pb-0 sm:px-6">
+            <div
+              className="px-4 pt-4 pb-0 sm:px-6 [&_[role=tab]>svg]:hidden [&_[role=tab]]:px-2 sm:[&_[role=tab]>svg]:block sm:[&_[role=tab]]:px-4"
+            >
               <SegmentedTabList
                 value={activeTab}
+                fullWidth
                 tabs={[
                   {
                     value: "details",


### PR DESCRIPTION
## Summary

Fixes the Java instrumentation detail page tabs so they no longer create a horizontal scroller on mobile.

## Changes

- Use the existing `SegmentedTabList` `fullWidth` layout for the instrumentation detail tabs
- Remove the horizontal overflow wrapper around the tab list
- Compact the tab trigger spacing on small screens so labels fit without scrolling

## Testing

- `git diff --check`