### PR TITLE
feat(ui): StatusPill + GlowBadge variants (Phase 1 - Foundation PR 4)

### DIFF
--- a/ecosystem-explorer/src/components/ui/glow-badge.tsx
+++ b/ecosystem-explorer/src/components/ui/glow-badge.tsx
@@ -15,7 +15,7 @@
  */
 import React from "react";
 
-type BadgeVariant = "primary" | "success" | "info" | "warning" | "muted";
+type BadgeVariant = "accent" | "secondary" | "success" | "info" | "warning" | "error" | "muted";
 
 interface GlowBadgeProps {
   children: React.ReactNode;
@@ -25,10 +25,13 @@ interface GlowBadgeProps {
 }
 
 const variantStyles: Record<BadgeVariant, { base: string; glow: string }> = {
-  // TODO(#84 PR 4): rename variant or remap tokens — "primary" currently uses secondary tokens after the brand swap.
-  primary: {
+  accent: {
     base: "bg-secondary/10 border-secondary/30 text-secondary",
     glow: "shadow-sm shadow-secondary/20",
+  },
+  secondary: {
+    base: "bg-slate-500/10 border-slate-500/30 text-slate-600 dark:text-slate-400",
+    glow: "shadow-sm shadow-slate-500/20",
   },
   success: {
     base: "bg-green-500/10 border-green-500/30 text-green-600 dark:text-green-400",
@@ -42,6 +45,10 @@ const variantStyles: Record<BadgeVariant, { base: string; glow: string }> = {
     base: "bg-orange-500/10 border-orange-500/30 text-orange-600 dark:text-orange-400",
     glow: "shadow-sm shadow-orange-500/20",
   },
+  error: {
+    base: "bg-red-500/10 border-red-500/30 text-red-600 dark:text-red-400",
+    glow: "shadow-sm shadow-red-500/20",
+  },
   muted: {
     base: "bg-muted border-border/50 text-muted-foreground",
     glow: "",
@@ -50,7 +57,7 @@ const variantStyles: Record<BadgeVariant, { base: string; glow: string }> = {
 
 export function GlowBadge({
   children,
-  variant = "primary",
+  variant = "accent",
   withGlow = false,
   className = "",
 }: GlowBadgeProps) {

--- a/ecosystem-explorer/src/components/ui/status-pill.test.tsx
+++ b/ecosystem-explorer/src/components/ui/status-pill.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { StatusPill, type Stability } from "./status-pill";
+
+// Locked color mapping per decision-log 2026-05-06.
+// Each entry pins the base text class (light theme) and the dark-mode override
+// against the rendered span's className. JSDOM does not evaluate Tailwind's
+// `dark:` modifier, so these are static-string assertions on the className —
+// they verify wiring, not visual output.
+const VARIANTS: ReadonlyArray<{
+  stability: Stability;
+  label: string;
+  base: string;
+  dark: string;
+}> = [
+  {
+    stability: "development",
+    label: "Development",
+    base: "text-slate-600",
+    dark: "dark:text-slate-400",
+  },
+  { stability: "alpha", label: "Alpha", base: "text-orange-600", dark: "dark:text-orange-400" },
+  { stability: "beta", label: "Beta", base: "text-blue-600", dark: "dark:text-blue-400" },
+  { stability: "stable", label: "Stable", base: "text-green-600", dark: "dark:text-green-400" },
+  { stability: "deprecated", label: "Deprecated", base: "text-red-600", dark: "dark:text-red-400" },
+  {
+    stability: "unmaintained",
+    label: "Unmaintained",
+    base: "text-red-600",
+    dark: "dark:text-red-400",
+  },
+];
+
+describe("StatusPill", () => {
+  it.each(VARIANTS)(
+    "renders $stability with $label label and $base + $dark classes",
+    ({ stability, label, base, dark }) => {
+      render(<StatusPill stability={stability} />);
+      const pill = screen.getByText(label);
+      expect(pill.className).toContain(base);
+      expect(pill.className).toContain(dark);
+    }
+  );
+
+  it("renders all six stability levels with title-case labels", () => {
+    render(
+      <>
+        {VARIANTS.map(({ stability }) => (
+          <StatusPill key={stability} stability={stability} />
+        ))}
+      </>
+    );
+    for (const { label } of VARIANTS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("renders deprecated and unmaintained with distinct labels but the same red classes", () => {
+    render(
+      <>
+        <StatusPill stability="deprecated" />
+        <StatusPill stability="unmaintained" />
+      </>
+    );
+    const deprecated = screen.getByText("Deprecated");
+    const unmaintained = screen.getByText("Unmaintained");
+    expect(deprecated).not.toBe(unmaintained);
+    expect(deprecated.className).toContain("text-red-600");
+    expect(deprecated.className).toContain("dark:text-red-400");
+    expect(unmaintained.className).toContain("text-red-600");
+    expect(unmaintained.className).toContain("dark:text-red-400");
+  });
+
+  it("forwards className to the rendered element", () => {
+    render(<StatusPill stability="stable" className="custom-class" />);
+    expect(screen.getByText("Stable").className).toContain("custom-class");
+  });
+});

--- a/ecosystem-explorer/src/components/ui/status-pill.tsx
+++ b/ecosystem-explorer/src/components/ui/status-pill.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GlowBadge } from "./glow-badge";
+
+const STABILITY_VARIANT = {
+  development: "secondary",
+  alpha: "warning",
+  beta: "info",
+  stable: "success",
+  deprecated: "error",
+  unmaintained: "error",
+} as const;
+
+const STABILITY_LABEL = {
+  development: "Development",
+  alpha: "Alpha",
+  beta: "Beta",
+  stable: "Stable",
+  deprecated: "Deprecated",
+  unmaintained: "Unmaintained",
+} as const;
+
+export type Stability = keyof typeof STABILITY_VARIANT;
+
+interface StatusPillProps {
+  stability: Stability;
+  className?: string;
+}
+
+export function StatusPill({ stability, className }: StatusPillProps) {
+  return (
+    <GlowBadge variant={STABILITY_VARIANT[stability]} className={className}>
+      {STABILITY_LABEL[stability]}
+    </GlowBadge>
+  );
+}


### PR DESCRIPTION
Part of the Phase 1 foundation work for the explorer redesign (#84).

Contributes to #370.

## What's in this PR

- Adds `<StatusPill stability="development|alpha|beta|stable|deprecated|unmaintained" />` at `src/components/ui/status-pill.tsx`. Internally renders `<GlowBadge>` with the variant mapping:
  - `development` → `secondary` (slate)
  - `alpha` → `warning` (orange)
  - `beta` → `info` (blue)
  - `stable` → `success` (green)
  - `deprecated` → `error` (red)
  - `unmaintained` → `error` (red, distinct label)
- Display labels are title case: `Development`, `Alpha`, `Beta`, `Stable`, `Deprecated`, `Unmaintained`.
- Extends `<GlowBadge>` with two new variants, both following the existing raw-Tailwind shade pattern (`bg-{color}-500/10 border-{color}-500/30 text-{color}-600 dark:text-{color}-400`):
  - `secondary` — slate (gray) for `development`
  - `error` — red for `deprecated` and `unmaintained`

## What's not in this PR

- `<StabilityBadge>` is untouched. Migrating the Java configuration builder to `<StatusPill stability="development" />` is a follow-up cleanup PR after Phase 1.
- Not yet rendered. `<StatusPill>` is a primitive; the list page (Phase 4) and ecosystem landing (Phase 3) will consume it behind the `V1_REDESIGN` flag.
- No new color tokens. The variants reuse Tailwind's `red-*` and `slate-*` shades, matching existing `<GlowBadge>` variants.

## Verification

- `bun run typecheck` — clean
- `bun run test` — 814 tests pass (9 new in `status-pill.test.tsx`)
- `npx react-doctor` — 100/100, zero findings on touched files
- `bun run format` — clean

---

> Co-authored with Claude Opus 4.7.