### PR TITLE
fix: show friendly error page when version in URL does not exist on detail page

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { useEffect, useState } from "react";
 import {
   Info,
@@ -79,7 +79,12 @@ export function InstrumentationDetailPage() {
 
   const { data: versionsData, loading: versionsLoading, error: versionsError } = useVersions();
 
-  const shouldFetchInstrumentation = version !== "latest";
+  const isVersionValid =
+    version === "latest" ||
+    !versionsData ||
+    versionsData.versions.some((v) => v.version === version);
+
+  const shouldFetchInstrumentation = version !== "latest" && isVersionValid;
   const {
     data: instrumentation,
     loading: instrumentationLoading,
@@ -145,6 +150,43 @@ export function InstrumentationDetailPage() {
                 <p className="text-sm text-red-600/90 dark:text-red-400/90">
                   {versionsError.message}
                 </p>
+              </div>
+            </div>
+          </DetailCard>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (!isVersionValid && versionsData) {
+    const latestVersion = versionsData.versions.find((v) => v.is_latest)?.version;
+    return (
+      <PageContainer>
+        <BackButton />
+        <div className="mt-3">
+          <DetailCard className="border-yellow-500/50 bg-yellow-500/5">
+            <div className="flex gap-4">
+              <AlertCircle
+                className="h-6 w-6 flex-shrink-0 text-yellow-600 dark:text-yellow-400"
+                aria-hidden="true"
+              />
+              <div className="flex-1 space-y-3">
+                <h3 className="font-semibold text-yellow-600 dark:text-yellow-400">
+                  Version not found
+                </h3>
+                <p className="text-sm text-yellow-600/90 dark:text-yellow-400/90">
+                  Version{" "}
+                  <code className="rounded bg-yellow-500/10 px-1 py-0.5">{version}</code> does not
+                  exist.
+                </p>
+                {latestVersion && name && (
+                  <Link
+                    to={`/java-agent/instrumentation/${latestVersion}/${name}`}
+                    className="inline-flex items-center gap-1.5 text-sm text-yellow-600 underline hover:no-underline dark:text-yellow-400"
+                  >
+                    View {name} under the latest version ({latestVersion})
+                  </Link>
+                )}
               </div>
             </div>
           </DetailCard>

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -175,9 +175,8 @@ export function InstrumentationDetailPage() {
                   Version not found
                 </h3>
                 <p className="text-sm text-yellow-600/90 dark:text-yellow-400/90">
-                  Version{" "}
-                  <code className="rounded bg-yellow-500/10 px-1 py-0.5">{version}</code> does not
-                  exist.
+                  Version <code className="rounded bg-yellow-500/10 px-1 py-0.5">{version}</code>{" "}
+                  does not exist.
                 </p>
                 {latestVersion && name && (
                   <Link


### PR DESCRIPTION
When a user visits a URL like `/java-agent/instrumentation/9.9.9/akka-actor` with a version that does not exist, the page was trying to fetch the data file for that version anyway. Since the version is not real, the server returned an HTML page instead of JSON, and the raw error `Unexpected token '<', "<!doctype "... is not valid JSON` was shown directly in the UI.

This is the same class of problem that was fixed on the list page in issue 424, now applied to the detail page.

The fix checks the version param against the list of known versions after `versionsData` loads. If the version is not recognised, the instrumentation fetch is skipped entirely and a friendly warning card is shown instead. The card displays the invalid version name and a direct link to view the same instrumentation under the latest version.

Closes #456