### PR TITLE
fix: prevent partial registry push when a watcher fails

### DIFF
--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -223,7 +223,11 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: |
+          steps.check_changes.outputs.has_changes == 'true' &&
+          steps.collector_watcher.outcome == 'success' &&
+          steps.java_instrumentation_watcher.outcome == 'success' &&
+          steps.configuration_watcher.outcome == 'success'
         env:
           GH_TOKEN:
             ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token


### PR DESCRIPTION
## What's wrong

In `nightly-registry-update.yml`, all three watchers run with `continue-on-error: true`.
The commit and push step that follows has no check on whether the watchers actually succeeded:


Fixes #468


```yaml
- name: Commit and push changes
  if: steps.check_changes.outputs.has_changes == 'true'






