### PR TITLE
feat: add Clear all button when filters are active

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-filter-bar.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-filter-bar.test.tsx
@@ -193,6 +193,66 @@ describe("InstrumentationFilterBar", () => {
     expect(standaloneButton.className).toContain(FILTER_STYLES.target.library.inactive);
   });
 
+  it("shows 'Clear all' button when any filter is active", () => {
+    const activeFilters: FilterState = {
+      search: "http",
+      telemetry: new Set(["spans"]),
+      target: new Set(),
+      semantic: [],
+      features: [],
+    };
+    render(
+      <InstrumentationFilterBar
+        filters={activeFilters}
+        onFiltersChange={vi.fn()}
+        instrumentations={[]}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeInTheDocument();
+  });
+
+  it("does not show 'Clear all' button when no filters are active", () => {
+    render(
+      <InstrumentationFilterBar
+        filters={defaultFilters}
+        onFiltersChange={vi.fn()}
+        instrumentations={[]}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Clear all" })).not.toBeInTheDocument();
+  });
+
+  it("clears all filters when 'Clear all' is clicked", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    const activeFilters: FilterState = {
+      search: "http",
+      telemetry: new Set(["spans"]),
+      target: new Set(["javaagent"]),
+      semantic: ["db"],
+      features: ["db.client.connections"],
+    };
+    render(
+      <InstrumentationFilterBar
+        filters={activeFilters}
+        onFiltersChange={onFiltersChange}
+        instrumentations={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      search: "",
+      telemetry: new Set(),
+      target: new Set(),
+      semantic: [],
+      features: [],
+    });
+  });
+
   it("sets aria-pressed attribute correctly for toggle buttons", () => {
     const activeFilters: FilterState = {
       search: "",

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-filter-bar.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-filter-bar.tsx
@@ -102,6 +102,28 @@ export function InstrumentationFilterBar({
       </div>
 
       <div className="relative z-40 space-y-6">
+        {(filters.search !== "" ||
+          filters.telemetry.size > 0 ||
+          filters.target.size > 0 ||
+          filters.semantic.length > 0 ||
+          filters.features.length > 0) && (
+          <div className="flex justify-end">
+            <button
+              onClick={() =>
+                onFiltersChange({
+                  search: "",
+                  telemetry: new Set(),
+                  target: new Set(),
+                  semantic: [],
+                  features: [],
+                })
+              }
+              className="text-primary text-sm font-semibold hover:underline"
+            >
+              Clear all
+            </button>
+          </div>
+        )}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-2">
             <label htmlFor="search" className="text-muted-foreground text-sm font-medium">


### PR DESCRIPTION
## SUMMARY

Adds a conditional **"Clear all"** action to the Java instrumentation filter bar, allowing users to quickly reset all active filters from a single place instead of manually clearing each filter individually. 

## FIX

Implemented a conditional `Clear all` button inside `InstrumentationFilterBar` that appears whenever any search, telemetry, or target filter is active. Clicking the button resets all filter dimensions back to their default empty state using the existing `onFiltersChange` callback. The update also includes test coverage validating button visibility, hidden state when no filters are active, and correct reset behavior when clicked.

## CHECKLIST

* [x] Feature implemented with minimal surface-area changes
* [x] Existing filter state API reused
* [x] Added unit test coverage
* [x] No breaking API changes
* [x] UI behavior verified locally
* [x] Ready for review
