### PR TITLE
fix(test): replace lazy-load heading assertion in App.test

### DIFF
--- a/ecosystem-explorer/src/App.test.tsx
+++ b/ecosystem-explorer/src/App.test.tsx
@@ -23,18 +23,19 @@ describe("App", () => {
     vi.unstubAllEnvs();
   });
 
-  it("renders the legacy app when V1_REDESIGN is disabled", async () => {
+  it("renders the legacy app when V1_REDESIGN is disabled", () => {
     vi.stubEnv("VITE_FEATURE_FLAG_V1_REDESIGN", "");
 
-    render(
+    const { container } = render(
       <ThemeProvider>
         <App />
       </ThemeProvider>
     );
 
-    const heading = await screen.findByRole("heading", { level: 1 });
-    expect(heading).toHaveTextContent("OpenTelemetry");
-    expect(heading).toHaveTextContent("Ecosystem Explorer");
+    // V1App adds .v1-app to scope its token overrides; absence confirms legacy rendering.
+    expect(container.querySelector(".v1-app")).toBeNull();
+    // LegacyApp's Header renders "OTel Explorer" synchronously — no lazy load needed.
+    expect(screen.getByText("OTel Explorer")).toBeInTheDocument();
   });
 
   it("renders the v1 app when V1_REDESIGN is enabled", async () => {


### PR DESCRIPTION
## SUMMARY

Fix flaky legacy app rendering test in `App.test.tsx` that failed during full test suite execution.

---

## FIX

The test was waiting for a heading rendered inside a lazy-loaded component, which sometimes timed out when all tests ran in parallel. This update replaces that async check with simple synchronous assertions by verifying the absence of `.v1-app` and checking for the `"OTel Explorer"` text. The approach matches the sibling V1 test and makes the test stable and deterministic.

---

## CHECKLIST

* [x] Reproduced issue locally
* [x] Verified fix with full test suite
* [x] Minimal test-only change
* [x] No production code changes
