### PR TITLE
fix: use (name, subtype) tuple as component key in DeprecationDetector

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/deprecation_detector.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/deprecation_detector.py
@@ -52,11 +52,11 @@ class DeprecationDetector:
             previous_set = self._build_component_set(previous_components.get(component_type, []))
             current_set = self._build_component_set(current_components.get(component_type, []))
 
-            removed_names = previous_set - current_set
+            removed_keys = previous_set - current_set
 
             deprecated_list = []
             for component in previous_components.get(component_type, []):
-                if component["name"] in removed_names:
+                if (component["name"], component.get("subtype")) in removed_keys:
                     deprecated_component = self._create_deprecated_component(
                         component, previous_version, current_version
                     )
@@ -67,9 +67,9 @@ class DeprecationDetector:
         return deprecated_components
 
     @staticmethod
-    def _build_component_set(components: list[dict[str, Any]]) -> set[str]:
-        """Build a set of component names."""
-        return {component["name"] for component in components}
+    def _build_component_set(components: list[dict[str, Any]]) -> set[tuple[str, str | None]]:
+        """Build a set of (name, subtype) tuples to uniquely identify components."""
+        return {(component["name"], component.get("subtype")) for component in components}
 
     @staticmethod
     def _create_deprecated_component(

--- a/ecosystem-automation/collector-watcher/tests/test_deprecation_detector.py
+++ b/ecosystem-automation/collector-watcher/tests/test_deprecation_detector.py
@@ -252,3 +252,97 @@ def test_create_deprecated_component(detector, previous_version, current_version
     assert deprecated["source_repo"] == "core"
     assert deprecated["distributions"] == ["core"]
     assert deprecated["subtype"] is None
+
+
+def test_detect_deprecated_subtype_removal(detector, previous_version, current_version):
+    """A component removed from one subtype should be detected even if the same
+    name still exists under a different subtype."""
+    previous = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "zipkin",
+                "source_repo": "contrib",
+                "distributions": ["contrib"],
+                "subtype": "encoding",
+            },
+            {
+                "name": "zipkin",
+                "source_repo": "contrib",
+                "distributions": ["contrib"],
+                "subtype": "storage",
+            },
+        ],
+    }
+
+    current = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "zipkin",
+                "source_repo": "contrib",
+                "distributions": ["contrib"],
+                "subtype": "storage",
+            },
+        ],
+    }
+
+    deprecated = detector.detect_deprecated(
+        previous_version=previous_version,
+        previous_components=previous,
+        current_version=current_version,
+        current_components=current,
+    )
+
+    assert len(deprecated["extension"]) == 1
+    assert deprecated["extension"][0]["name"] == "zipkin"
+    assert deprecated["extension"][0]["subtype"] == "encoding"
+
+
+def test_detect_deprecated_same_name_different_subtype_no_false_positive(detector, previous_version, current_version):
+    """When a component exists under the same name but its subtype changes,
+    only the removed subtype entry should be flagged, not the surviving one."""
+    previous = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "otlp",
+                "source_repo": "core",
+                "distributions": ["core"],
+                "subtype": "encoding",
+            },
+        ],
+    }
+
+    current = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "otlp",
+                "source_repo": "core",
+                "distributions": ["core"],
+                "subtype": "encoding",
+            },
+        ],
+    }
+
+    deprecated = detector.detect_deprecated(
+        previous_version=previous_version,
+        previous_components=previous,
+        current_version=current_version,
+        current_components=current,
+    )
+
+    assert len(deprecated["extension"]) == 0


### PR DESCRIPTION
Fixes #493

## What was wrong

The `_build_component_set` method in `DeprecationDetector` was building a plain set of component names to figure out which components had been removed between versions. That works fine when every component in a list has a unique name, but collector extension components can have a `subtype` field (encoding, observer, storage) because they live in nested directories. Two extension components with the same name but different subtypes are completely separate things, yet the old code treated them as the same.

A concrete example: if you had a `zipkin` encoding extension and a `zipkin` storage extension in the previous version, and then the encoding one got removed in the next version, the detector would see `zipkin` in both the old and new sets and conclude nothing was removed. The deprecation would go untracked.

## What I changed

Changed the set to hold `(name, subtype)` tuples instead of plain names. Updated the check inside `detect_deprecated` to match against those tuples. The variable was also renamed from `removed_names` to `removed_keys` to reflect that it now holds tuples rather than plain strings.

## Tests

Added two new test cases in `test_deprecation_detector.py`:

- `test_detect_deprecated_subtype_removal`: verifies that removing one subtype entry while keeping another with the same name is correctly detected as a deprecation.
- `test_detect_deprecated_same_name_different_subtype_no_false_positive`: verifies that when a component with a specific subtype survives unchanged, no false deprecation is reported.

All 8 tests pass.