### PR TITLE
fix(config-builder): keep YAML preview sticky on scroll

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
@@ -46,7 +46,7 @@ export function PreviewCard({ schema }: PreviewCardProps): JSX.Element {
   return (
     <section
       aria-label="Output Preview"
-      className="border-border/50 bg-card/40 space-y-3 rounded-xl border p-5 lg:sticky lg:top-24"
+      className="border-border/50 bg-card/40 space-y-3 rounded-xl border p-5 lg:sticky lg:top-24 lg:self-start"
     >
       <header className="flex flex-wrap items-center justify-between gap-3">
         <h3 className="text-foreground text-sm font-medium">Output Preview</h3>

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
@@ -46,7 +46,7 @@ export function PreviewCard({ schema }: PreviewCardProps): JSX.Element {
   return (
     <section
       aria-label="Output Preview"
-      className="border-border/50 bg-card/40 space-y-3 rounded-xl border p-5 lg:sticky lg:top-24 lg:self-start"
+      className="border-border/50 bg-card/40 space-y-3 rounded-xl border p-5 lg:sticky lg:top-20 lg:self-start"
     >
       <header className="flex flex-wrap items-center justify-between gap-3">
         <h3 className="text-foreground text-sm font-medium">Output Preview</h3>


### PR DESCRIPTION
The Output Preview on the Configuration Builder was supposed to stay pinned in view while scrolling the form, but in practice it scrolled off with the page.

Cause: the section was being stretched to the full grid row height by the default `align-items: stretch`. Sticky only works when the element is shorter than its containing block, otherwise it falls back to static. The form column makes the row ~2700px tall, the preview saturated the same height, sticky stopped working.

`lg:self-start` keeps the section at its natural height (~880px) inside the much taller row.

Prerequisite for #478 (highlight the YAML section being edited): that feature is only useful if the preview stays in view
