### PR TITLE
fix: use (name, subtype) tuple as deduplication key in add_deprecated_components

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -353,10 +353,14 @@ class InventoryManager:
             new_deprecated: New deprecated components by type
         """
         for component_type, components in new_deprecated.items():
-            existing_names = {comp["name"] for comp in deprecations[distribution][component_type]}
+            existing_keys = {
+                (comp["name"], comp.get("subtype"))
+                for comp in deprecations[distribution][component_type]
+            }
 
             for component in components:
-                if component["name"] not in existing_names:
+                key = (component["name"], component.get("subtype"))
+                if key not in existing_keys:
                     deprecations[distribution][component_type].append(component)
                     logger.info(
                         f"Added deprecated {component_type}: {component['name']} "

--- a/ecosystem-automation/collector-watcher/tests/test_inventory.py
+++ b/ecosystem-automation/collector-watcher/tests/test_inventory.py
@@ -607,3 +607,110 @@ def test_add_deprecated_components_multiple_distributions(temp_inventory_dir):
     assert deprecations["core"]["receiver"][0]["name"] == "corereceiver"
     assert len(deprecations["contrib"]["exporter"]) == 1
     assert deprecations["contrib"]["exporter"][0]["name"] == "contribexporter"
+
+
+def test_add_deprecated_components_same_name_different_subtype(temp_inventory_dir):
+    """A component removed under a second subtype should be added even when the
+    same name is already present in the index under a different subtype."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    deprecations = {
+        "core": {
+            "receiver": [],
+            "processor": [],
+            "exporter": [],
+            "connector": [],
+            "extension": [
+                {
+                    "name": "zipkin",
+                    "last_version": "v0.139.0",
+                    "deprecated_in_version": "v0.140.0",
+                    "source_repo": "contrib",
+                    "distributions": ["contrib"],
+                    "subtype": "encoding",
+                }
+            ],
+        },
+        "contrib": {
+            "receiver": [],
+            "processor": [],
+            "exporter": [],
+            "connector": [],
+            "extension": [],
+        },
+    }
+
+    new_deprecated = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "zipkin",
+                "last_version": "v0.140.0",
+                "deprecated_in_version": "v0.141.0",
+                "source_repo": "contrib",
+                "distributions": ["contrib"],
+                "subtype": "storage",
+            }
+        ],
+    }
+
+    manager.add_deprecated_components(deprecations, "core", new_deprecated)
+
+    assert len(deprecations["core"]["extension"]) == 2
+    subtypes = {comp["subtype"] for comp in deprecations["core"]["extension"]}
+    assert subtypes == {"encoding", "storage"}
+
+
+def test_add_deprecated_components_no_duplicate_same_name_and_subtype(temp_inventory_dir):
+    """A component with the same name AND subtype must not be added twice."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    deprecations = {
+        "core": {
+            "receiver": [],
+            "processor": [],
+            "exporter": [],
+            "connector": [],
+            "extension": [
+                {
+                    "name": "zipkin",
+                    "last_version": "v0.139.0",
+                    "deprecated_in_version": "v0.140.0",
+                    "source_repo": "contrib",
+                    "distributions": ["contrib"],
+                    "subtype": "encoding",
+                }
+            ],
+        },
+        "contrib": {
+            "receiver": [],
+            "processor": [],
+            "exporter": [],
+            "connector": [],
+            "extension": [],
+        },
+    }
+
+    new_deprecated = {
+        "receiver": [],
+        "processor": [],
+        "exporter": [],
+        "connector": [],
+        "extension": [
+            {
+                "name": "zipkin",
+                "last_version": "v0.139.0",
+                "deprecated_in_version": "v0.140.0",
+                "source_repo": "contrib",
+                "distributions": ["contrib"],
+                "subtype": "encoding",
+            }
+        ],
+    }
+
+    manager.add_deprecated_components(deprecations, "core", new_deprecated)
+
+    assert len(deprecations["core"]["extension"]) == 1


### PR DESCRIPTION
Closes #523

## What this fixes

The `add_deprecated_components` method in `InventoryManager` was checking for duplicates using only the component name. That works fine when every component name is unique, but it breaks down as soon as two components share the same name under different subtypes.

Here is a concrete example. The Collector has extensions under both `extension/encoding` and `extension/storage`. If a component called `zipkin` existed under both, and the encoding variant was removed first and recorded as deprecated, then when the storage variant was removed later, the code would find `zipkin` already in `existing_names` and skip the second entry entirely. The storage deprecation would be permanently lost from the registry with no warning.

## The fix

Changed the deduplication set from a flat set of names to a set of `(name, subtype)` tuples. This is exactly the same approach used to fix `DeprecationDetector._build_component_set` in PR 498 and issue 493. The detection side was already corrected there, and this PR corrects the persistence side so correctly detected removals are not dropped before they reach the registry.

Before:
```python
existing_names = {comp["name"] for comp in deprecations[distribution][component_type]}

if component["name"] not in existing_names:
```

After:
```python
existing_keys = {
    (comp["name"], comp.get("subtype"))
    for comp in deprecations[distribution][component_type]
}

if (component["name"], component.get("subtype")) not in existing_keys:
```

## Tests

Added two new test cases in `test_inventory.py`:

`test_add_deprecated_components_same_name_different_subtype`
Verifies that when `zipkin (encoding)` is already in the index and `zipkin (storage)` is newly deprecated, both entries end up in the index.

`test_add_deprecated_components_no_duplicate_same_name_and_subtype`
Verifies that an entry with the exact same name and the exact same subtype is still correctly skipped, so the existing deduplication behavior is preserved.

All 145 tests in the collector-watcher suite pass.