### PR TITLE
ci: aggregate javaagent global-configurations in db-builder workflow

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -85,6 +85,16 @@ jobs:
         if: inputs.build_mode == 'clean'
         run: uv run explorer-db-builder --ecosystem ${{ inputs.ecosystem }} --clean
 
+      - name: Set up Bun
+        if: inputs.ecosystem == 'all' || inputs.ecosystem == 'javaagent'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.13"
+
+      - name: Aggregate Java agent global configurations
+        if: inputs.ecosystem == 'all' || inputs.ecosystem == 'javaagent'
+        run: bun ecosystem-explorer/scripts/aggregate-configurations.mjs
+
       - name: Check for database changes
         id: check_changes
         run: |


### PR DESCRIPTION
Runs `bun scripts/aggregate-configurations.mjs` after the Python db-builder, so a clean rebuild regenerates `global-configurations.json` instead of dropping it.