### PR TITLE
fix(config-builder): prune orphan instrumentation customizations on agent version switch

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -70,6 +70,19 @@ const INSTRUMENTATIONS_SECTION_KEY = "instrumentations";
 const INSTRUMENTATIONS_SECTION_LABEL = "Instrumentations";
 const GENERAL_SETTINGS_LABEL = "General settings";
 
+// Drops instrumentation customizations that reference modules not present in the
+// selected agent version. Without this, switching from a newer agent (where a
+// module exists) to an older one would leak orphan entries into the YAML output.
+function PruneInstrumentationsForAgentVersion({ javaAgentVersion }: { javaAgentVersion: string }) {
+  const { pruneInstrumentations } = useConfigurationBuilder();
+  const { data } = useInstrumentations(javaAgentVersion);
+  useEffect(() => {
+    if (!data) return;
+    pruneInstrumentations(groupByModule(data).map((m) => m.name));
+  }, [data, pruneInstrumentations]);
+  return null;
+}
+
 interface SdkTabContentProps {
   schema: GroupNode;
   starter: ReturnType<typeof useConfigStarter>["data"];
@@ -111,6 +124,7 @@ function SdkTabContent({
       version={schemaVersion}
       starter={starter}
     >
+      <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
       <div className={BUILDER_GRID}>
         <ConfigurationTocSidebar
           activeTab={activeTab}
@@ -162,6 +176,7 @@ function InstrumentationTabContent({
       version={schemaVersion}
       starter={starter}
     >
+      <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
       <InstrumentationTabBody
         activeTab={activeTab}
         schema={schema}

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -176,7 +176,6 @@ function InstrumentationTabContent({
       version={schemaVersion}
       starter={starter}
     >
-      <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
       <InstrumentationTabBody
         activeTab={activeTab}
         schema={schema}
@@ -214,7 +213,7 @@ function InstrumentationTabBody({
   const sectionsContainerRef = useRef<HTMLDivElement>(null);
   const { activeKey, scrollToSection } = useActiveSection(sectionKeys, sectionsContainerRef);
 
-  const { state, setEnabled } = useConfigurationBuilder();
+  const { state, setEnabled, pruneInstrumentations } = useConfigurationBuilder();
 
   const instrumentationsState = useInstrumentations(javaAgentVersion);
   const modules = useMemo(
@@ -223,6 +222,11 @@ function InstrumentationTabBody({
   );
   const customizedSet = useCustomizedModules(modules);
   const customizationCount = customizedSet.size;
+
+  useEffect(() => {
+    if (!instrumentationsState.data) return;
+    pruneInstrumentations(modules.map((m) => m.name));
+  }, [instrumentationsState.data, modules, pruneInstrumentations]);
 
   const devSection = state.values[INSTRUMENTATION_DEV_KEY];
   const hasDevContent = useMemo(() => hasMeaningfulLeaf(devSection), [devSection]);

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.test.ts
@@ -23,6 +23,27 @@ describe("configurationBuilderReducer", () => {
     version: "1.0.0",
   };
 
+  const INSTRUMENTATION_PATH = ["distribution", "javaagent", "instrumentation"] as const;
+
+  function getInst(s: ReturnType<typeof configurationBuilderReducer>) {
+    let cur: unknown = s.values;
+    for (const seg of INSTRUMENTATION_PATH) {
+      if (!cur || typeof cur !== "object") return undefined;
+      cur = (cur as Record<string, unknown>)[seg];
+    }
+    return cur as { enabled?: string[]; disabled?: string[] } | undefined;
+  }
+
+  function stateWithInstrumentationLists(enabled: string[], disabled: string[]) {
+    const inst: Record<string, string[]> = {};
+    if (enabled.length > 0) inst.enabled = enabled;
+    if (disabled.length > 0) inst.disabled = disabled;
+    return {
+      ...baseState,
+      values: { distribution: { javaagent: { instrumentation: inst } } },
+    };
+  }
+
   describe("SET_VALUE", () => {
     it("should set a top-level value", () => {
       const result = configurationBuilderReducer(baseState, {
@@ -338,20 +359,8 @@ describe("configurationBuilderReducer", () => {
   });
 
   describe("SET_CUSTOMIZATION", () => {
-    const PATH = ["distribution", "javaagent", "instrumentation"] as const;
-    const initial = { ...INITIAL_STATE, version: "1.0.0" };
-
-    function getInst(s: ReturnType<typeof configurationBuilderReducer>) {
-      let cur: unknown = s.values;
-      for (const seg of PATH) {
-        if (!cur || typeof cur !== "object") return undefined;
-        cur = (cur as Record<string, unknown>)[seg];
-      }
-      return cur as { enabled?: string[]; disabled?: string[] } | undefined;
-    }
-
     it("adds a module to disabled[] sorted alphabetically", () => {
-      let s = configurationBuilderReducer(initial, {
+      let s = configurationBuilderReducer(baseState, {
         type: "SET_CUSTOMIZATION",
         module: "kafka_clients",
         status: "disabled",
@@ -366,7 +375,7 @@ describe("configurationBuilderReducer", () => {
     });
 
     it("moves a module between arrays atomically (no duplicates)", () => {
-      let s = configurationBuilderReducer(initial, {
+      let s = configurationBuilderReducer(baseState, {
         type: "SET_CUSTOMIZATION",
         module: "cassandra",
         status: "disabled",
@@ -381,7 +390,7 @@ describe("configurationBuilderReducer", () => {
     });
 
     it("removes a module from both arrays when status is none", () => {
-      let s = configurationBuilderReducer(initial, {
+      let s = configurationBuilderReducer(baseState, {
         type: "SET_CUSTOMIZATION",
         module: "cassandra",
         status: "disabled",
@@ -395,16 +404,7 @@ describe("configurationBuilderReducer", () => {
     });
 
     it("recovers from corrupt initial state (module in both arrays)", () => {
-      const corrupt = {
-        ...initial,
-        values: {
-          distribution: {
-            javaagent: {
-              instrumentation: { enabled: ["cassandra"], disabled: ["cassandra"] },
-            },
-          },
-        },
-      };
+      const corrupt = stateWithInstrumentationLists(["cassandra"], ["cassandra"]);
       const s = configurationBuilderReducer(corrupt, {
         type: "SET_CUSTOMIZATION",
         module: "cassandra",
@@ -415,10 +415,66 @@ describe("configurationBuilderReducer", () => {
     });
 
     it("sets isDirty", () => {
-      const s = configurationBuilderReducer(initial, {
+      const s = configurationBuilderReducer(baseState, {
         type: "SET_CUSTOMIZATION",
         module: "cassandra",
         status: "disabled",
+      });
+      expect(s.isDirty).toBe(true);
+    });
+  });
+
+  describe("PRUNE_INSTRUMENTATIONS", () => {
+    it("drops customizations for modules absent from the valid set", () => {
+      const before = stateWithInstrumentationLists(["reactor"], ["thrift", "cassandra"]);
+      const s = configurationBuilderReducer(before, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor", "cassandra"],
+      });
+      expect(getInst(s)?.enabled).toEqual(["reactor"]);
+      expect(getInst(s)?.disabled).toEqual(["cassandra"]);
+    });
+
+    it("removes the whole distribution branch when nothing valid remains", () => {
+      const before = stateWithInstrumentationLists([], ["thrift", "jaxws_2_0_cxf_3_0"]);
+      const s = configurationBuilderReducer(before, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor", "cassandra"],
+      });
+      expect(s.values["distribution"]).toBeUndefined();
+    });
+
+    it("returns the same state reference when nothing needs pruning", () => {
+      const before = stateWithInstrumentationLists(["reactor"], ["cassandra"]);
+      const s = configurationBuilderReducer(before, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor", "cassandra", "thrift"],
+      });
+      expect(s).toBe(before);
+    });
+
+    it("is a no-op when no instrumentation customizations are present", () => {
+      const s = configurationBuilderReducer(baseState, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor"],
+      });
+      expect(s).toBe(baseState);
+    });
+
+    it("does not mark the state dirty (the prune is system-driven, not user-driven)", () => {
+      const before = stateWithInstrumentationLists([], ["thrift"]);
+      const s = configurationBuilderReducer(before, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor"],
+      });
+      expect(s.isDirty).toBe(false);
+    });
+
+    it("preserves an existing dirty flag", () => {
+      const before = { ...stateWithInstrumentationLists([], ["thrift"]), isDirty: true };
+      const s = configurationBuilderReducer(before, {
+        type: "PRUNE_INSTRUMENTATIONS",
+        validModules: ["reactor"],
       });
       expect(s.isDirty).toBe(true);
     });

--- a/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
+++ b/ecosystem-explorer/src/hooks/configuration-builder-reducer.ts
@@ -33,6 +33,36 @@ export const INITIAL_STATE: ConfigurationBuilderState = {
   listItemIds: {},
 };
 
+const INSTRUMENTATION_PATH = ["distribution", "javaagent", "instrumentation"];
+
+function readInstrumentationLists(values: ConfigValues): {
+  enabled: string[];
+  disabled: string[];
+} {
+  const current = getByPath(values, INSTRUMENTATION_PATH);
+  const inst = isPlainObject(current) ? current : {};
+  return {
+    enabled: Array.isArray(inst.enabled) ? (inst.enabled as string[]) : [],
+    disabled: Array.isArray(inst.disabled) ? (inst.disabled as string[]) : [],
+  };
+}
+
+function withInstrumentationLists(
+  values: ConfigValues,
+  nextEnabled: string[],
+  nextDisabled: string[]
+): ConfigValues {
+  if (nextEnabled.length === 0 && nextDisabled.length === 0) {
+    const { distribution: _omit, ...rest } = values;
+    void _omit;
+    return rest;
+  }
+  const inst: ConfigValues = {};
+  if (nextEnabled.length > 0) inst.enabled = nextEnabled;
+  if (nextDisabled.length > 0) inst.disabled = nextDisabled;
+  return setByPath(values, INSTRUMENTATION_PATH, inst);
+}
+
 export function configurationBuilderReducer(
   state: ConfigurationBuilderState,
   action: ConfigurationBuilderAction
@@ -171,16 +201,25 @@ export function configurationBuilderReducer(
       return { ...state, values: newValues, enabledSections: newEnabled, isDirty: true };
     }
 
+    case "PRUNE_INSTRUMENTATIONS": {
+      const { enabled, disabled } = readInstrumentationLists(state.values);
+      if (enabled.length === 0 && disabled.length === 0) return state;
+      const valid = new Set(action.validModules);
+      const nextEnabled = enabled.filter((m) => valid.has(m));
+      const nextDisabled = disabled.filter((m) => valid.has(m));
+      if (nextEnabled.length === enabled.length && nextDisabled.length === disabled.length) {
+        return state;
+      }
+      return {
+        ...state,
+        values: withInstrumentationLists(state.values, nextEnabled, nextDisabled),
+      };
+    }
+
     case "SET_CUSTOMIZATION": {
-      const path = ["distribution", "javaagent", "instrumentation"];
-      const current = getByPath(state.values, path);
-      const inst = isPlainObject(current) ? current : {};
-      const enabledArr = Array.isArray(inst.enabled) ? (inst.enabled as string[]) : [];
-      const disabledArr = Array.isArray(inst.disabled) ? (inst.disabled as string[]) : [];
-
-      const remainingEnabled = enabledArr.filter((m) => m !== action.module);
-      const remainingDisabled = disabledArr.filter((m) => m !== action.module);
-
+      const { enabled, disabled } = readInstrumentationLists(state.values);
+      const remainingEnabled = enabled.filter((m) => m !== action.module);
+      const remainingDisabled = disabled.filter((m) => m !== action.module);
       let nextEnabled = remainingEnabled;
       let nextDisabled = remainingDisabled;
       if (action.status === "enabled") {
@@ -188,20 +227,9 @@ export function configurationBuilderReducer(
       } else if (action.status === "disabled") {
         nextDisabled = [...remainingDisabled, action.module].sort();
       }
-
-      if (nextEnabled.length === 0 && nextDisabled.length === 0) {
-        const { distribution: _omit, ...rest } = state.values;
-        void _omit;
-        return { ...state, values: rest, isDirty: true };
-      }
-
-      const newInstrumentation: ConfigValues = {};
-      if (nextEnabled.length > 0) newInstrumentation.enabled = nextEnabled;
-      if (nextDisabled.length > 0) newInstrumentation.disabled = nextDisabled;
-
       return {
         ...state,
-        values: setByPath(state.values, path, newInstrumentation),
+        values: withInstrumentationLists(state.values, nextEnabled, nextDisabled),
         isDirty: true,
       };
     }

--- a/ecosystem-explorer/src/hooks/use-configuration-builder.ts
+++ b/ecosystem-explorer/src/hooks/use-configuration-builder.ts
@@ -63,6 +63,7 @@ export interface ConfigurationBuilderActionsContextValue {
   setValue: (path: string, value: ConfigValue) => void;
   setValueByPath: (path: Path, value: ConfigValue) => void;
   setCustomization: (module: string, status: "enabled" | "disabled" | "none") => void;
+  pruneInstrumentations: (validModules: readonly string[]) => void;
   setEnabled: (section: string, enabled: boolean) => void;
   selectPlugin: (path: string, pluginKey: string) => void;
   addListItem: (path: string) => void;
@@ -170,6 +171,10 @@ export function useConfigurationBuilderState(
     },
     []
   );
+
+  const pruneInstrumentations = useCallback((validModules: readonly string[]) => {
+    dispatch({ type: "PRUNE_INSTRUMENTATIONS", validModules });
+  }, []);
 
   const setEnabled = useCallback((section: string, enabled: boolean) => {
     let defaults: ConfigValues | undefined;
@@ -300,6 +305,7 @@ export function useConfigurationBuilderState(
       setValue,
       setValueByPath,
       setCustomization,
+      pruneInstrumentations,
       setEnabled,
       selectPlugin,
       addListItem,

--- a/ecosystem-explorer/src/test/integration/configuration-builder-instrumentation-version.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-instrumentation-version.integration.test.tsx
@@ -118,6 +118,39 @@ describe("ConfigurationBuilderPage version selectors", () => {
     expect(resourceToggle).toHaveAttribute("aria-checked", "false");
   });
 
+  it("prunes instrumentation customizations referencing modules absent from the selected Agent version", async () => {
+    if (!otherAgentVersion) return;
+    renderPage();
+    const user = userEvent.setup();
+    const agent = await findAgentSelector();
+
+    await openInstrumentationTab(user);
+    const thriftRow = (await screen.findByTestId(
+      "instrumentation-row-thrift",
+      {},
+      { timeout: 10_000 }
+    )) as HTMLElement;
+    const customize = within(thriftRow).getByRole("button", { name: /Customize thrift/i });
+    await user.click(customize);
+    const preview = (await screen.findByLabelText(
+      "Output Preview",
+      {},
+      { timeout: 10_000 }
+    )) as HTMLElement;
+    await waitFor(() => expect(preview.textContent).toMatch(/- thrift\b/));
+
+    await user.selectOptions(agent, otherAgentVersion);
+
+    await waitFor(
+      () => {
+        expect(preview.textContent).toContain(`Java agent: ${otherAgentVersion}`);
+        expect(preview.textContent).not.toMatch(/- thrift\b/);
+        expect(preview.textContent).not.toMatch(/^distribution:/m);
+      },
+      { timeout: 10_000 }
+    );
+  });
+
   it("does not persist the Agent selection: remount resets to latest with empty localStorage", async () => {
     if (!otherAgentVersion) return;
     const { unmount } = renderPage();

--- a/ecosystem-explorer/src/test/integration/configuration-builder-instrumentation-version.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-instrumentation-version.integration.test.tsx
@@ -13,17 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import schemaVersionsIndex from "../../../public/data/configuration/versions-index.json";
 import javaAgentVersionsIndex from "../../../public/data/javaagent/versions-index.json";
+import { normalizeRegistryName } from "@/lib/normalize-instrumentation";
 import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
 import { renderBuilderPage as renderPage } from "./helpers/render-builder-page";
 
 const latestSchemaVersion = schemaVersionsIndex.versions.find((v) => v.is_latest)!.version;
 const latestAgentVersion = javaAgentVersionsIndex.versions.find((v) => v.is_latest)!.version;
 const otherAgentVersion = javaAgentVersionsIndex.versions.find((v) => !v.is_latest)?.version;
+
+const MANIFESTS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../public/data/javaagent/versions"
+);
+
+function moduleNamesFor(version: string): Set<string> {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(MANIFESTS_DIR, `${version}-index.json`), "utf-8")
+  ) as { instrumentations: Record<string, string> };
+  return new Set(Object.keys(manifest.instrumentations).map(normalizeRegistryName));
+}
+
+// Pick a module present in the latest agent version but absent in `otherAgentVersion`,
+// so the prune test exercises the actual code path regardless of which versions ship.
+const moduleOnlyInLatest = (() => {
+  if (!otherAgentVersion) return undefined;
+  const latest = moduleNamesFor(latestAgentVersion);
+  const other = moduleNamesFor(otherAgentVersion);
+  return [...latest].find((m) => !other.has(m));
+})();
 
 beforeAll(() => installFetchInterceptor());
 afterAll(() => uninstallFetchInterceptor());
@@ -119,32 +144,36 @@ describe("ConfigurationBuilderPage version selectors", () => {
   });
 
   it("prunes instrumentation customizations referencing modules absent from the selected Agent version", async () => {
-    if (!otherAgentVersion) return;
+    if (!otherAgentVersion || !moduleOnlyInLatest) return;
+    const orphan = moduleOnlyInLatest;
+    const orphanLineRe = new RegExp(`- ${orphan}\\b`);
     renderPage();
     const user = userEvent.setup();
     const agent = await findAgentSelector();
 
     await openInstrumentationTab(user);
-    const thriftRow = (await screen.findByTestId(
-      "instrumentation-row-thrift",
+    const row = (await screen.findByTestId(
+      `instrumentation-row-${orphan}`,
       {},
       { timeout: 10_000 }
     )) as HTMLElement;
-    const customize = within(thriftRow).getByRole("button", { name: /Customize thrift/i });
+    const customize = within(row).getByRole("button", {
+      name: new RegExp(`Customize ${orphan}`, "i"),
+    });
     await user.click(customize);
     const preview = (await screen.findByLabelText(
       "Output Preview",
       {},
       { timeout: 10_000 }
     )) as HTMLElement;
-    await waitFor(() => expect(preview.textContent).toMatch(/- thrift\b/));
+    await waitFor(() => expect(preview.textContent).toMatch(orphanLineRe));
 
     await user.selectOptions(agent, otherAgentVersion);
 
     await waitFor(
       () => {
         expect(preview.textContent).toContain(`Java agent: ${otherAgentVersion}`);
-        expect(preview.textContent).not.toMatch(/- thrift\b/);
+        expect(preview.textContent).not.toMatch(orphanLineRe);
         expect(preview.textContent).not.toMatch(/^distribution:/m);
       },
       { timeout: 10_000 }

--- a/ecosystem-explorer/src/types/configuration-builder.ts
+++ b/ecosystem-explorer/src/types/configuration-builder.ts
@@ -56,4 +56,5 @@ export type ConfigurationBuilderAction =
   | { type: "SET_VALIDATION_ERRORS"; errors: Record<string, string> }
   | { type: "SET_FIELD_ERROR"; path: string; error: string | null }
   | { type: "ENABLE_ALL_SECTIONS"; defaultsBySection: Record<string, ConfigValues> }
-  | { type: "SET_CUSTOMIZATION"; module: string; status: "enabled" | "disabled" | "none" };
+  | { type: "SET_CUSTOMIZATION"; module: string; status: "enabled" | "disabled" | "none" }
+  | { type: "PRUNE_INSTRUMENTATIONS"; validModules: readonly string[] };


### PR DESCRIPTION
When the user customized an instrumentation on a newer agent version, then switched to an older version where the module didn't exist, the row vanished from the UI but the customization persisted in state and leaked into the YAML as `disabled: - <orphan>`.

Adds a `PRUNE_INSTRUMENTATIONS` reducer action. When `useInstrumentations` resolves for the new agent version, customizations referencing modules absent from that version are dropped. Customizations for modules still present are preserved.