### PR TITLE
fix: keep loading spinner visible while awaiting latest URL redirect in InstrumentationDetailPage

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -180,6 +180,20 @@ describe("InstrumentationDetailPage", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/1.9.0/jdbc");
   });
 
+  it("shows loading spinner on latest URL after versions load, never shows error card", () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/latest/jdbc");
+
+    expect(screen.getByText("Loading instrumentation...")).toBeInTheDocument();
+    expect(screen.queryByText("Instrumentation not found")).not.toBeInTheDocument();
+    expect(screen.queryByText("Error loading instrumentation")).not.toBeInTheDocument();
+  });
+
   it("does not fetch instrumentation when version is 'latest'", () => {
     vi.mocked(useInstrumentation).mockReturnValue({
       data: null,

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -94,7 +94,7 @@ export function InstrumentationDetailPage() {
     shouldFetchInstrumentation ? (version ?? "") : ""
   );
 
-  const loading = versionsLoading || instrumentationLoading;
+  const loading = versionsLoading || instrumentationLoading || (version === "latest" && !versionsError);
 
   useEffect(() => {
     if (version === "latest" && versionsData) {

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -94,7 +94,8 @@ export function InstrumentationDetailPage() {
     shouldFetchInstrumentation ? (version ?? "") : ""
   );
 
-  const loading = versionsLoading || instrumentationLoading || (version === "latest" && !versionsError);
+  const loading =
+    versionsLoading || instrumentationLoading || (version === "latest" && !versionsError);
 
   useEffect(() => {
     if (version === "latest" && versionsData) {


### PR DESCRIPTION
Closes #531

## What was happening

When someone opened a URL like `/java-agent/instrumentation/latest/jdbc`, the page would briefly flash a red **Instrumentation not found** error card before redirecting to the correct versioned URL. The error was completely wrong and should never have appeared in this flow.

## Why it was happening

The `loading` flag was calculated as `versionsLoading || instrumentationLoading`. The page is designed to redirect away from `latest` using a `useEffect` that fires after versions load. The problem is that React paints to the screen before effects run. So the sequence looked like this:

1. Versions finish loading — `versionsLoading` becomes `false`
2. The instrumentation hook was never started for `latest` URLs, so `instrumentationLoading` is also `false`
3. `loading` drops to `false` on this render
4. The component skips the spinner, skips the version error check, skips the invalid version check, and reaches `if (error || !instrumentation)` where `instrumentation` is `null`
5. React paints the error card to the screen
6. Only after the paint, the `useEffect` fires, calls `navigate()`, and redirects

The user would see the error flash for a brief moment every time they followed a `latest` link.

## The fix

One line in `instrumentation-detail-page.tsx`:

```tsx
const loading =
  versionsLoading ||
  instrumentationLoading ||
  (version === "latest" && !versionsError);
```

When `version` is `"latest"` and no versions error has occurred, the page is in a pending-redirect state. Treating that as a loading state keeps the spinner visible until the `useEffect` redirect navigates away, so the error branch is never reached.

## Test added

A new test case was added to `instrumentation-detail-page.test.tsx` that simulates the exact race condition: versions have finished loading, version is `"latest"`, and the instrumentation hook returns null. The test confirms the spinner is shown and neither error text is visible.

All 899 existing tests continue to pass.