### PR TITLE
feat(v1): EcosystemsGrid (Phase 2 - Home page PR 4)

### DIFF
--- a/ecosystem-explorer/scripts/take-screenshots.mjs
+++ b/ecosystem-explorer/scripts/take-screenshots.mjs
@@ -214,8 +214,9 @@ async function takeScreenshots() {
           // 1. Home page
           await page.goto(BASE_URL, { waitUntil: "domcontentloaded", timeout: 10000 });
           await page.waitForSelector("h1", { state: "visible", timeout: 5000 });
+          await settle(page);
           await assertNoError(page, BASE_URL);
-          await page.screenshot({ path: p("home") });
+          await page.screenshot({ path: p("home"), fullPage: true });
           if (isFirstViewport) await recordA11y(page, "home", theme);
 
           // 2. Java agent instrumentation list
@@ -225,7 +226,7 @@ async function takeScreenshots() {
           });
           await settle(page);
           await assertNoError(page, `${BASE_URL}/java-agent/instrumentation`);
-          await page.screenshot({ path: p("instrumentation-list") });
+          await page.screenshot({ path: p("instrumentation-list"), fullPage: true });
           if (isFirstViewport) await recordA11y(page, "instrumentation-list", theme);
 
           // 3. Java agent instrumentation detail - Details tab
@@ -255,7 +256,7 @@ async function takeScreenshots() {
           });
           await settle(page);
           await assertNoError(page, `${BASE_URL}/collector/components`);
-          await page.screenshot({ path: p("collector-list") });
+          await page.screenshot({ path: p("collector-list"), fullPage: true });
           if (isFirstViewport) await recordA11y(page, "collector-list", theme);
 
           // 7. Collector detail

--- a/ecosystem-explorer/src/v1/components/home/ecosystems-grid.test.tsx
+++ b/ecosystem-explorer/src/v1/components/home/ecosystems-grid.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+
+import { EcosystemsGrid } from "./ecosystems-grid";
+
+function renderGrid() {
+  return render(
+    <MemoryRouter>
+      <EcosystemsGrid />
+    </MemoryRouter>
+  );
+}
+
+describe("EcosystemsGrid", () => {
+  it("labels the section via aria-labelledby pointing at the heading", () => {
+    const { container } = renderGrid();
+    const section = container.querySelector(".td-ecosystems-grid");
+    expect(section).toHaveAttribute("aria-labelledby", "ecosystems-grid-title");
+    expect(screen.getByRole("heading", { level: 2, name: "Ecosystems" })).toHaveAttribute(
+      "id",
+      "ecosystems-grid-title"
+    );
+  });
+
+  it("renders the Collector card linking to /collector with stability + counts", () => {
+    renderGrid();
+    const card = screen.getByRole("link", { name: /OpenTelemetry Collector/i });
+    expect(card).toHaveAttribute("href", "/collector");
+    expect(within(card).getByText(/Stable/i)).toBeInTheDocument();
+    expect(within(card).getByText("200+")).toBeInTheDocument();
+    expect(within(card).getByText("v0.150.0")).toBeInTheDocument();
+  });
+
+  it("renders the Java Agent card linking to /java-agent with stability + counts", () => {
+    renderGrid();
+    const card = screen.getByRole("link", { name: /OpenTelemetry Java Agent/i });
+    expect(card).toHaveAttribute("href", "/java-agent");
+    expect(within(card).getByText("187")).toBeInTheDocument();
+    expect(within(card).getByText("v2.10.0")).toBeInTheDocument();
+  });
+
+  it("renders four coming-soon placeholders that are not anchor links", () => {
+    renderGrid();
+    const placeholders = ["Python SDK", "Go SDK", "JS / Node", ".NET"];
+    for (const name of placeholders) {
+      const node = screen.getByText(name);
+      expect(node).toBeInTheDocument();
+      expect(node.closest("a")).toBeNull();
+    }
+  });
+
+  it("links 'View all projects' to opentelemetry.io with target=_blank and rel=noopener noreferrer", () => {
+    renderGrid();
+    const link = screen.getByRole("link", { name: /View all projects/i });
+    expect(link).toHaveAttribute("href", "https://opentelemetry.io/ecosystem/");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("uses per-ecosystem icon-class modifiers (no inline hex)", () => {
+    const { container } = renderGrid();
+    expect(container.querySelector(".td-ecosystem-card__icon--collector")).not.toBeNull();
+    expect(container.querySelector(".td-ecosystem-card__icon--java-agent")).not.toBeNull();
+  });
+});

--- a/ecosystem-explorer/src/v1/components/home/ecosystems-grid.test.tsx
+++ b/ecosystem-explorer/src/v1/components/home/ecosystems-grid.test.tsx
@@ -30,8 +30,8 @@ function renderGrid() {
 
 describe("EcosystemsGrid", () => {
   it("labels the section via aria-labelledby pointing at the heading", () => {
-    const { container } = renderGrid();
-    const section = container.querySelector(".td-ecosystems-grid");
+    renderGrid();
+    const section = screen.getByRole("region", { name: "Ecosystems" });
     expect(section).toHaveAttribute("aria-labelledby", "ecosystems-grid-title");
     expect(screen.getByRole("heading", { level: 2, name: "Ecosystems" })).toHaveAttribute(
       "id",
@@ -72,11 +72,5 @@ describe("EcosystemsGrid", () => {
     expect(link).toHaveAttribute("href", "https://opentelemetry.io/ecosystem/");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
-  });
-
-  it("uses per-ecosystem icon-class modifiers (no inline hex)", () => {
-    const { container } = renderGrid();
-    expect(container.querySelector(".td-ecosystem-card__icon--collector")).not.toBeNull();
-    expect(container.querySelector(".td-ecosystem-card__icon--java-agent")).not.toBeNull();
   });
 });

--- a/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
+++ b/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
@@ -166,11 +166,7 @@ export function EcosystemsGrid({
           ))}
 
           {comingSoon.map((eco) => (
-            <div
-              key={eco.id}
-              className="td-ecosystem-card td-ecosystem-card--placeholder"
-              aria-label={`${eco.name} — coming soon`}
-            >
+            <div key={eco.id} className="td-ecosystem-card td-ecosystem-card--placeholder">
               {PLACEHOLDER_ICON}
               <div className="td-ecosystem-card__name td-ecosystem-card__name--placeholder">
                 {eco.name}

--- a/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
+++ b/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
@@ -15,34 +15,30 @@
  */
 
 /*
- * EcosystemsGrid — two large active cards (Collector, Java Agent) followed
- * by four dashed "coming soon" placeholders for Python / Go / JS / .NET.
- *
- * Numbers are the canonical 2026-05-19 values from
- * `projects/84-ui-ux-design/ecosystem-explorer-v1-mockups.html`. They can be
- * swapped to live counts (`loadAllComponents()` / `loadAllInstrumentations()`)
- * in a follow-up once the data layer exposes synchronous counts; for now
- * they're hardcoded so this PR doesn't drag the data layer along.
- *
- * Icon color/background is driven by per-ecosystem CSS modifiers in
- * `ecosystems-grid.css` so the OTel-purple and OTel-orange tokens stay the
- * single source of truth (no inline hex).
+ * EcosystemsGrid — two active cards (Collector, Java Agent) plus four
+ * dashed "coming soon" placeholders. Counts are the canonical 2026-05-19
+ * values from `projects/84-ui-ux-design/ecosystem-explorer-v1-mockups.html`;
+ * they stay hardcoded until the data layer exposes synchronous totals.
  */
 
 import type { ReactNode } from "react";
-import { Boxes, Coffee, Network } from "lucide-react";
+import { Boxes, Network } from "lucide-react";
 import { Link } from "react-router-dom";
 
+import { JavaIcon } from "@/components/icons/java-icon";
 import { type Stability, StatusPill } from "@/components/ui/status-pill";
 
+export type ActiveEcosystemId = "collector" | "java-agent";
+export type ComingSoonEcosystemId = "python" | "go" | "js" | "dotnet";
+
 export interface ActiveEcosystem {
-  id: string;
+  id: ActiveEcosystemId;
   name: string;
   tagline: string;
   description: string;
   stability: Stability;
   components: string;
-  unit: string;
+  unit: "components" | "instrumentations";
   version: string;
   weeklyDelta: string;
   href: string;
@@ -50,9 +46,8 @@ export interface ActiveEcosystem {
 }
 
 export interface ComingSoonEcosystem {
-  id: string;
+  id: ComingSoonEcosystemId;
   name: string;
-  icon: ReactNode;
 }
 
 const DEFAULT_ACTIVE: ActiveEcosystem[] = [
@@ -82,31 +77,17 @@ const DEFAULT_ACTIVE: ActiveEcosystem[] = [
     version: "v2.10.0",
     weeklyDelta: "8",
     href: "/java-agent",
-    icon: <Coffee className="td-ecosystem-card__icon-svg" aria-hidden />,
+    icon: <JavaIcon className="td-ecosystem-card__icon-svg" />,
   },
 ];
 
+const PLACEHOLDER_ICON = <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />;
+
 const DEFAULT_COMING_SOON: ComingSoonEcosystem[] = [
-  {
-    id: "python",
-    name: "Python SDK",
-    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
-  },
-  {
-    id: "go",
-    name: "Go SDK",
-    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
-  },
-  {
-    id: "js",
-    name: "JS / Node",
-    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
-  },
-  {
-    id: "dotnet",
-    name: ".NET",
-    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
-  },
+  { id: "python", name: "Python SDK" },
+  { id: "go", name: "Go SDK" },
+  { id: "js", name: "JS / Node" },
+  { id: "dotnet", name: ".NET" },
 ];
 
 export interface EcosystemsGridProps {
@@ -168,18 +149,18 @@ export function EcosystemsGrid({
               </div>
               <p className="td-ecosystem-card__description">{eco.description}</p>
               <div className="td-ecosystem-card__metrics">
-                <span>
-                  <span className="td-ecosystem-card__metric-value">{eco.components}</span>{" "}
-                  <span className="td-ecosystem-card__metric-label">{eco.unit}</span>
-                </span>
-                <span>
-                  <span className="td-ecosystem-card__metric-value">{eco.version}</span>{" "}
-                  <span className="td-ecosystem-card__metric-label">latest</span>
-                </span>
-                <span>
-                  <span className="td-ecosystem-card__metric-value">{eco.weeklyDelta}</span>{" "}
-                  <span className="td-ecosystem-card__metric-label">updated this week</span>
-                </span>
+                {(
+                  [
+                    [eco.components, eco.unit],
+                    [eco.version, "latest"],
+                    [eco.weeklyDelta, "updated this week"],
+                  ] as const
+                ).map(([value, label]) => (
+                  <span key={label}>
+                    <span className="td-ecosystem-card__metric-value">{value}</span>{" "}
+                    <span className="td-ecosystem-card__metric-label">{label}</span>
+                  </span>
+                ))}
               </div>
             </Link>
           ))}
@@ -190,7 +171,7 @@ export function EcosystemsGrid({
               className="td-ecosystem-card td-ecosystem-card--placeholder"
               aria-label={`${eco.name} — coming soon`}
             >
-              {eco.icon}
+              {PLACEHOLDER_ICON}
               <div className="td-ecosystem-card__name td-ecosystem-card__name--placeholder">
                 {eco.name}
               </div>

--- a/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
+++ b/ecosystem-explorer/src/v1/components/home/ecosystems-grid.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * EcosystemsGrid — two large active cards (Collector, Java Agent) followed
+ * by four dashed "coming soon" placeholders for Python / Go / JS / .NET.
+ *
+ * Numbers are the canonical 2026-05-19 values from
+ * `projects/84-ui-ux-design/ecosystem-explorer-v1-mockups.html`. They can be
+ * swapped to live counts (`loadAllComponents()` / `loadAllInstrumentations()`)
+ * in a follow-up once the data layer exposes synchronous counts; for now
+ * they're hardcoded so this PR doesn't drag the data layer along.
+ *
+ * Icon color/background is driven by per-ecosystem CSS modifiers in
+ * `ecosystems-grid.css` so the OTel-purple and OTel-orange tokens stay the
+ * single source of truth (no inline hex).
+ */
+
+import type { ReactNode } from "react";
+import { Boxes, Coffee, Network } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { type Stability, StatusPill } from "@/components/ui/status-pill";
+
+export interface ActiveEcosystem {
+  id: string;
+  name: string;
+  tagline: string;
+  description: string;
+  stability: Stability;
+  components: string;
+  unit: string;
+  version: string;
+  weeklyDelta: string;
+  href: string;
+  icon: ReactNode;
+}
+
+export interface ComingSoonEcosystem {
+  id: string;
+  name: string;
+  icon: ReactNode;
+}
+
+const DEFAULT_ACTIVE: ActiveEcosystem[] = [
+  {
+    id: "collector",
+    name: "OpenTelemetry Collector",
+    tagline: "Vendor-agnostic agent",
+    description:
+      "Receive, process, and export telemetry data. 200+ receivers, processors, exporters, connectors and extensions.",
+    stability: "stable",
+    components: "200+",
+    unit: "components",
+    version: "v0.150.0",
+    weeklyDelta: "12",
+    href: "/collector",
+    icon: <Network className="td-ecosystem-card__icon-svg" aria-hidden />,
+  },
+  {
+    id: "java-agent",
+    name: "OpenTelemetry Java Agent",
+    tagline: "Auto-instrumentation",
+    description:
+      "Discover supported libraries, configuration options, and emitted telemetry for the Java auto-instrumentation agent.",
+    stability: "stable",
+    components: "187",
+    unit: "instrumentations",
+    version: "v2.10.0",
+    weeklyDelta: "8",
+    href: "/java-agent",
+    icon: <Coffee className="td-ecosystem-card__icon-svg" aria-hidden />,
+  },
+];
+
+const DEFAULT_COMING_SOON: ComingSoonEcosystem[] = [
+  {
+    id: "python",
+    name: "Python SDK",
+    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
+  },
+  {
+    id: "go",
+    name: "Go SDK",
+    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
+  },
+  {
+    id: "js",
+    name: "JS / Node",
+    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
+  },
+  {
+    id: "dotnet",
+    name: ".NET",
+    icon: <Boxes className="td-ecosystem-card__placeholder-icon" aria-hidden />,
+  },
+];
+
+export interface EcosystemsGridProps {
+  active?: ActiveEcosystem[];
+  comingSoon?: ComingSoonEcosystem[];
+  /** Override the `<h2>` id (used by `aria-labelledby`). Defaults to `"ecosystems-grid-title"`. */
+  headingId?: string;
+}
+
+export function EcosystemsGrid({
+  active = DEFAULT_ACTIVE,
+  comingSoon = DEFAULT_COMING_SOON,
+  headingId = "ecosystems-grid-title",
+}: EcosystemsGridProps) {
+  return (
+    <section className="td-ecosystems-grid" aria-labelledby={headingId}>
+      <div className="td-ecosystems-grid__container">
+        <div className="td-section-header">
+          <div>
+            <h2 id={headingId} className="td-section-header__title">
+              Ecosystems
+            </h2>
+            <p className="td-section-header__lead">
+              Browse the projects that make up OpenTelemetry.
+            </p>
+          </div>
+          <a
+            className="td-section-header__action"
+            href="https://opentelemetry.io/ecosystem/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View all projects →
+          </a>
+        </div>
+
+        <div className="td-ecosystems-grid__cards">
+          {active.map((eco) => (
+            <Link
+              key={eco.id}
+              to={eco.href}
+              className="td-ecosystem-card"
+              aria-label={`${eco.name} — ${eco.tagline}`}
+            >
+              <div className="td-ecosystem-card__head">
+                <div className="td-ecosystem-card__id">
+                  <div
+                    className={`td-ecosystem-card__icon td-ecosystem-card__icon--${eco.id}`}
+                    aria-hidden
+                  >
+                    {eco.icon}
+                  </div>
+                  <div>
+                    <h3 className="td-ecosystem-card__name">{eco.name}</h3>
+                    <p className="td-ecosystem-card__tagline">{eco.tagline}</p>
+                  </div>
+                </div>
+                <StatusPill stability={eco.stability} />
+              </div>
+              <p className="td-ecosystem-card__description">{eco.description}</p>
+              <div className="td-ecosystem-card__metrics">
+                <span>
+                  <span className="td-ecosystem-card__metric-value">{eco.components}</span>{" "}
+                  <span className="td-ecosystem-card__metric-label">{eco.unit}</span>
+                </span>
+                <span>
+                  <span className="td-ecosystem-card__metric-value">{eco.version}</span>{" "}
+                  <span className="td-ecosystem-card__metric-label">latest</span>
+                </span>
+                <span>
+                  <span className="td-ecosystem-card__metric-value">{eco.weeklyDelta}</span>{" "}
+                  <span className="td-ecosystem-card__metric-label">updated this week</span>
+                </span>
+              </div>
+            </Link>
+          ))}
+
+          {comingSoon.map((eco) => (
+            <div
+              key={eco.id}
+              className="td-ecosystem-card td-ecosystem-card--placeholder"
+              aria-label={`${eco.name} — coming soon`}
+            >
+              {eco.icon}
+              <div className="td-ecosystem-card__name td-ecosystem-card__name--placeholder">
+                {eco.name}
+              </div>
+              <small className="td-ecosystem-card__tagline">Coming soon</small>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
+++ b/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
@@ -30,6 +30,7 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { StabilityBadge } from "@/components/ui/stability-badge";
 import { type Stability, StatusPill } from "@/components/ui/status-pill";
 import { CoverBlock } from "@/v1/components/home/cover-block";
+import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { StatsBand } from "@/v1/components/home/stats-band";
 
 const STABILITIES: Stability[] = [
@@ -171,6 +172,14 @@ export function DevComponentsPage() {
 
       <Section id="stats-band" title="StatsBand (OTel-purple counter strip)" bare>
         <StatsBand headingId="stats-band-showcase-title" />
+      </Section>
+
+      <Section
+        id="ecosystems-grid"
+        title="EcosystemsGrid (two active + four coming-soon cards)"
+        bare
+      >
+        <EcosystemsGrid headingId="ecosystems-grid-showcase-title" />
       </Section>
 
       <Section

--- a/ecosystem-explorer/src/v1/features/home/home-page.test.tsx
+++ b/ecosystem-explorer/src/v1/features/home/home-page.test.tsx
@@ -64,16 +64,16 @@ describe("HomeV1 (composition)", () => {
       el.getAttribute("aria-label")
     );
 
-    // CoverBlock and StatsBand render <section>s with aria-labelledby (not
-    // aria-label), so they aren't picked up here — these are the three PR 4-6
-    // placeholder slots that remain.
-    expect(sections).toEqual(["Featured ecosystems", "Browse by signal", "Recent activity"]);
+    // CoverBlock, StatsBand, and EcosystemsGrid render <section>s with
+    // aria-labelledby (not aria-label), so they aren't picked up here —
+    // these are the two PR 5-6 placeholder slots that remain.
+    expect(sections).toEqual(["Browse by signal", "Recent activity"]);
   });
 
   it("renders exactly one skeleton element inside each of the remaining placeholder sections", () => {
     const { container } = renderHome();
 
-    for (const label of ["Featured ecosystems", "Browse by signal", "Recent activity"]) {
+    for (const label of ["Browse by signal", "Recent activity"]) {
       const section = container.querySelector(`section[aria-label="${label}"]`);
       expect(section, `section[aria-label="${label}"] should exist`).not.toBeNull();
       const skeletons = section!.querySelectorAll(".td-home__skeleton");
@@ -86,6 +86,13 @@ describe("HomeV1 (composition)", () => {
     const band = container.querySelector(".td-stats-band");
     expect(band).not.toBeNull();
     expect(band).toHaveAttribute("aria-labelledby", "stats-band-title");
+  });
+
+  it("renders the EcosystemsGrid below the StatsBand", () => {
+    const { container } = renderHome();
+    const grid = container.querySelector(".td-ecosystems-grid");
+    expect(grid).not.toBeNull();
+    expect(grid).toHaveAttribute("aria-labelledby", "ecosystems-grid-title");
   });
 
   it("renders the GlobalSearch skeleton inside the CoverBlock with aria-hidden", () => {

--- a/ecosystem-explorer/src/v1/features/home/home-page.tsx
+++ b/ecosystem-explorer/src/v1/features/home/home-page.tsx
@@ -23,14 +23,8 @@ import { StatsBand } from "@/v1/components/home/stats-band";
 
 /**
  * Home page (v1) — composes the v1 chrome with home-specific sections.
- *
- * StatsBand and EcosystemsGrid are real; the remaining two sections below
- * (SignalsRow, RecentActivityRail) are still skeleton-box placeholders that
- * PRs 5-6 replace. The GlobalSearch slot inside CoverBlock is also a skeleton
- * until PR 2.
- *
- * The CncfCallout and FooterV1 are mounted by `<V1App />`, not here —
- * HomeV1 only owns the page-content slot.
+ * Sections that haven't shipped yet render as skeleton-box placeholders.
+ * The CncfCallout and FooterV1 are mounted by `<V1App />`, not here.
  */
 export function HomeV1() {
   return (

--- a/ecosystem-explorer/src/v1/features/home/home-page.tsx
+++ b/ecosystem-explorer/src/v1/features/home/home-page.tsx
@@ -18,15 +18,16 @@ import { Link } from "react-router-dom";
 
 import { Compass } from "@/components/icons/compass";
 import { CoverBlock } from "@/v1/components/home/cover-block";
+import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { StatsBand } from "@/v1/components/home/stats-band";
 
 /**
  * Home page (v1) — composes the v1 chrome with home-specific sections.
  *
- * StatsBand is real; the remaining three sections below the hero
- * (EcosystemsGrid, SignalsRow, RecentActivityRail) are still skeleton-box
- * placeholders that PRs 4-6 replace. The GlobalSearch slot inside CoverBlock
- * is also a skeleton until PR 2.
+ * StatsBand and EcosystemsGrid are real; the remaining two sections below
+ * (SignalsRow, RecentActivityRail) are still skeleton-box placeholders that
+ * PRs 5-6 replace. The GlobalSearch slot inside CoverBlock is also a skeleton
+ * until PR 2.
  *
  * The CncfCallout and FooterV1 are mounted by `<V1App />`, not here —
  * HomeV1 only owns the page-content slot.
@@ -63,9 +64,7 @@ export function HomeV1() {
 
       <StatsBand />
 
-      <section aria-label="Featured ecosystems">
-        <div className="td-home__skeleton td-home__skeleton--ecosystems" aria-hidden="true" />
-      </section>
+      <EcosystemsGrid />
 
       <section aria-label="Browse by signal">
         <div className="td-home__skeleton td-home__skeleton--signals" aria-hidden="true" />

--- a/ecosystem-explorer/src/v1/styles/ecosystems-grid.css
+++ b/ecosystem-explorer/src/v1/styles/ecosystems-grid.css
@@ -99,10 +99,10 @@
   }
 }
 
-.td-ecosystem-card:hover,
-.td-ecosystem-card:focus-visible {
+a.td-ecosystem-card:hover,
+a.td-ecosystem-card:focus-visible {
   border-color: hsl(var(--primary-hsl) / 0.5);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 12px hsl(var(--primary-hsl) / 0.12);
   transform: translateY(-1px);
 }
 
@@ -113,12 +113,6 @@
   justify-content: center;
   min-height: 120px;
   cursor: default;
-}
-
-.td-ecosystem-card--placeholder:hover {
-  transform: none;
-  box-shadow: none;
-  border-color: hsl(var(--border-hsl));
 }
 
 .td-ecosystem-card__head {
@@ -154,9 +148,10 @@
   color: hsl(var(--otel-purple-hsl));
 }
 
+/* Java Agent card uses the branded <JavaIcon> SVG, which carries its own
+   orange fill — only the neutral tinted tile is needed here. */
 .td-ecosystem-card__icon--java-agent {
-  background-color: hsl(var(--otel-orange-hsl) / 0.18);
-  color: hsl(var(--otel-orange-hsl));
+  background-color: hsl(var(--otel-orange-hsl) / 0.12);
 }
 
 .td-ecosystem-card__name {

--- a/ecosystem-explorer/src/v1/styles/ecosystems-grid.css
+++ b/ecosystem-explorer/src/v1/styles/ecosystems-grid.css
@@ -1,0 +1,206 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * EcosystemsGrid — surface + 12-column grid + per-card icon modifiers. The
+ * Collector and Java-Agent icon colors are driven by `--otel-purple-hsl` /
+ * `--otel-orange-hsl` so the brand tokens stay the single source of truth
+ * (no inline hex on the React side).
+ */
+
+.td-ecosystems-grid {
+  background-color: hsl(var(--background-hsl));
+  color: hsl(var(--foreground-hsl));
+  padding: 4rem 1.5rem;
+}
+
+.td-ecosystems-grid__container {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+/* ---------- Section header (shared shape with future v1 sections) ---------- */
+
+.td-section-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.td-section-header__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.td-section-header__lead {
+  margin: 0.25rem 0 0;
+  color: hsl(var(--muted-foreground-hsl));
+}
+
+.td-section-header__action {
+  color: hsl(var(--primary-hsl));
+  font-size: 0.9375rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.td-section-header__action:hover,
+.td-section-header__action:focus-visible {
+  text-decoration: underline;
+}
+
+/* ---------- Card grid ---------- */
+
+.td-ecosystems-grid__cards {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+
+.td-ecosystem-card {
+  grid-column: span 12;
+  display: flex;
+  flex-direction: column;
+  background-color: hsl(var(--card-hsl));
+  border: 1px solid hsl(var(--border-hsl));
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
+}
+
+@media (min-width: 768px) {
+  .td-ecosystem-card {
+    grid-column: span 6;
+  }
+  .td-ecosystem-card--placeholder {
+    grid-column: span 3;
+  }
+}
+
+.td-ecosystem-card:hover,
+.td-ecosystem-card:focus-visible {
+  border-color: hsl(var(--primary-hsl) / 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+.td-ecosystem-card--placeholder {
+  border-style: dashed;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  cursor: default;
+}
+
+.td-ecosystem-card--placeholder:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: hsl(var(--border-hsl));
+}
+
+.td-ecosystem-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.td-ecosystem-card__id {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.td-ecosystem-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.td-ecosystem-card__icon-svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.td-ecosystem-card__icon--collector {
+  background-color: hsl(var(--otel-purple-hsl) / 0.15);
+  color: hsl(var(--otel-purple-hsl));
+}
+
+.td-ecosystem-card__icon--java-agent {
+  background-color: hsl(var(--otel-orange-hsl) / 0.18);
+  color: hsl(var(--otel-orange-hsl));
+}
+
+.td-ecosystem-card__name {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.td-ecosystem-card__name--placeholder {
+  font-size: 0.9375rem;
+}
+
+.td-ecosystem-card__tagline {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: hsl(var(--muted-foreground-hsl));
+}
+
+.td-ecosystem-card__description {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground-hsl));
+}
+
+.td-ecosystem-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  font-size: 0.8125rem;
+  margin-top: auto;
+  padding-top: 0.75rem;
+}
+
+.td-ecosystem-card__metric-value {
+  font-weight: 700;
+}
+
+.td-ecosystem-card__metric-label {
+  color: hsl(var(--muted-foreground-hsl));
+}
+
+.td-ecosystem-card__placeholder-icon {
+  width: 28px;
+  height: 28px;
+  margin: 0 auto 0.5rem;
+  color: hsl(var(--muted-foreground-hsl));
+}

--- a/ecosystem-explorer/src/v1/styles/home.css
+++ b/ecosystem-explorer/src/v1/styles/home.css
@@ -15,9 +15,9 @@
  */
 
 /*
- * Home (v1) — wrapper + skeleton-box placeholders for the sections PRs 4-6
- * will replace (EcosystemsGrid, SignalsRow, RecentActivityRail) and for the
- * GlobalSearch slot inside CoverBlock.
+ * Home (v1) — wrapper + skeleton-box placeholders for the sections PRs 5-6
+ * will replace (SignalsRow, RecentActivityRail) and for the GlobalSearch slot
+ * inside CoverBlock.
  *
  * Skeleton rules are intentionally low-fidelity: subtle neutral fill that
  * adapts to either theme, with per-slot heights that approximate the real
@@ -26,10 +26,10 @@
  * scope its `--<slot>` modifier rules here; the base `.td-home__skeleton`
  * rule can stay as a reusable utility for future staged work.
  *
- * Cover-block surface rules live in `cover-block.css`; stats-band rules in
- * `stats-band.css`. The remaining components' surface rules
- * (`.td-ecosystems-grid`, `.td-signals-row`, `.td-recent-activity`) land in
- * PRs 4-6.
+ * Cover-block surface rules live in `cover-block.css`; stats-band in
+ * `stats-band.css`; ecosystems-grid in `ecosystems-grid.css`. The remaining
+ * components' surface rules (`.td-signals-row`, `.td-recent-activity`) land
+ * in PRs 5-6.
  */
 
 .td-home {
@@ -64,10 +64,6 @@
   height: 3rem;
   margin: 2rem auto 0;
   background-color: hsl(var(--cover-block-fg-hsl) / 0.1);
-}
-
-.td-home__skeleton--ecosystems {
-  height: 24rem;
 }
 
 .td-home__skeleton--signals {

--- a/ecosystem-explorer/src/v1/styles/home.css
+++ b/ecosystem-explorer/src/v1/styles/home.css
@@ -15,21 +15,16 @@
  */
 
 /*
- * Home (v1) — wrapper + skeleton-box placeholders for the sections PRs 5-6
- * will replace (SignalsRow, RecentActivityRail) and for the GlobalSearch slot
- * inside CoverBlock.
+ * Home (v1) — wrapper + skeleton-box placeholders for sections that haven't
+ * shipped yet. Rules are intentionally low-fidelity: subtle neutral fill
+ * that adapts to either theme, with per-slot heights approximating the real
+ * component footprint so the page reads as "this will be filled in" instead
+ * of "this is broken". As each real component lands, drop its `--<slot>`
+ * modifier rule here; the base `.td-home__skeleton` rule stays as a
+ * reusable utility.
  *
- * Skeleton rules are intentionally low-fidelity: subtle neutral fill that
- * adapts to either theme, with per-slot heights that approximate the real
- * component footprint so the page reads as "this will be filled in"
- * instead of "this is broken". As each real component lands, drop or
- * scope its `--<slot>` modifier rules here; the base `.td-home__skeleton`
- * rule can stay as a reusable utility for future staged work.
- *
- * Cover-block surface rules live in `cover-block.css`; stats-band in
- * `stats-band.css`; ecosystems-grid in `ecosystems-grid.css`. The remaining
- * components' surface rules (`.td-signals-row`, `.td-recent-activity`) land
- * in PRs 5-6.
+ * Each shipped section's surface rules live in its own partial (e.g.
+ * `cover-block.css`, `stats-band.css`, `ecosystems-grid.css`).
  */
 
 .td-home {

--- a/ecosystem-explorer/src/v1/styles/index.css
+++ b/ecosystem-explorer/src/v1/styles/index.css
@@ -24,6 +24,7 @@
  * - buttons.css      — v1 `.td-btn` primitive (primary, outline-light variants)
  * - cover-block.css  — v1 hero shell (`.td-cover-block`) — mirrors opentelemetry.io
  * - stats-band.css   — v1 home stats band (`.td-stats-band`) — OTel-purple counter strip
+ * - ecosystems-grid.css — v1 home ecosystems grid (`.td-ecosystems-grid`)
  * - home.css         — v1 home page wrapper + remaining skeleton placeholders
  * - cncf-callout.css — sitewide CNCF band above the footer
  * - footer.css       — v1 footer (`.td-footer`) — mirrors opentelemetry.io
@@ -40,6 +41,7 @@
 @import "./buttons.css";
 @import "./cover-block.css";
 @import "./stats-band.css";
+@import "./ecosystems-grid.css";
 @import "./home.css";
 @import "./cncf-callout.css";
 @import "./footer.css";

--- a/projects/84-ui-ux-design/NEXT-STEPS.md
+++ b/projects/84-ui-ux-design/NEXT-STEPS.md
@@ -4,7 +4,7 @@ issue: 84
 type: roadmap
 phase: meta
 status: planning
-last_updated: "2026-05-19"
+last_updated: "2026-05-21"
 ---
 
 ## Next steps
@@ -66,6 +66,11 @@ This is a _living_ document. Update it as decisions land and PRs ship. Cross-ref
   onto current `main` on 2026-05-19; each PR re-derives small reviewable slices off it rather than
   cherry-picking the bundled commit. PR 8 (cleanup) is deferred to end-of-redesign per the routing
   pivot — it bundles all phases' cleanups and is **not** Phase-1-scoped.
+- **2026-05-21 snapshot:** Phase 2 PR 1 (#517, CoverBlock + HomeV1 shell) and PR 3 (#524, StatsBand
+  with canonical home stats) are both merged on `main`. PR 4 (EcosystemsGrid) is rebased onto
+  current `main` on `feat/84-phase2-pr4-ecosystems-grid` — single commit, typecheck + 916 tests
+  green, ready to push. PR 2 (GlobalSearch) is being shipped out of numeric order — the home page's
+  GlobalSearch slot stays a skeleton until then.
 
 ---
 
@@ -75,10 +80,16 @@ In order:
 
 - [x] PR 1 (#377), PR 2 (#453), PR 2b (#470), PR 3 (#482), PR 4 (#455), PR 5 (#483), PR 6 (#484), PR
       7 (#487) — all merged on `main`. Phase 1 complete; #370 closed.
-- [ ] **Open Phase 2 PR 1** — `feat(v1): CoverBlock + HomeV1 shell (Phase 2 - Home page PR 1)`. Adds
-      `<CoverBlock>` + a `<HomeV1 />` shell with placeholder sections for PRs 2-6 + the `/` route
-      swap in `V1App.tsx`. Branch off current `main`; re-derive from `feat/84-tmp-full-layout`
-      rather than cherry-pick.
+- [x] Phase 2 PR 1 (#517) — `feat(v1): CoverBlock + HomeV1 shell`. Merged.
+- [x] Phase 2 PR 3 (#524) — `feat(v1): StatsBand + canonical home stats`. Merged 2026-05-21.
+- [ ] **Push Phase 2 PR 4** — `feat(v1): EcosystemsGrid (Phase 2 - Home page PR 4)`. Branch
+      `feat/84-phase2-pr4-ecosystems-grid` rebased on current `main`; needs
+      `git push -u origin feat/84-phase2-pr4-ecosystems-grid` then a PR opened against `main`.
+- [ ] Phase 2 PR 5 (SignalsRow) — branch `feat/84-phase2-pr5-signals-row` is stacked on the old PR 4
+      SHA; rebase onto `main`
+      (`git rebase --onto main <old-PR4-SHA> feat/84-phase2-pr5-signals-row`) after PR 4 merges.
+- [ ] Phase 2 PR 2 (GlobalSearch) and PR 6 (RecentActivityRail) — still to be derived from
+      `feat/84-tmp-full-layout`.
 
 ---
 
@@ -291,5 +302,6 @@ Surface early so it's not blocking when PR 04b is ready.
 | 2026-05-19 | PR 1 of Phase 2: `V1App.tsx` route table swap from legacy `<HomePage />` to `<HomeV1 />` for path `/` ships in PR 1 — preview deploys show hero + 4 skeleton sections.                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Route swap is in the locked #371 PR 1 scope. Skeleton placeholders (Q1, Q2) were chosen specifically to make this acceptable in preview. Production stays on legacy `<HomePage />` because `V1_REDESIGN` is off on `main` branch deploys.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | 2026-05-19 | PR 1 of Phase 2: visual-regression baseline impact accepted — PR 1's `/` and `/_dev/components` diffs surface in the PR comment via the #487 workflow; baseline updates automatically on merge via `screenshots-baseline.yml`.                                                                                                                                                                                                                                                                                                                                                                                                        | No workflow modifications needed; the system from #487 is built for this exact case. Over-budget visual diffs are **informational, not CI-gating** — confirmed by Vitor 2026-05-19. Threshold tuning not required for PR 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | 2026-05-19 | PR 1 of Phase 2 also consolidates OTel purple as a primitive token: `--otel-purple-hsl: 230 38% 49%` added to `src/styles/tokens.css`; `cncf-callout.css` line 28 refactored from hardcoded `#4f62ad` to `hsl(var(--otel-purple-hsl))`; rebased `--stats-band-bg-hsl` references `var(--otel-purple-hsl)` rather than duplicating the raw value.                                                                                                                                                                                                                                                                                      | "Concise and in-sync" sweep. CNCF callout was the only place purple was used and it was a hardcoded hex; new v1 tokens reuse the primitive. CoverBlock self-scopes dark via `--cover-block-*` tokens (not `--background-hsl`); the light-theme `.v1-app` override block explicitly redeclares all `--cover-block-*` and `--stats-band-*` tokens with the same values as the dark block — symmetric contract, no implicit fallthrough.                                                                                                                                                                                                                                                                                                                                                                |
+| 2026-05-21 | Phase 2 PR 3 (#524, StatsBand) merged on `main`. PR 4 (EcosystemsGrid) rebased onto current `main` via `git rebase --onto main 7da2b4e feat/84-phase2-pr4-ecosystems-grid` — drops the stale local copy of PR 3 (`7da2b4e`) and replays only the EcosystemsGrid commit. Clean rebase, no conflicts. Typecheck clean; all 916 vitest tests pass.                                                                                                                                                                                                                                                                                       | Stacked branch `feat/84-phase2-pr5-signals-row` still points at the pre-rebase PR 4 SHA (`50c70a2`) and will need its own `git rebase --onto main 50c70a2 feat/84-phase2-pr5-signals-row` once PR 4 merges. Out-of-numeric-order shipping continues: PR 2 (GlobalSearch) and PR 6 (RecentActivityRail) are still pending re-derivation from `feat/84-tmp-full-layout`.                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 Add a row whenever a decision lands. Keeps the doc honest.


### PR DESCRIPTION
Swaps the "Featured ecosystems" skeleton in `<HomeV1 />` for a real grid of two active ecosystem cards (Collector, Java Agent) and four dashed "coming soon" placeholders (Python, Go, JS, .NET).

Contributes to #371. Part of #84.

## What's in this PR

- New `<EcosystemsGrid>` at `src/v1/components/home/ecosystems-grid.tsx`:
  - Two large active cards linking to `/collector` and `/java-agent` via `<Link>`
  - Collector card uses the lucide `Network` icon tinted OTel purple; Java Agent card uses the project's branded `<JavaIcon />` SVG
  - Four dashed "coming soon" cards for Python, Go, JS, .NET (not links). Shared placeholder icon is hoisted to a single module-level `ReactNode` constant
  - Reuses the existing `<StatusPill>` from `src/components/ui/status-pill.tsx` for the stability badge
  - Ecosystem `id` and `unit` are union types, so adding an ecosystem without the matching CSS modifier or unit is a type error
- New `src/v1/styles/ecosystems-grid.css`, imported from `src/v1/styles/index.css`:
  - Per-id CSS modifiers (`--collector`, `--java-agent`) carry the brand-tinted icon-tile background, no inline hex
  - Hover effect (transform, shadow, border) scoped to `a.td-ecosystem-card` so placeholders never react to hover
  - Hover shadow is `hsl(var(--primary-hsl) / 0.12)`, stays visible against dark surfaces
- `src/v1/features/home/home-page.tsx` mounts `<EcosystemsGrid />` in place of the "Featured ecosystems" skeleton
- `home.css` drops the `--ecosystems` skeleton modifier rule. Trims the now-stale PR-numbered narration from the header comments in both `home.css` and `home-page.tsx`
- `home-page.test.tsx` composition assertions drop "Featured ecosystems" and add an EcosystemsGrid presence check
- `ecosystems-grid.test.tsx` covers section labelling, both active cards (href, stability pill, counts), all four placeholders (rendered, not anchors), and the external "View all projects" link
- `/_dev/components` showcase route gets an EcosystemsGrid variant
- Update `take-screenshots.mjs` to capture full-page screenshots for home and list pages 

## What's not in this PR

- Live counts via `loadAllComponents()` / `loadAllInstrumentations()`. Tracked follow-up, intentionally deferred so this PR doesn't drag the data layer along
- GlobalSearch (Phase 2 PR 2), SignalsRow (Phase 2 PR 5), RecentActivityRail (Phase 2 PR 6). Each is a separate staged PR; the corresponding skeletons remain in `<HomeV1 />`
- A shared `.td-section-header` partial. The block lives inside `ecosystems-grid.css` for now; it will move to its own partial when the next consumer (SignalsRow) arrives

## Verification

- `bun run typecheck` clean
- `bun run test` passes (915 / 915)
- `bun run format:check` clean
- Local dev server with `V1_REDESIGN=true`, `/` route: hero, stats band, ecosystems grid, two skeletons below. Both themes pass a contrast check
- `/_dev/components`: EcosystemsGrid showcase variant renders both active cards and four coming-soon placeholders

---

> Co-authored with Claude Opus 4.7.