### PR TITLE
Fix linting error

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -8,6 +8,7 @@ ignores:
   - "**/tmp_repos/**"
   - "**/node_modules/**"
   - ".claude/**"
+  - "ecosystem-explorer/public/data/**"
 
 config:
   default: true


### PR DESCRIPTION
Markdown files are causing errors:

```
ecosystem-explorer/public/data/javaagent/markdown/runtime-telemetry-69f1ccf3457f.md:209:121 error MD013/line-length Line length [Expected: 120; Actual: 209]
ecosystem-explorer/public/data/javaagent/markdown/runtime-telemetry-69f1ccf3457f.md:211:121 error MD013/line-length Line length [Expected: 120; Actual: 147]
```