### PR TITLE
feat(config-builder): add Import YAML button to load existing configurations

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-button.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-button.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportYamlButton } from "./import-yaml-button";
+
+const loadFromYaml = vi.fn();
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    loadFromYaml: (...a: unknown[]) => loadFromYaml(...a),
+  }),
+}));
+
+// jsdom does not implement HTMLDialogElement.showModal/close
+HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+  this.setAttribute("open", "");
+});
+HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+  this.removeAttribute("open");
+});
+
+describe("ImportYamlButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the Import trigger button", () => {
+    render(<ImportYamlButton />);
+    expect(screen.getByRole("button", { name: /import/i })).toBeInTheDocument();
+  });
+
+  it("opens the dialog when the Import button is clicked", () => {
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Import YAML Configuration")).toBeInTheDocument();
+  });
+
+  it("closes the dialog when Cancel is clicked", () => {
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it("closes the dialog when the X button is clicked", () => {
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+    fireEvent.click(screen.getByRole("button", { name: /close import dialog/i }));
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it("shows an error when Load is clicked without any YAML content", async () => {
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+    fireEvent.click(screen.getByRole("button", { name: /load configuration/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Please provide a YAML configuration to import."
+    );
+    expect(loadFromYaml).not.toHaveBeenCalled();
+  });
+
+  it("calls loadFromYaml with pasted YAML and closes the dialog on success", async () => {
+    loadFromYaml.mockResolvedValueOnce(undefined);
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+
+    fireEvent.change(screen.getByLabelText(/paste yaml/i), {
+      target: { value: "file_format: '0.3'\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /load configuration/i }));
+
+    await waitFor(() => {
+      expect(loadFromYaml).toHaveBeenCalledWith("file_format: '0.3'");
+    });
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it("shows the error message when loadFromYaml rejects", async () => {
+    loadFromYaml.mockRejectedValueOnce(new Error("Failed to parse YAML configuration"));
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+
+    fireEvent.change(screen.getByLabelText(/paste yaml/i), {
+      target: { value: "bad: yaml: :\n  wrong indent" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /load configuration/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to parse YAML configuration"
+    );
+    expect(HTMLDialogElement.prototype.close).not.toHaveBeenCalled();
+  });
+
+  it("clears error when the user edits the textarea after a failure", async () => {
+    loadFromYaml.mockRejectedValueOnce(new Error("Failed to parse YAML configuration"));
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+
+    const textarea = screen.getByLabelText(/paste yaml/i);
+    fireEvent.change(textarea, { target: { value: "bad yaml" } });
+    fireEvent.click(screen.getByRole("button", { name: /load configuration/i }));
+    await screen.findByRole("alert");
+
+    fireEvent.change(textarea, { target: { value: "file_format: '0.3'" } });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("resets the textarea and error when the dialog is reopened", async () => {
+    loadFromYaml.mockRejectedValueOnce(new Error("Failed to parse YAML configuration"));
+    render(<ImportYamlButton />);
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+
+    fireEvent.change(screen.getByLabelText(/paste yaml/i), {
+      target: { value: "bad yaml" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /load configuration/i }));
+    await screen.findByRole("alert");
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+
+    expect(screen.getByLabelText(/paste yaml/i)).toHaveValue("");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-button.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-button.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Upload, X } from "lucide-react";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+
+export function ImportYamlButton() {
+  const { loadFromYaml } = useConfigurationBuilder();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pastedYaml, setPastedYaml] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const openDialog = () => {
+    setPastedYaml("");
+    setError(null);
+    dialogRef.current?.showModal();
+  };
+
+  const closeDialog = useCallback(() => {
+    dialogRef.current?.close();
+    setPastedYaml("");
+    setError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, []);
+
+  // Close on backdrop click
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    const handleClick = (e: MouseEvent) => {
+      const rect = el.getBoundingClientRect();
+      const clickedOutside =
+        e.clientX < rect.left ||
+        e.clientX > rect.right ||
+        e.clientY < rect.top ||
+        e.clientY > rect.bottom;
+      if (clickedOutside) closeDialog();
+    };
+    el.addEventListener("click", handleClick);
+    return () => el.removeEventListener("click", handleClick);
+  }, [closeDialog]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result;
+      if (typeof text === "string") {
+        setPastedYaml(text);
+        setError(null);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleLoad = async () => {
+    const yaml = pastedYaml.trim();
+    if (!yaml) {
+      setError("Please provide a YAML configuration to import.");
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      await loadFromYaml(yaml);
+      closeDialog();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse YAML configuration.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const buttonClass =
+    "border-border/60 bg-card text-foreground hover:bg-card/80 focus-visible:ring-primary inline-flex cursor-pointer items-center gap-1 rounded-md border px-3 py-1.5 text-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none";
+
+  return (
+    <>
+      <button type="button" onClick={openDialog} className={buttonClass}>
+        <Upload className="h-3 w-3" aria-hidden="true" />
+        Import
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        aria-labelledby="import-yaml-title"
+        aria-describedby="import-yaml-desc"
+        className="bg-card text-foreground border-border/50 w-full max-w-lg rounded-xl border p-0 shadow-xl backdrop:bg-black/50"
+      >
+        <div className="space-y-4 p-6">
+          <div className="flex items-center justify-between">
+            <h2 id="import-yaml-title" className="text-base font-semibold">
+              Import YAML Configuration
+            </h2>
+            <button
+              type="button"
+              onClick={closeDialog}
+              aria-label="Close import dialog"
+              className="text-muted-foreground hover:text-foreground rounded-md p-1"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+
+          <p id="import-yaml-desc" className="text-muted-foreground text-sm">
+            Load an existing OpenTelemetry Java Agent configuration into the builder. Choose a file
+            from your machine or paste the YAML directly below.
+          </p>
+
+          <div className="space-y-1">
+            <label htmlFor="import-yaml-file" className="text-sm font-medium">
+              Choose a YAML file
+            </label>
+            <input
+              ref={fileInputRef}
+              id="import-yaml-file"
+              type="file"
+              accept=".yaml,.yml"
+              onChange={handleFileChange}
+              className="border-border/60 text-foreground bg-background/80 file:bg-card file:text-foreground file:border-border/60 w-full rounded-lg border px-3 py-2 text-sm file:mr-3 file:rounded-md file:border file:px-2 file:py-0.5 file:text-xs"
+            />
+          </div>
+
+          <div className="relative flex items-center gap-3">
+            <span className="bg-border/60 h-px flex-1" aria-hidden="true" />
+            <span className="text-muted-foreground text-xs">or paste below</span>
+            <span className="bg-border/60 h-px flex-1" aria-hidden="true" />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="import-yaml-paste" className="text-sm font-medium">
+              Paste YAML
+            </label>
+            <textarea
+              id="import-yaml-paste"
+              value={pastedYaml}
+              onChange={(e) => {
+                setPastedYaml(e.target.value);
+                setError(null);
+              }}
+              placeholder="file_format: '0.3'&#10;sdk:&#10;  ..."
+              rows={10}
+              className="border-border/60 bg-background/80 placeholder:text-muted-foreground/50 focus:border-primary/50 focus:ring-primary/20 w-full rounded-lg border px-3 py-2 font-mono text-xs focus:ring-2 focus:outline-none"
+              aria-invalid={error !== null}
+              aria-describedby={error ? "import-yaml-error" : undefined}
+            />
+          </div>
+
+          {error && (
+            <p id="import-yaml-error" role="alert" className="text-sm text-red-400">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={closeDialog}
+              className="border-border/60 bg-card text-foreground hover:bg-card/80 rounded-md border px-4 py-1.5 text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleLoad}
+              disabled={isLoading}
+              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isLoading ? "Loading..." : "Load Configuration"}
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
@@ -49,8 +49,16 @@ vi.mock("@/hooks/use-configuration-builder", () => ({
     setEnabled: vi.fn(),
     selectPlugin: vi.fn(),
     validateAll: (...a: unknown[]) => validateAll(...a),
+    loadFromYaml: vi.fn(),
   }),
 }));
+
+HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+  this.setAttribute("open", "");
+});
+HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+  this.removeAttribute("open");
+});
 
 const downloadSpy = vi.spyOn(downloadModule, "downloadText").mockImplementation(() => {});
 
@@ -69,6 +77,7 @@ describe("PreviewCard", () => {
     expect(screen.getByText("Output Preview")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /import/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add all/i })).toBeInTheDocument();
   });

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
@@ -28,6 +28,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { YamlCodeBlock } from "./yaml-code-block";
+import { ImportYamlButton } from "./import-yaml-button";
 
 interface HeaderActionButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>;
@@ -109,6 +110,7 @@ export function PreviewCard({ schema, javaAgentVersion }: PreviewCardProps): JSX
         <h3 className="text-foreground text-sm font-medium">Output Preview</h3>
         <div className="flex flex-wrap items-center gap-2">
           <PreviewActions yaml={yaml} filename={filename} onValidate={validateAll} />
+          <ImportYamlButton />
           <span className="bg-border/60 mx-1 h-4 w-px" aria-hidden="true" />
           <HeaderActionButton icon={ListPlus} label="Add all" onClick={enableAllSections} />
           <HeaderActionButton icon={RefreshCcw} label="Reset" onClick={handleReset} />


### PR DESCRIPTION
Closes #540

## What this does

Adds an Import button to the Output Preview card in the Configuration Builder. Clicking it opens a modal where you can either pick a `.yaml` or `.yml` file from your machine using a file picker, or paste raw YAML directly into a text area. Once you click Load Configuration, the builder parses the YAML and populates all the fields so you can continue editing visually.

Before this change, users who already had an existing OpenTelemetry Java Agent config file had no way to bring it into the builder. They had to start from scratch and re-enter every value by hand. This was especially painful for teams that manage their configs in version control and just wanted to use the builder to inspect or make a small change.

## How it works

The `loadFromYaml` function was already implemented and tested inside `useConfigurationBuilder`. This PR just wires it up to a UI. The new `ImportYamlButton` component renders the trigger button and a native `<dialog>` element that handles the file reading and paste workflow. When the YAML fails to parse, the error message is shown inside the dialog so the user knows what went wrong before any state changes happen.

The file input reads the selected file using `FileReader` and puts the content into the same textarea, so the Load logic only ever needs to deal with one code path.

## Files changed

- `src/features/java-agent/configuration/components/import-yaml-button.tsx` — new component
- `src/features/java-agent/configuration/components/import-yaml-button.test.tsx` — 8 new tests covering open, close, validation, success, and error paths
- `src/features/java-agent/configuration/components/preview-card.tsx` — import and render the new button
- `src/features/java-agent/configuration/components/preview-card.test.tsx` — adds the Import button to the existing render assertion, adds dialog polyfill for jsdom

## Testing

All tests pass locally. Typecheck and lint are clean.