### PR TITLE
fix: hoist ConfigurationBuilderProvider above tabs to prevent unsaved edit loss on tab switch

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { GroupNode } from "@/types/configuration";
+import { ConfigurationBuilderPage } from "./configuration-builder-page";
+
+/*
+ * These tests pin the loading and error states of ConfigurationBuilderPage,
+ * which must be handled OUTSIDE the ConfigurationBuilderProvider. The provider
+ * is hoisted above <Tabs> so builder state survives tab switches, but gating
+ * its mount also gates the loader and error UI — earlier that swallowed both
+ * into a blank screen while the schema/starter loaded or failed. The data hooks
+ * set `data: null` whenever they are loading or have errored, so `root` is null
+ * in exactly those windows; these tests assert the page still shows feedback.
+ */
+
+const mocks = vi.hoisted(() => {
+  const idle = { data: null as unknown, loading: false, error: null as Error | null };
+  return {
+    configVersions: { ...idle },
+    configSchema: { ...idle },
+    configStarter: { ...idle },
+    agentVersions: { ...idle },
+    instrumentations: { ...idle },
+  };
+});
+
+vi.mock("@/hooks/use-configuration-data", () => ({
+  useConfigVersions: () => mocks.configVersions,
+  useConfigSchema: () => mocks.configSchema,
+  useConfigStarter: () => mocks.configStarter,
+}));
+
+vi.mock("@/hooks/use-javaagent-data", () => ({
+  useVersions: () => mocks.agentVersions,
+  useInstrumentations: () => mocks.instrumentations,
+}));
+
+const ROOT_SCHEMA: GroupNode = {
+  controlType: "group",
+  key: "root",
+  label: "Root",
+  path: "",
+  children: [],
+};
+
+const VERSIONS_OK = {
+  data: { versions: [{ version: "1.0.0", is_latest: true }] },
+  loading: false,
+  error: null,
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ConfigurationBuilderPage />
+    </MemoryRouter>
+  );
+}
+
+describe("ConfigurationBuilderPage loading/error states", () => {
+  beforeEach(() => {
+    // Reset to a benign idle baseline; each test overrides what it needs.
+    mocks.configVersions = { data: null, loading: false, error: null };
+    mocks.configSchema = { data: null, loading: false, error: null };
+    mocks.configStarter = { data: null, loading: false, error: null };
+    mocks.agentVersions = { data: null, loading: false, error: null };
+    mocks.instrumentations = { data: null, loading: false, error: null };
+  });
+
+  it("shows the versions loader while the versions index is loading", () => {
+    mocks.configVersions = { data: null, loading: true, error: null };
+    renderPage();
+    expect(screen.getByText("Loading versions…")).toBeInTheDocument();
+  });
+
+  it("shows the versions error when the versions index fails", () => {
+    mocks.configVersions = { data: null, loading: false, error: new Error("boom") };
+    renderPage();
+    expect(screen.getByText("Failed to load available versions.")).toBeInTheDocument();
+  });
+
+  it("shows the schema loader (not a blank screen) while the schema is still loading", () => {
+    // Versions resolved, but schema/starter are mid-flight: `root` is null here.
+    mocks.configVersions = VERSIONS_OK;
+    mocks.configSchema = { data: null, loading: true, error: null };
+    mocks.configStarter = { data: null, loading: true, error: null };
+    renderPage();
+    expect(screen.getByText("Loading schema…")).toBeInTheDocument();
+    // The provider/tabs must not mount until data is ready.
+    expect(screen.queryByRole("tab")).toBeNull();
+  });
+
+  it("shows the schema error (not a blank screen) when the schema fails to load", () => {
+    mocks.configVersions = VERSIONS_OK;
+    mocks.configSchema = { data: null, loading: false, error: new Error("bad schema") };
+    mocks.configStarter = { data: null, loading: false, error: null };
+    renderPage();
+    expect(screen.getByText("Failed to load schema.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading schema…")).toBeNull();
+  });
+
+  it("shows the starter-template error when the schema loaded but the starter failed", () => {
+    mocks.configVersions = VERSIONS_OK;
+    mocks.configSchema = { data: ROOT_SCHEMA, loading: false, error: null };
+    mocks.configStarter = { data: null, loading: false, error: new Error("bad starter") };
+    renderPage();
+    expect(screen.getByText("Failed to load starter template.")).toBeInTheDocument();
+    // The builder tabs must not render while the starter is in an error state.
+    expect(screen.queryByRole("tab")).toBeNull();
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -109,11 +109,7 @@ interface SdkTabContentProps {
   activeTab: string;
 }
 
-function SdkTabContent({
-  schema,
-  javaAgentVersion,
-  activeTab,
-}: SdkTabContentProps) {
+function SdkTabContent({ schema, javaAgentVersion, activeTab }: SdkTabContentProps) {
   const { t } = useTranslation("java-agent");
   const [activePreviewKey, setActivePreviewKey] = useState<string | null>(null);
 
@@ -442,54 +438,63 @@ export function ConfigurationBuilderPage() {
           <Loader size="lg" label={t("builder.loading.versions")} className="mt-4" />
         ) : schemaVersionsState.error ? (
           <p className="mt-4 text-sm text-red-400">{t("builder.error.versions")}</p>
-        ) : root && (
-          <ConfigurationBuilderProvider
-            key={schemaVersion}
-            schema={root}
-            version={schemaVersion}
-            starter={starter.data}
-          >
-            <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsContent value="sdk">
-                {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
-                  <Loader
-                    size={root ? "sm" : "lg"}
-                    label={t("builder.loading.schema")}
-                    className={root ? "mt-4" : undefined}
-                  />
-                ) : schema.error ? (
-                  <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-                ) : starter.error ? (
-                  <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-                ) : root ? (
-                  <SdkTabContent
-                    schema={root}
-                    javaAgentVersion={javaAgentVersion}
-                    activeTab={activeTab}
-                  />
-                ) : null}
-              </TabsContent>
-              <TabsContent value="instrumentation">
-                {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
-                  <Loader
-                    size={root ? "sm" : "lg"}
-                    label={t("builder.loading.schema")}
-                    className={root ? "mt-4" : undefined}
-                  />
-                ) : schema.error ? (
-                  <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-                ) : starter.error ? (
-                  <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-                ) : root ? (
-                  <InstrumentationTabContent
-                    schema={root}
-                    javaAgentVersion={javaAgentVersion}
-                    activeTab={activeTab}
-                  />
-                ) : null}
-              </TabsContent>
-            </Tabs>
-          </ConfigurationBuilderProvider>
+        ) : (
+          root &&
+          !starter.loading && (
+            <ConfigurationBuilderProvider
+              key={schemaVersion}
+              schema={root}
+              version={schemaVersion}
+              starter={starter.data}
+            >
+              <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <TabsContent value="sdk">
+                  {!schemaVersion ||
+                  schema.loading ||
+                  starter.loading ||
+                  (!schema.error && !root) ? (
+                    <Loader
+                      size={root ? "sm" : "lg"}
+                      label={t("builder.loading.schema")}
+                      className={root ? "mt-4" : undefined}
+                    />
+                  ) : schema.error ? (
+                    <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
+                  ) : starter.error ? (
+                    <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
+                  ) : root ? (
+                    <SdkTabContent
+                      schema={root}
+                      javaAgentVersion={javaAgentVersion}
+                      activeTab={activeTab}
+                    />
+                  ) : null}
+                </TabsContent>
+                <TabsContent value="instrumentation">
+                  {!schemaVersion ||
+                  schema.loading ||
+                  starter.loading ||
+                  (!schema.error && !root) ? (
+                    <Loader
+                      size={root ? "sm" : "lg"}
+                      label={t("builder.loading.schema")}
+                      className={root ? "mt-4" : undefined}
+                    />
+                  ) : schema.error ? (
+                    <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
+                  ) : starter.error ? (
+                    <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
+                  ) : root ? (
+                    <InstrumentationTabContent
+                      schema={root}
+                      javaAgentVersion={javaAgentVersion}
+                      activeTab={activeTab}
+                    />
+                  ) : null}
+                </TabsContent>
+              </Tabs>
+            </ConfigurationBuilderProvider>
+          )
         )}
       </div>
     </PageContainer>

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -434,68 +434,50 @@ export function ConfigurationBuilderPage() {
             ) : null}
           </div>
         </div>
+        {/*
+         * Loading and error states are handled here, OUTSIDE the provider, so
+         * the schema-loading Loader and schema/starter error messages stay
+         * reachable. The provider is mounted only once data is ready, and it is
+         * hoisted above <Tabs> (not nested per-tab) so builder state survives
+         * tab switches — Radix unmounts the inactive TabsContent, which would
+         * otherwise discard unsaved edits. `key={schemaVersion}` remounts (and
+         * resets) state only when the schema version changes.
+         */}
         {schemaVersionsState.loading ? (
           <Loader size="lg" label={t("builder.loading.versions")} className="mt-4" />
         ) : schemaVersionsState.error ? (
           <p className="mt-4 text-sm text-red-400">{t("builder.error.versions")}</p>
-        ) : (
-          root &&
-          !starter.loading && (
-            <ConfigurationBuilderProvider
-              key={schemaVersion}
-              schema={root}
-              version={schemaVersion}
-              starter={starter.data}
-            >
-              <Tabs value={activeTab} onValueChange={setActiveTab}>
-                <TabsContent value="sdk">
-                  {!schemaVersion ||
-                  schema.loading ||
-                  starter.loading ||
-                  (!schema.error && !root) ? (
-                    <Loader
-                      size={root ? "sm" : "lg"}
-                      label={t("builder.loading.schema")}
-                      className={root ? "mt-4" : undefined}
-                    />
-                  ) : schema.error ? (
-                    <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-                  ) : starter.error ? (
-                    <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-                  ) : root ? (
-                    <SdkTabContent
-                      schema={root}
-                      javaAgentVersion={javaAgentVersion}
-                      activeTab={activeTab}
-                    />
-                  ) : null}
-                </TabsContent>
-                <TabsContent value="instrumentation">
-                  {!schemaVersion ||
-                  schema.loading ||
-                  starter.loading ||
-                  (!schema.error && !root) ? (
-                    <Loader
-                      size={root ? "sm" : "lg"}
-                      label={t("builder.loading.schema")}
-                      className={root ? "mt-4" : undefined}
-                    />
-                  ) : schema.error ? (
-                    <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-                  ) : starter.error ? (
-                    <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-                  ) : root ? (
-                    <InstrumentationTabContent
-                      schema={root}
-                      javaAgentVersion={javaAgentVersion}
-                      activeTab={activeTab}
-                    />
-                  ) : null}
-                </TabsContent>
-              </Tabs>
-            </ConfigurationBuilderProvider>
-          )
-        )}
+        ) : schema.loading || starter.loading || (!schema.error && !root) ? (
+          <Loader size="lg" label={t("builder.loading.schema")} className="mt-4" />
+        ) : schema.error ? (
+          <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
+        ) : starter.error ? (
+          <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
+        ) : root ? (
+          <ConfigurationBuilderProvider
+            key={schemaVersion}
+            schema={root}
+            version={schemaVersion}
+            starter={starter.data}
+          >
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsContent value="sdk">
+                <SdkTabContent
+                  schema={root}
+                  javaAgentVersion={javaAgentVersion}
+                  activeTab={activeTab}
+                />
+              </TabsContent>
+              <TabsContent value="instrumentation">
+                <InstrumentationTabContent
+                  schema={root}
+                  javaAgentVersion={javaAgentVersion}
+                  activeTab={activeTab}
+                />
+              </TabsContent>
+            </Tabs>
+          </ConfigurationBuilderProvider>
+        ) : null}
       </div>
     </PageContainer>
   );

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -105,16 +105,12 @@ function ExpandCollapseToolbar() {
 
 interface SdkTabContentProps {
   schema: GroupNode;
-  starter: ReturnType<typeof useConfigStarter>["data"];
-  schemaVersion: string;
   javaAgentVersion: string;
   activeTab: string;
 }
 
 function SdkTabContent({
   schema,
-  starter,
-  schemaVersion,
   javaAgentVersion,
   activeTab,
 }: SdkTabContentProps) {
@@ -153,12 +149,7 @@ function SdkTabContent({
   const { activeKey, scrollToSection } = useActiveSection(sectionKeys, sectionsContainerRef);
 
   return (
-    <ConfigurationBuilderProvider
-      key={schemaVersion}
-      schema={schema}
-      version={schemaVersion}
-      starter={starter}
-    >
+    <>
       <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
       <SectionExpansionProvider>
         <div className={BUILDER_GRID}>
@@ -195,22 +186,18 @@ function SdkTabContent({
           />
         </div>
       </SectionExpansionProvider>
-    </ConfigurationBuilderProvider>
+    </>
   );
 }
 
 interface InstrumentationTabContentProps {
   schema: GroupNode;
-  starter: ReturnType<typeof useConfigStarter>["data"];
-  schemaVersion: string;
   javaAgentVersion: string;
   activeTab: string;
 }
 
 function InstrumentationTabContent({
   schema,
-  starter,
-  schemaVersion,
   javaAgentVersion,
   activeTab,
 }: InstrumentationTabContentProps) {
@@ -223,19 +210,12 @@ function InstrumentationTabContent({
   }, [schema]);
 
   return (
-    <ConfigurationBuilderProvider
-      key={schemaVersion}
+    <InstrumentationTabBody
+      activeTab={activeTab}
       schema={schema}
-      version={schemaVersion}
-      starter={starter}
-    >
-      <InstrumentationTabBody
-        activeTab={activeTab}
-        schema={schema}
-        generalNode={generalNode}
-        javaAgentVersion={javaAgentVersion}
-      />
-    </ConfigurationBuilderProvider>
+      generalNode={generalNode}
+      javaAgentVersion={javaAgentVersion}
+    />
   );
 }
 
@@ -462,51 +442,54 @@ export function ConfigurationBuilderPage() {
           <Loader size="lg" label={t("builder.loading.versions")} className="mt-4" />
         ) : schemaVersionsState.error ? (
           <p className="mt-4 text-sm text-red-400">{t("builder.error.versions")}</p>
-        ) : (
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsContent value="sdk">
-              {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
-                <Loader
-                  size={root ? "sm" : "lg"}
-                  label={t("builder.loading.schema")}
-                  className={root ? "mt-4" : undefined}
-                />
-              ) : schema.error ? (
-                <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-              ) : starter.error ? (
-                <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-              ) : root ? (
-                <SdkTabContent
-                  schema={root}
-                  starter={starter.data}
-                  schemaVersion={schemaVersion}
-                  javaAgentVersion={javaAgentVersion}
-                  activeTab={activeTab}
-                />
-              ) : null}
-            </TabsContent>
-            <TabsContent value="instrumentation">
-              {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
-                <Loader
-                  size={root ? "sm" : "lg"}
-                  label={t("builder.loading.schema")}
-                  className={root ? "mt-4" : undefined}
-                />
-              ) : schema.error ? (
-                <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
-              ) : starter.error ? (
-                <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
-              ) : root ? (
-                <InstrumentationTabContent
-                  schema={root}
-                  starter={starter.data}
-                  schemaVersion={schemaVersion}
-                  javaAgentVersion={javaAgentVersion}
-                  activeTab={activeTab}
-                />
-              ) : null}
-            </TabsContent>
-          </Tabs>
+        ) : root && (
+          <ConfigurationBuilderProvider
+            key={schemaVersion}
+            schema={root}
+            version={schemaVersion}
+            starter={starter.data}
+          >
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsContent value="sdk">
+                {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
+                  <Loader
+                    size={root ? "sm" : "lg"}
+                    label={t("builder.loading.schema")}
+                    className={root ? "mt-4" : undefined}
+                  />
+                ) : schema.error ? (
+                  <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
+                ) : starter.error ? (
+                  <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
+                ) : root ? (
+                  <SdkTabContent
+                    schema={root}
+                    javaAgentVersion={javaAgentVersion}
+                    activeTab={activeTab}
+                  />
+                ) : null}
+              </TabsContent>
+              <TabsContent value="instrumentation">
+                {!schemaVersion || schema.loading || starter.loading || (!schema.error && !root) ? (
+                  <Loader
+                    size={root ? "sm" : "lg"}
+                    label={t("builder.loading.schema")}
+                    className={root ? "mt-4" : undefined}
+                  />
+                ) : schema.error ? (
+                  <p className="mt-4 text-sm text-red-400">{t("builder.error.schema")}</p>
+                ) : starter.error ? (
+                  <p className="mt-4 text-sm text-red-400">{t("builder.error.template")}</p>
+                ) : root ? (
+                  <InstrumentationTabContent
+                    schema={root}
+                    javaAgentVersion={javaAgentVersion}
+                    activeTab={activeTab}
+                  />
+                ) : null}
+              </TabsContent>
+            </Tabs>
+          </ConfigurationBuilderProvider>
         )}
       </div>
     </PageContainer>

--- a/ecosystem-explorer/src/test/integration/configuration-builder-tab-state.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/configuration-builder-tab-state.integration.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { installFetchInterceptor, uninstallFetchInterceptor } from "./helpers/fetch-interceptor";
+import { renderBuilderPage as renderPage } from "./helpers/render-builder-page";
+import { openInstrumentationTab } from "./helpers/open-instrumentation-tab";
+
+beforeAll(() => installFetchInterceptor());
+afterAll(() => uninstallFetchInterceptor());
+beforeEach(() => localStorage.clear());
+
+async function clickTab(name: RegExp) {
+  const user = userEvent.setup();
+  const sidebar = screen.getByRole("complementary");
+  await user.click(within(sidebar).getByRole("tab", { name }));
+}
+
+describe("ConfigurationBuilderPage tab state preservation", () => {
+  /*
+   * Regression test for the fix that hoisted ConfigurationBuilderProvider above
+   * <Tabs>. Radix unmounts the inactive TabsContent, so a provider nested
+   * per-tab would be torn down on every switch, discarding unsaved edits. With
+   * a single hoisted provider, edits made on one tab must survive switching
+   * away and back.
+   */
+  it("preserves an unsaved edit when switching tabs and back", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    // Resource is enabled by the starter; toggle it OFF on the SDK tab.
+    const resourceToggle = await screen.findByRole(
+      "switch",
+      { name: /Enable Resource/i },
+      { timeout: 10_000 }
+    );
+    expect(resourceToggle).toHaveAttribute("aria-checked", "true");
+    await user.click(resourceToggle);
+    await waitFor(() => {
+      expect(resourceToggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    // Switch to the Instrumentation tab (unmounts the SDK TabsContent)...
+    await openInstrumentationTab(user);
+    await screen.findByTestId("instrumentation-row-reactor", {}, { timeout: 10_000 });
+
+    // ...and back to the SDK tab. The toggle must still reflect the edit.
+    await clickTab(/SDK/i);
+    const resourceToggleAgain = await screen.findByRole(
+      "switch",
+      { name: /Enable Resource/i },
+      { timeout: 10_000 }
+    );
+    expect(resourceToggleAgain).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("keeps the toggled-off section out of the YAML preview after a tab round-trip", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    const resourceToggle = await screen.findByRole(
+      "switch",
+      { name: /Enable Resource/i },
+      { timeout: 10_000 }
+    );
+    await user.click(resourceToggle);
+    await waitFor(() => {
+      expect(resourceToggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    await openInstrumentationTab(user);
+    await screen.findByTestId("instrumentation-row-reactor", {}, { timeout: 10_000 });
+    await clickTab(/SDK/i);
+
+    await screen.findByRole("switch", { name: /Enable Resource/i }, { timeout: 10_000 });
+    const pre = screen.getByText(/OpenTelemetry SDK Configuration/).closest("pre");
+    expect(pre?.textContent).not.toMatch(/^resource:/m);
+  });
+});


### PR DESCRIPTION
## What
Fixes a race condition where unsaved edits in the Configuration Builder were silently lost when switching tabs before the 500ms debounce save completed.

## Changes
- Removed `ConfigurationBuilderProvider` from `SdkTabContent`
- Removed `ConfigurationBuilderProvider` from `InstrumentationTabContent`
- Removed now-unused `starter` and `schemaVersion` props from both `SdkTabContentProps` and `InstrumentationTabContentProps` interfaces
- Hoisted a single `ConfigurationBuilderProvider` above `<Tabs>` in `ConfigurationBuilderPage`, guarded by `root &&`
- Added React fragment wrapper in `SdkTabContent` return to support `PruneInstrumentationsForAgentVersion` sibling

**File changed:**
`ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx`

## Before / After
**Before:** Each tab owned its own provider. Switching tabs unmounted the inactive `TabsContent`, which unmounted the provider and cancelled the pending debounce timer, losing any edits made in the last 500ms.

**After:** A single provider lives at the page level, tied to the page lifetime not the tab lifetime. The debounce timer survives tab switches.

## Verified By
1. Navigated to `/java-agent/configuration/builder`
2. Enabled 6x CPU slowdown in DevTools -> Performance
3. Edited a field in the **SDK** tab
4. Immediately switched to **Instrumentation** tab
5. Switched back, edit was still present
6. Repeated in reverse, edits persisted in both directions

## Type of Change
- [x] Bug fix

Closes #510 