### PR TITLE
corner radius fix for " versions" and "dev " Tag

### DIFF
--- a/ecosystem-explorer/src/components/ui/stability-badge.tsx
+++ b/ecosystem-explorer/src/components/ui/stability-badge.tsx
@@ -26,6 +26,6 @@ interface StabilityBadgeProps {
 export function StabilityBadge({ stability }: StabilityBadgeProps): JSX.Element | null {
   if (stability !== "development") return null;
   return (
-    <span className="rounded-full bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-500">dev</span>
+    <span className="rounded-md bg-yellow-500/15 px-2 py-0.5 text-xs text-yellow-500">dev</span>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
@@ -73,7 +73,7 @@ export function MultiInstrumentationGroupCard({
                 }`}
               />
               <h3 className="truncate text-lg leading-tight font-semibold">{group.displayName}</h3>
-              <span className="bg-secondary/15 text-secondary flex-shrink-0 rounded-full px-2.5 py-1 text-xs font-medium">
+              <span className="bg-secondary/15 text-secondary flex-shrink-0 rounded-md px-2.5 py-1 text-xs font-medium">
                 {group.instrumentations.length} versions
               </span>
             </div>


### PR DESCRIPTION
Closes #566 

## Summary
Fixes inconsistent badge corner radius styling across the OpenTelemetry Explorer UI.

This updates:
- `versions` tags in multi-instrumentation cards
- `dev` stability badges in the Configuration Options Explorer

to use the shared badge radius instead of `rounded-full`.

## Changes
- Updated badge radius styling for consistency across the app
- Kept existing spacing, typography, and layout unchanged

## Files changed
- `src/features/java-agent/components/multi-instrumentation-group-card.tsx`
- `src/components/ui/stability-badge.tsx`

## Screenshots

1.versions
<img width="835" height="201" alt="f1" src="https://github.com/user-attachments/assets/51596513-0055-40e1-bac3-2963b76f8b69" />

2. Dev
<img width="831" height="386" alt="f2" src="https://github.com/user-attachments/assets/f82e245d-7801-4a2c-9642-c27b52890868" />
