### PR TITLE
feat: move java agent version to query parameter

### DIFF
--- a/ecosystem-explorer/src/LegacyApp.tsx
+++ b/ecosystem-explorer/src/LegacyApp.tsx
@@ -105,12 +105,9 @@ export function LegacyApp() {
               <Route path="/" element={<HomePage />} />
               <Route path="/java-agent" element={<JavaAgentPage />} />
               <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
+
               <Route
-                path="/java-agent/instrumentation/:version"
-                element={<JavaInstrumentationListPage />}
-              />
-              <Route
-                path="/java-agent/instrumentation/:version/:name"
+                path="/java-agent/instrumentation/:name"
                 element={<InstrumentationDetailPage />}
               />
               <Route path="/java-agent/configuration" element={<JavaConfigurationListPage />} />

--- a/ecosystem-explorer/src/LegacyApp.tsx
+++ b/ecosystem-explorer/src/LegacyApp.tsx
@@ -19,6 +19,8 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { isEnabled } from "@/lib/feature-flags";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { InstrumentationHandler } from "./features/java-agent/instrumentation-handler";
+import { LegacyNameVersionRedirect } from "./features/java-agent/legacy-name-version-redirect";
 
 const HomePage = lazy(() =>
   import("@/features/home/home-page").then((m) => ({ default: m.HomePage }))
@@ -57,11 +59,7 @@ const JavaReleaseComparisonPage = lazy(() =>
     default: m.JavaReleaseComparisonPage,
   }))
 );
-const InstrumentationDetailPage = lazy(() =>
-  import("@/features/java-agent/instrumentation-detail-page").then((m) => ({
-    default: m.InstrumentationDetailPage,
-  }))
-);
+
 const ConfigurationBuilderPage = lazy(() =>
   import("@/features/java-agent/configuration/configuration-builder-page").then((m) => ({
     default: m.ConfigurationBuilderPage,
@@ -107,8 +105,12 @@ export function LegacyApp() {
               <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
 
               <Route
-                path="/java-agent/instrumentation/:name"
-                element={<InstrumentationDetailPage />}
+                path="/java-agent/instrumentation/:param"
+                element={<InstrumentationHandler />}
+              />
+              <Route
+                path="/java-agent/instrumentation/:version/:name"
+                element={<LegacyNameVersionRedirect />}
               />
               <Route path="/java-agent/configuration" element={<JavaConfigurationListPage />} />
               {isEnabled("JAVA_RELEASE_COMPARISON") && (

--- a/ecosystem-explorer/src/LegacyApp.tsx
+++ b/ecosystem-explorer/src/LegacyApp.tsx
@@ -19,8 +19,8 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { isEnabled } from "@/lib/feature-flags";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
-import { InstrumentationHandler } from "./features/java-agent/instrumentation-handler";
-import { LegacyNameVersionRedirect } from "./features/java-agent/legacy-name-version-redirect";
+import { InstrumentationHandler } from "@/features/java-agent/instrumentation-handler";
+import { LegacyNameVersionRedirect } from "@/features/java-agent/legacy-name-version-redirect";
 
 const HomePage = lazy(() =>
   import("@/features/home/home-page").then((m) => ({ default: m.HomePage }))

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.test.tsx
@@ -250,6 +250,9 @@ describe("InstrumentationCard", () => {
     const link = screen.getByRole("link", {
       name: "View details for Test Instrumentation",
     });
-    expect(link).toHaveAttribute("href", "/java-agent/instrumentation/2.0.0/test-instrumentation");
+    expect(link).toHaveAttribute(
+      "href",
+      "/java-agent/instrumentation/test-instrumentation?version=2.0.0"
+    );
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-card.tsx
@@ -29,7 +29,7 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 interface InstrumentationCardProps {
   instrumentation: InstrumentationData;
   activeFilters?: FilterState;
-  version: string;
+  version: string | null;
 }
 
 export function InstrumentationCard({
@@ -39,7 +39,11 @@ export function InstrumentationCard({
 }: InstrumentationCardProps) {
   const displayName = getInstrumentationDisplayName(instrumentation);
   const badgeInfo = getBadgeInfo(instrumentation);
-  const detailUrl = `/java-agent/instrumentation/${version}/${instrumentation.name}`;
+
+  const detailUrl =
+    version && version !== "latest"
+      ? `/java-agent/instrumentation/${instrumentation.name}?version=${version}`
+      : `/java-agent/instrumentation/${instrumentation.name}`;
 
   return (
     <Link

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-group-card.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-group-card.test.tsx
@@ -255,7 +255,7 @@ describe("InstrumentationGroupCard", () => {
       });
       expect(link40).toHaveAttribute(
         "href",
-        "/java-agent/instrumentation/2.26.1/apache-httpclient-4.0"
+        "/java-agent/instrumentation/apache-httpclient-4.0?version=2.26.1"
       );
 
       const link50 = screen.getByRole("link", {
@@ -263,7 +263,7 @@ describe("InstrumentationGroupCard", () => {
       });
       expect(link50).toHaveAttribute(
         "href",
-        "/java-agent/instrumentation/2.26.1/apache-httpclient-5.0"
+        "/java-agent/instrumentation/apache-httpclient-5.0?version=2.26.1"
       );
     });
 

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-group-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-group-card.tsx
@@ -21,7 +21,7 @@ import { MultiInstrumentationGroupCard } from "./multi-instrumentation-group-car
 interface InstrumentationGroupCardProps {
   group: InstrumentationGroup;
   activeFilters?: FilterState;
-  version: string;
+  version: string | null;
 }
 
 export function InstrumentationGroupCard({

--- a/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/multi-instrumentation-group-card.tsx
@@ -25,7 +25,7 @@ import { renderWithInlineCode } from "@/lib/render-inline-code";
 interface MultiInstrumentationGroupCardProps {
   group: InstrumentationGroup;
   activeFilters?: FilterState;
-  version: string;
+  version: string | null;
 }
 
 export function MultiInstrumentationGroupCard({

--- a/ecosystem-explorer/src/features/java-agent/components/sub-instrumentation-item.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/sub-instrumentation-item.tsx
@@ -22,7 +22,7 @@ import { renderWithInlineCode } from "@/lib/render-inline-code";
 
 interface SubInstrumentationItemProps {
   instrumentation: InstrumentationData;
-  version: string;
+  version: string | null;
   activeFilters?: FilterState;
 }
 
@@ -32,7 +32,10 @@ export function SubInstrumentationItem({
   activeFilters,
 }: SubInstrumentationItemProps) {
   const badges = getBadgeInfo(instrumentation);
-  const detailUrl = `/java-agent/instrumentation/${version}/${instrumentation.name}`;
+  const detailUrl =
+    version && version !== "latest"
+      ? `/java-agent/instrumentation/${instrumentation.name}?version=${version}`
+      : `/java-agent/instrumentation/${instrumentation.name}`;
 
   return (
     <Link

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -66,10 +66,7 @@ function renderWithRouter(initialPath: string) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
-        <Route
-          path="/java-agent/instrumentation/:version/:name"
-          element={<InstrumentationDetailPage />}
-        />
+        <Route path="/java-agent/instrumentation/:name" element={<InstrumentationDetailPage />} />
       </Routes>
     </MemoryRouter>
   );
@@ -95,7 +92,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     expect(screen.getByText("Loading instrumentation...")).toBeInTheDocument();
   });
@@ -107,7 +104,7 @@ describe("InstrumentationDetailPage", () => {
       error: new Error("Failed to fetch instrumentation data"),
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     expect(screen.getByText("Error loading instrumentation")).toBeInTheDocument();
     expect(screen.getByText("Failed to fetch instrumentation data")).toBeInTheDocument();
@@ -120,7 +117,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     expect(screen.getByText("Error loading instrumentation")).toBeInTheDocument();
     expect(screen.getByText("Instrumentation not found")).toBeInTheDocument();
@@ -133,7 +130,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     const header = screen.getByRole("banner");
 
@@ -157,7 +154,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     const select = screen.getByRole("combobox", { name: /version/i });
     expect(select).toBeInTheDocument();
@@ -172,12 +169,12 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     const select = screen.getByRole("combobox", { name: /version/i });
     fireEvent.change(select, { target: { value: "1.9.0" } });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/1.9.0/jdbc");
+    expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/jdbc?version=1.9.0");
   });
 
   it("shows loading spinner on latest URL after versions load, never shows error card", () => {
@@ -187,7 +184,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/latest/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc?version=latest");
 
     expect(screen.getByText("Loading instrumentation...")).toBeInTheDocument();
     expect(screen.queryByText("Instrumentation not found")).not.toBeInTheDocument();
@@ -201,7 +198,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/latest/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc?version=latest");
 
     expect(useInstrumentation).toHaveBeenCalledWith("", "");
   });
@@ -213,9 +210,9 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/latest/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc?version=latest");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/2.0.0/jdbc", {
+    expect(mockNavigate).toHaveBeenCalledWith("/java-agent/instrumentation/jdbc", {
       replace: true,
     });
   });
@@ -227,7 +224,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     expect(screen.getByRole("heading", { name: "Semantic Conventions" })).toBeInTheDocument();
 
@@ -254,7 +251,7 @@ describe("InstrumentationDetailPage", () => {
       error: null,
     });
 
-    renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
+    renderWithRouter("/java-agent/instrumentation/jdbc");
 
     expect(screen.getByText("UNKNOWN_CONVENTION")).toBeInTheDocument();
   });

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -66,7 +66,7 @@ function renderWithRouter(initialPath: string) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
-        <Route path="/java-agent/instrumentation/:name" element={<InstrumentationDetailPage />} />
+        <Route path="/java-agent/instrumentation/:param" element={<InstrumentationDetailPage />} />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate, Link, useSearchParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import {
   Info,
@@ -72,13 +72,17 @@ function isSafeUrl(url: string): boolean {
 }
 
 export function InstrumentationDetailPage() {
-  const { version, name } = useParams<{ version: string; name: string }>();
+  const [searchParams] = useSearchParams();
+  const { name } = useParams<{ version: string; name: string }>();
+
   const navigate = useNavigate();
   const [showComparison, setShowComparison] = useState(false);
   const [activeTab, setActiveTab] = useState("details");
 
   const { data: versionsData, loading: versionsLoading, error: versionsError } = useVersions();
 
+  const latestVersion = versionsData?.versions.find((v) => v.is_latest)?.version;
+  const version = searchParams.get("version") || latestVersion;
   const isVersionValid =
     version === "latest" ||
     !versionsData ||
@@ -91,7 +95,7 @@ export function InstrumentationDetailPage() {
     error,
   } = useInstrumentation(
     shouldFetchInstrumentation ? (name ?? "") : "",
-    shouldFetchInstrumentation ? (version ?? "") : ""
+    shouldFetchInstrumentation ? (version as string) : ""
   );
 
   const loading =
@@ -99,15 +103,18 @@ export function InstrumentationDetailPage() {
 
   useEffect(() => {
     if (version === "latest" && versionsData) {
-      const latestVersion = versionsData.versions.find((v) => v.is_latest)?.version;
       if (latestVersion && name) {
-        navigate(`/java-agent/instrumentation/${latestVersion}/${name}`, { replace: true });
+        navigate(`/java-agent/instrumentation/${name}`, { replace: true });
       }
     }
-  }, [version, name, versionsData, navigate]);
+  }, [version, name, versionsData, navigate, latestVersion]);
 
   const handleVersionChange = (newVersion: string) => {
-    navigate(`/java-agent/instrumentation/${newVersion}/${name}`);
+    navigate(
+      newVersion != latestVersion
+        ? `/java-agent/instrumentation/${name}?version=${newVersion}`
+        : `/java-agent/instrumentation/${name}`
+    );
   };
 
   if (loading) {
@@ -160,7 +167,6 @@ export function InstrumentationDetailPage() {
   }
 
   if (!isVersionValid && versionsData) {
-    const latestVersion = versionsData.versions.find((v) => v.is_latest)?.version;
     return (
       <PageContainer>
         <BackButton />

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -185,7 +185,7 @@ export function InstrumentationDetailPage() {
                   Version <code className="rounded bg-yellow-500/10 px-1 py-0.5">{version}</code>{" "}
                   does not exist.
                 </p>
-                {latestVersion && param&& (
+                {latestVersion && param && (
                   <Link
                     to={`/java-agent/instrumentation/${latestVersion}/${param}`}
                     className="inline-flex items-center gap-1.5 text-sm text-yellow-600 underline hover:no-underline dark:text-yellow-400"

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -187,7 +187,7 @@ export function InstrumentationDetailPage() {
                 </p>
                 {latestVersion && param && (
                   <Link
-                    to={`/java-agent/instrumentation/${latestVersion}/${param}`}
+                    to={`/java-agent/instrumentation/${param}?version=${latestVersion}`}
                     className="inline-flex items-center gap-1.5 text-sm text-yellow-600 underline hover:no-underline dark:text-yellow-400"
                   >
                     View {param} under the latest version ({latestVersion})

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -73,7 +73,7 @@ function isSafeUrl(url: string): boolean {
 
 export function InstrumentationDetailPage() {
   const [searchParams] = useSearchParams();
-  const { name } = useParams<{ version: string; name: string }>();
+  const { param } = useParams<{ param: string }>();
 
   const navigate = useNavigate();
   const [showComparison, setShowComparison] = useState(false);
@@ -94,7 +94,7 @@ export function InstrumentationDetailPage() {
     loading: instrumentationLoading,
     error,
   } = useInstrumentation(
-    shouldFetchInstrumentation ? (name ?? "") : "",
+    shouldFetchInstrumentation ? (param ?? "") : "",
     shouldFetchInstrumentation ? (version as string) : ""
   );
 
@@ -103,17 +103,17 @@ export function InstrumentationDetailPage() {
 
   useEffect(() => {
     if (version === "latest" && versionsData) {
-      if (latestVersion && name) {
-        navigate(`/java-agent/instrumentation/${name}`, { replace: true });
+      if (latestVersion && param) {
+        navigate(`/java-agent/instrumentation/${param}`, { replace: true });
       }
     }
-  }, [version, name, versionsData, navigate, latestVersion]);
+  }, [version, param, versionsData, navigate, latestVersion]);
 
   const handleVersionChange = (newVersion: string) => {
     navigate(
       newVersion != latestVersion
-        ? `/java-agent/instrumentation/${name}?version=${newVersion}`
-        : `/java-agent/instrumentation/${name}`
+        ? `/java-agent/instrumentation/${param}?version=${newVersion}`
+        : `/java-agent/instrumentation/${param}`
     );
   };
 

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -185,12 +185,12 @@ export function InstrumentationDetailPage() {
                   Version <code className="rounded bg-yellow-500/10 px-1 py-0.5">{version}</code>{" "}
                   does not exist.
                 </p>
-                {latestVersion && name && (
+                {latestVersion && param&& (
                   <Link
-                    to={`/java-agent/instrumentation/${latestVersion}/${name}`}
+                    to={`/java-agent/instrumentation/${latestVersion}/${param}`}
                     className="inline-flex items-center gap-1.5 text-sm text-yellow-600 underline hover:no-underline dark:text-yellow-400"
                   >
-                    View {name} under the latest version ({latestVersion})
+                    View {param} under the latest version ({latestVersion})
                   </Link>
                 )}
               </div>

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-handler.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-handler.tsx
@@ -19,10 +19,10 @@ import { InstrumentationDetailPage } from "./instrumentation-detail-page";
 export function InstrumentationHandler() {
   const { param } = useParams<{ param: string }>();
 
-  const isVersion = /^\d+\.\d+\.\d+$/.test(param as string);
+  const isVersion = /^\d+\.\d+\.\d+$/.test(param as string) || param == "latest";
 
   if (isVersion) {
-    return <Navigate to={`/java-agent/instrumentation?version=${param}`} />;
+    return <Navigate to={`/java-agent/instrumentation?version=${param}`} replace />;
   }
   return <InstrumentationDetailPage />;
 }

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-handler.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-handler.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Navigate, useParams } from "react-router-dom";
+import { InstrumentationDetailPage } from "./instrumentation-detail-page";
+
+export function InstrumentationHandler() {
+  const { param } = useParams<{ param: string }>();
+
+  const isVersion = /^\d+\.\d+\.\d+$/.test(param as string);
+
+  if (isVersion) {
+    return <Navigate to={`/java-agent/instrumentation?version=${param}`} />;
+  }
+  return <InstrumentationDetailPage />;
+}

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import userEvent from "@testing-library/user-event";
-import { JavaInstrumentationListPage } from "./java-instrumentation-list-page";
 import type { InstrumentationData } from "@/types/javaagent";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JavaInstrumentationListPage } from "./java-instrumentation-list-page";
 
 vi.mock("@/hooks/use-javaagent-data", () => ({
   useVersions: vi.fn(),
@@ -29,22 +29,19 @@ vi.mock("@/components/ui/back-button", () => ({
   BackButton: () => <button>Back</button>,
 }));
 
-import { useVersions, useInstrumentations } from "@/hooks/use-javaagent-data";
+import { useInstrumentations, useVersions } from "@/hooks/use-javaagent-data";
 
 function LocationDisplay() {
   const location = useLocation();
   return <div data-testid="location">{location.pathname + location.search}</div>;
 }
 
-function renderPage(initialPath = "/java-agent/instrumentation/2.0.0") {
+function renderPage(initialPath = "/java-agent/instrumentation") {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
-        <Route
-          path="/java-agent/instrumentation/:version"
-          element={<JavaInstrumentationListPage />}
-        />
+        <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
       </Routes>
       <LocationDisplay />
     </MemoryRouter>
@@ -144,7 +141,7 @@ describe("JavaInstrumentationListPage - URL Persistence", () => {
   });
 
   it("reads search query from URL on mount", async () => {
-    renderPage("/java-agent/instrumentation/2.0.0?search=kafka");
+    renderPage("/java-agent/instrumentation?search=kafka");
 
     await waitFor(() => {
       expect(screen.getByText("Kafka Client")).toBeInTheDocument();
@@ -168,7 +165,7 @@ describe("JavaInstrumentationListPage - URL Persistence", () => {
   });
 
   it("reads telemetry filter from URL on mount", async () => {
-    renderPage("/java-agent/instrumentation/2.0.0?telemetry=spans");
+    renderPage("/java-agent/instrumentation?telemetry=spans");
 
     await waitFor(() => {
       expect(screen.getByText("HTTP Client")).toBeInTheDocument();
@@ -190,7 +187,7 @@ describe("JavaInstrumentationListPage - URL Persistence", () => {
   });
 
   it("reads type filter from URL on mount", async () => {
-    renderPage("/java-agent/instrumentation/2.0.0?type=javaagent");
+    renderPage("/java-agent/instrumentation?type=javaagent");
 
     await waitFor(() => {
       expect(screen.getByText("HTTP Client")).toBeInTheDocument();
@@ -215,7 +212,7 @@ describe("JavaInstrumentationListPage - URL Persistence", () => {
 
     await waitFor(() => {
       const loc = screen.getByTestId("location").textContent ?? "";
-      expect(loc).toContain("2.0.0");
+      expect(loc).not.toContain("2.0.0");
       expect(loc).toContain("search=kafka");
       expect(loc).toContain("telemetry=spans");
     });

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.test.tsx
@@ -41,7 +41,6 @@ function renderPage(initialPath = "/java-agent/instrumentation") {
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
-        <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
       </Routes>
       <LocationDisplay />
     </MemoryRouter>
@@ -208,7 +207,7 @@ describe("JavaInstrumentationListPage - URL Persistence", () => {
   });
 
   it("preserves existing search params when redirecting no-version to latest", async () => {
-    renderPage("/java-agent/instrumentation/latest?search=kafka&telemetry=spans");
+    renderPage("/java-agent/instrumentation?version=latest&search=kafka&telemetry=spans");
 
     await waitFor(() => {
       const loc = screen.getByTestId("location").textContent ?? "";

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -21,7 +21,7 @@ import {
   InstrumentationFilterBar,
 } from "@/features/java-agent/components/instrumentation-filter-bar.tsx";
 import { useMemo, useState, useEffect } from "react";
-import { useParams, useNavigate, useSearchParams, useLocation } from "react-router-dom";
+import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
 import { InstrumentationGroupCard } from "@/features/java-agent/components/instrumentation-group-card.tsx";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import { getInstrumentationDisplayName } from "./utils/format";
@@ -29,7 +29,8 @@ import { groupInstrumentationsByDisplayName } from "./utils/group-instrumentatio
 import { PageContainer } from "@/components/layout/page-container";
 
 export function JavaInstrumentationListPage() {
-  const { version: versionParam } = useParams<{ version?: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -37,7 +38,7 @@ export function JavaInstrumentationListPage() {
 
   const latestVersion = versionsData?.versions.find((v) => v.is_latest)?.version ?? "";
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const versionParam = searchParams.get("version");
   const invalidVersion = searchParams.get("redirectedFrom");
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
@@ -51,18 +52,24 @@ export function JavaInstrumentationListPage() {
   useEffect(() => {
     if (versionsData && latestVersion) {
       if (!versionParam || versionParam === "latest") {
-        navigate(`/java-agent/instrumentation/${latestVersion}${location.search}`, {
+        const params = new URLSearchParams(location.search);
+
+        params.delete("version");
+
+        const query = params.toString();
+
+        navigate(`/java-agent/instrumentation${query ? `?${query}` : ""}`, {
           replace: true,
         });
       } else if (!isVersionValid) {
-        navigate(`/java-agent/instrumentation/${latestVersion}?redirectedFrom=${versionParam}`, {
+        navigate(`/java-agent/instrumentation?redirectedFrom=${versionParam}`, {
           replace: true,
         });
       }
     }
   }, [versionParam, versionsData, latestVersion, navigate, isVersionValid, location.search]);
 
-  const resolvedVersion = versionParam && versionParam !== "latest" ? versionParam : "";
+  const resolvedVersion = versionParam ?? latestVersion;
 
   const {
     data: instrumentations,
@@ -236,9 +243,18 @@ export function JavaInstrumentationListPage() {
 
   const handleVersionChange = (newVersion: string) => {
     const params = new URLSearchParams(location.search);
+
     params.delete("redirectedFrom");
+
+    if (newVersion === latestVersion || newVersion === "latest") {
+      params.delete("version");
+    } else {
+      params.set("version", newVersion);
+    }
+
     const query = params.toString();
-    navigate(`/java-agent/instrumentation/${newVersion}${query ? `?${query}` : ""}`);
+
+    navigate(`/java-agent/instrumentation${query ? `?${query}` : ""}`);
   };
 
   return (
@@ -335,7 +351,7 @@ export function JavaInstrumentationListPage() {
                         key={group.displayName}
                         group={group}
                         activeFilters={filters}
-                        version={resolvedVersion}
+                        version={versionParam}
                       />
                     ))}
                   </div>
@@ -358,7 +374,7 @@ export function JavaInstrumentationListPage() {
                           key={group.displayName}
                           group={group}
                           activeFilters={filters}
-                          version={resolvedVersion}
+                          version={versionParam}
                         />
                       ))}
                     </div>

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -51,18 +51,18 @@ export function JavaInstrumentationListPage() {
   // Invalid version → latest with redirectedFrom banner.
   useEffect(() => {
     if (versionsData && latestVersion) {
+      const params = new URLSearchParams(location.search);
+      params.delete("version");
+
+      const query = params.toString();
+
+      console.log(query);
       if (!versionParam || versionParam === "latest") {
-        const params = new URLSearchParams(location.search);
-
-        params.delete("version");
-
-        const query = params.toString();
-
         navigate(`/java-agent/instrumentation${query ? `?${query}` : ""}`, {
           replace: true,
         });
       } else if (!isVersionValid) {
-        navigate(`/java-agent/instrumentation?redirectedFrom=${versionParam}`, {
+        navigate(`/java-agent/instrumentation?${query}&redirectedFrom=${versionParam}`, {
           replace: true,
         });
       }

--- a/ecosystem-explorer/src/features/java-agent/legacy-name-version-redirect.tsx
+++ b/ecosystem-explorer/src/features/java-agent/legacy-name-version-redirect.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Navigate, useParams } from "react-router-dom";
+
+export function LegacyNameVersionRedirect() {
+  const { name, version } = useParams<{ name: string; version: string }>();
+
+  return <Navigate to={`/java-agent/instrumentation/${name}?version=${version}`} />;
+}

--- a/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
@@ -43,12 +43,9 @@ afterAll(() => uninstallFetchInterceptor());
 
 function renderDetailPage(version: string, name: string) {
   return render(
-    <MemoryRouter initialEntries={[`/java-agent/instrumentation/${version}/${name}`]}>
+    <MemoryRouter initialEntries={[`/java-agent/instrumentation/${name}?version=${version}`]}>
       <Routes>
-        <Route
-          path="/java-agent/instrumentation/:version/:name"
-          element={<InstrumentationDetailPage />}
-        />
+        <Route path="/java-agent/instrumentation/:name" element={<InstrumentationDetailPage />} />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-detail.integration.test.tsx
@@ -45,7 +45,7 @@ function renderDetailPage(version: string, name: string) {
   return render(
     <MemoryRouter initialEntries={[`/java-agent/instrumentation/${name}?version=${version}`]}>
       <Routes>
-        <Route path="/java-agent/instrumentation/:name" element={<InstrumentationDetailPage />} />
+        <Route path="/java-agent/instrumentation/:param" element={<InstrumentationDetailPage />} />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
@@ -32,12 +32,9 @@ afterAll(() => uninstallFetchInterceptor());
 
 function renderPage() {
   return render(
-    <MemoryRouter initialEntries={[`/java-agent/instrumentation/${latestVersion}`]}>
+    <MemoryRouter initialEntries={[`/java-agent/instrumentation?version=${latestVersion}`]}>
       <Routes>
-        <Route
-          path="/java-agent/instrumentation/:version"
-          element={<JavaInstrumentationListPage />}
-        />
+        <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
       </Routes>
     </MemoryRouter>
   );

--- a/ecosystem-explorer/src/v1/V1App.tsx
+++ b/ecosystem-explorer/src/v1/V1App.tsx
@@ -113,12 +113,9 @@ export function V1App() {
               <Route path="/" element={<HomePage />} />
               <Route path="/java-agent" element={<JavaAgentPage />} />
               <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
+
               <Route
-                path="/java-agent/instrumentation/:version"
-                element={<JavaInstrumentationListPage />}
-              />
-              <Route
-                path="/java-agent/instrumentation/:version/:name"
+                path="/java-agent/instrumentation/:name"
                 element={<InstrumentationDetailPage />}
               />
               <Route path="/java-agent/configuration" element={<JavaConfigurationListPage />} />

--- a/ecosystem-explorer/src/v1/V1App.tsx
+++ b/ecosystem-explorer/src/v1/V1App.tsx
@@ -21,6 +21,8 @@ import { CncfCallout } from "@/v1/components/layout/cncf-callout";
 import { FooterV1 } from "@/v1/components/layout/footer";
 import { NavBar } from "@/v1/components/layout/nav-bar";
 import "@/v1/styles/index.css";
+import { InstrumentationHandler } from "@/features/java-agent/instrumentation-handler";
+import { LegacyNameVersionRedirect } from "@/features/java-agent/legacy-name-version-redirect";
 
 /*
  * V1 sub-app entry. Reached via the V1_REDESIGN boundary read in `src/App.tsx`.
@@ -75,11 +77,7 @@ const JavaReleaseComparisonPage = lazy(() =>
     default: m.JavaReleaseComparisonPage,
   }))
 );
-const InstrumentationDetailPage = lazy(() =>
-  import("@/features/java-agent/instrumentation-detail-page").then((m) => ({
-    default: m.InstrumentationDetailPage,
-  }))
-);
+
 const ConfigurationBuilderPage = lazy(() =>
   import("@/features/java-agent/configuration/configuration-builder-page").then((m) => ({
     default: m.ConfigurationBuilderPage,
@@ -115,9 +113,14 @@ export function V1App() {
               <Route path="/java-agent/instrumentation" element={<JavaInstrumentationListPage />} />
 
               <Route
-                path="/java-agent/instrumentation/:name"
-                element={<InstrumentationDetailPage />}
+                path="/java-agent/instrumentation/:param"
+                element={<InstrumentationHandler />}
               />
+              <Route
+                path="/java-agent/instrumentation/:version/:name"
+                element={<LegacyNameVersionRedirect />}
+              />
+
               <Route path="/java-agent/configuration" element={<JavaConfigurationListPage />} />
               {isEnabled("JAVA_RELEASE_COMPARISON") && (
                 <Route path="/java-agent/releases" element={<JavaReleaseComparisonPage />} />


### PR DESCRIPTION
fixes #369 

## Summary

This PR refactors Java Agent instrumentation routing to move the version from the URL path into an optional query parameter.

Instrumentation URLs are now stable and version-independent by default.

## Changes

### Routing updates

Changed instrumentation routes from:

```txt
/java-agent/instrumentation/:version
/java-agent/instrumentation/:version/:name
```

to:

```txt
/java-agent/instrumentation
/java-agent/instrumentation/:name
```

### Version handling

Moved version selection from path params to query params.

Examples:

Before:

```txt
/java-agent/instrumentation/2.27.0/tomcat-10.0
/java-agent/instrumentation/2.27.0/http-url-connection
```

After:

```txt
/java-agent/instrumentation/tomcat-10.0
/java-agent/instrumentation/http-url-connection
```

Specific version:

```txt
/java-agent/instrumentation/tomcat-10.0?version=2.27.0
```

### Frontend updates

* Updated routes to remove `:version`
* Updated `instrumentation-detail-page.tsx`

  * reads version from `useSearchParams`
  * version selector updates query params instead of navigating with path params
* Updated `java-instrumentation-list-page.tsx`

  * reads version from query params
  * preserves filters/search params during navigation
* Updated `instrumentation-card.tsx`

  * detail links no longer include version in the path
  * non-latest versions are preserved via query params
* Updated tests and assertions for new routing behavior

## Example URLs

Latest version:

```txt
/java-agent/instrumentation
/java-agent/instrumentation/tomcat-10.0
```

Specific version:

```txt
/java-agent/instrumentation?version=2.27.0
/java-agent/instrumentation/tomcat-10.0?version=2.27.0
```

## Migration

No backend or data pipeline changes were required.

Instrumentation names are already stable identifiers, so existing data loading logic continues to work with query-param-based version selection.
