### PR TITLE
Fix watcher permissions

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -70,7 +70,6 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
-          permission-contents: write
           permission-pull-requests: write
 
       - name: Configure git (fork)

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -63,7 +63,6 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
-          permission-contents: write
           permission-pull-requests: write
 
       - name: Configure git (forked repository)

--- a/.github/workflows/screenshots-commit.yml
+++ b/.github/workflows/screenshots-commit.yml
@@ -157,7 +157,7 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
-          permission-issues: write
+          permission-pull-requests: write
 
       - name: Post or update PR comment
         env:


### PR DESCRIPTION
Some cleanups from some recent hardening tasks. In two cases we are asking for permissions from the otelbot app that don't exist, and in the other we were grabbing the wrong one.

This is [causing](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/actions/runs/26350534805/job/77567863918):

> Failed to create token for "open-telemetry/opentelemetry-ecosystem-explorer" (attempt 1): The permissions requested are not granted to this installation. - 

Fixes #568 #569 #571 #570