### PR TITLE
Add grid background to Configuration Options Explorer cards

### DIFF
--- a/ecosystem-explorer/src/components/ui/detail-card.tsx
+++ b/ecosystem-explorer/src/components/ui/detail-card.tsx
@@ -36,7 +36,7 @@ export function DetailCard({
 
   return (
     <div
-      className={`group border-border/60 bg-card/80 relative overflow-hidden rounded-lg border p-6 ${
+      className={`group border-border/60 bg-card/80 relative flex flex-col overflow-hidden rounded-lg border p-6 ${
         withHoverEffect
           ? "hover:border-secondary/40 hover:bg-card hover:shadow-secondary/10 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg"
           : ""
@@ -49,7 +49,7 @@ export function DetailCard({
         />
       )}
       {withGrid && (
-        <div className="absolute inset-0 opacity-10">
+        <div className="pointer-events-none absolute inset-0 -z-10 opacity-10">
           <svg className="h-full w-full" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <pattern id={patternId} width="20" height="20" patternUnits="userSpaceOnUse">
@@ -67,7 +67,8 @@ export function DetailCard({
         </div>
       )}
 
-      <div className="relative z-10">{children}</div>
+     
+      <div className="relative z-10 flex-1 w-full">{children}</div>
     </div>
   );
 }

--- a/ecosystem-explorer/src/components/ui/detail-card.tsx
+++ b/ecosystem-explorer/src/components/ui/detail-card.tsx
@@ -67,8 +67,7 @@ export function DetailCard({
         </div>
       )}
 
-     
-      <div className="relative z-10 flex-1 w-full">{children}</div>
+      <div className="relative z-10 w-full flex-1">{children}</div>
     </div>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -52,7 +52,7 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
   return (
     <DetailCard withHoverEffect>
       {/* Grid pattern background */}
-      <div className="absolute -inset-6 opacity-[0.15] -z-10 pointer-events-none">
+      <div className="pointer-events-none absolute -inset-6 -z-10 opacity-[0.15]">
         <div
           className="h-full w-full"
           style={{

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -51,6 +51,18 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
 
   return (
     <DetailCard withHoverEffect>
+      {/* Grid pattern background */}
+      <div className="absolute -inset-6 opacity-[0.15] -z-10 pointer-events-none">
+        <div
+          className="h-full w-full"
+          style={{
+            backgroundImage:
+              "linear-gradient(hsl(var(--border-hsl)) 1px, transparent 1px), linear-gradient(90deg, hsl(var(--border-hsl)) 1px, transparent 1px)",
+            backgroundSize: "20px 20px",
+          }}
+        />
+      </div>
+
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-3">
           {showDeclarative ? (


### PR DESCRIPTION
Closes #589 

Title: Add grid background to Configuration Options Explorer cards

### Description:
This PR adds the grid background styling to the cards in the Configuration Options Explorer page to maintain consistency with the existing UI design patterns used across the application.

### Changes made:

* Added grid background styling to configuration cards
* Aligned card appearance with other pages/components
* Improved overall visual consistency and user experience

### Screenshot

Before

<img width="1465" height="745" alt="Before" src="https://github.com/user-attachments/assets/6157860a-db04-44c9-b0dd-f0b5ffeb6cd5" />

After

<img width="1463" height="747" alt="after" src="https://github.com/user-attachments/assets/69a2dc32-ca38-4102-9e73-a248d3940961" />

Reason:
The Configuration Options Explorer page was the only page where cards did not include the grid background pattern used throughout the application.
