### PR TITLE
feat(java-agent): improve mobile navigation for configuration builder

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
@@ -66,7 +66,7 @@ export function ConfigurationTocSidebar({
   const isCustomizedActive = statusFilter === "customized";
 
   return (
-    <aside className="lg:sticky lg:top-20 lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto">
+    <aside className="hidden lg:block lg:sticky lg:top-20 lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto w-full">
       <SegmentedTabList tabs={TABS} value={activeTab} fullWidth />
       {isInstrumentation && (
         <div className="mt-3">

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
@@ -29,6 +29,7 @@ export interface ConfigurationTocSidebarProps {
   sections: TocSection[];
   activeKey: string | null;
   onSectionClick: (key: string) => void;
+  className?: string;
   /** Only meaningful when activeTab === "instrumentation". */
   search?: string;
   onSearchChange?: (value: string) => void;
@@ -59,6 +60,7 @@ export function ConfigurationTocSidebar({
   statusFilter = "all",
   onStatusFilterChange,
   customizationCount = 0,
+  className = "",
 }: ConfigurationTocSidebarProps): JSX.Element {
   const isInstrumentation = activeTab === "instrumentation";
   const showTocNav = activeTab === "sdk" || isInstrumentation;
@@ -66,7 +68,9 @@ export function ConfigurationTocSidebar({
   const isCustomizedActive = statusFilter === "customized";
 
   return (
-    <aside className="hidden w-full lg:sticky lg:top-20 lg:block lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto">
+    <aside
+      className={`w-full lg:sticky lg:top-20 lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto ${className}`}
+    >
       <SegmentedTabList tabs={TABS} value={activeTab} fullWidth />
       {isInstrumentation && (
         <div className="mt-3">

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/configuration-toc-sidebar.tsx
@@ -66,7 +66,7 @@ export function ConfigurationTocSidebar({
   const isCustomizedActive = statusFilter === "customized";
 
   return (
-    <aside className="hidden lg:block lg:sticky lg:top-20 lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto w-full">
+    <aside className="hidden w-full lg:sticky lg:top-20 lg:block lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-auto">
       <SegmentedTabList tabs={TABS} value={activeTab} fullWidth />
       {isInstrumentation && (
         <div className="mt-3">

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -145,7 +145,12 @@ function SdkTabContent({
       <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
 
       <div className={BUILDER_GRID}>
-        <ConfigurationTocSidebar activeTab={activeTab} sections={tocSections} activeKey={activeKey} onSectionClick={scrollToSection} />
+        <ConfigurationTocSidebar
+          activeTab={activeTab}
+          sections={tocSections}
+          activeKey={activeKey}
+          onSectionClick={scrollToSection}
+        />
         <div ref={sectionsContainerRef} className="space-y-4">
           {hasGeneralLeaves && (
             <GeneralSectionCard label={GENERAL_SECTION_LABEL}>{leafChildren}</GeneralSectionCard>
@@ -275,21 +280,39 @@ function InstrumentationTabBody({
           type="button"
           aria-expanded={tocOpen}
           onClick={() => setTocOpen(true)}
-          className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/70 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
+          className="border-border/60 bg-card/70 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm shadow-sm backdrop-blur"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 6h16M4 12h16M4 18h16"
+            />
           </svg>
           Navigation
         </button>
       </div>
       {tocOpen && (
         <div className="fixed inset-0 z-50 flex lg:hidden">
-          <div className="fixed inset-0 bg-black/50 backdrop-blur-[1px]" onClick={() => setTocOpen(false)} />
-          <div className="relative z-50 ml-auto h-full w-full max-w-sm overflow-y-auto border-l border-border/60 bg-background p-4 shadow-2xl">
+          <div
+            className="fixed inset-0 bg-black/50 backdrop-blur-[1px]"
+            onClick={() => setTocOpen(false)}
+          />
+          <div className="border-border/60 bg-background relative z-50 ml-auto h-full w-full max-w-sm overflow-y-auto border-l p-4 shadow-2xl">
             <div className="mb-3 flex items-center justify-between">
               <h3 className="text-lg font-medium">Navigation</h3>
-              <button type="button" onClick={() => setTocOpen(false)} className="text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setTocOpen(false)}
+                className="text-muted-foreground"
+              >
                 Close
               </button>
             </div>
@@ -312,43 +335,38 @@ function InstrumentationTabBody({
       )}
 
       <div className={BUILDER_GRID}>
-      <ConfigurationTocSidebar
-        activeTab={activeTab}
-        sections={tocSections}
-        activeKey={activeKey}
-        onSectionClick={scrollToSection}
-        search={search}
-        onSearchChange={setSearch}
-        statusFilter={statusFilter}
-        onStatusFilterChange={setStatusFilter}
-        customizationCount={customizationCount}
-      />
-      <div ref={sectionsContainerRef} className="space-y-4">
-        <GeneralSectionCard
-          label={GENERAL_SETTINGS_LABEL}
-          sectionKey={GENERAL_SECTION_KEY}
-          pathPrefix={`${INSTRUMENTATION_DEV_KEY}.${GENERAL_SUBKEY}`}
-          defaultExpanded={true}
-          emptyMessage="The schema for this version does not expose general instrumentation settings."
-        >
-          {generalNode?.children ?? []}
-        </GeneralSectionCard>
-        <InstrumentationBrowser
-          instrumentations={instrumentationsState.data}
-          loading={instrumentationsState.loading}
-          error={instrumentationsState.error}
+        <ConfigurationTocSidebar
+          activeTab={activeTab}
+          sections={tocSections}
+          activeKey={activeKey}
+          onSectionClick={scrollToSection}
           search={search}
+          onSearchChange={setSearch}
           statusFilter={statusFilter}
-          onJumpToGeneral={scrollToSection}
+          onStatusFilterChange={setStatusFilter}
+          customizationCount={customizationCount}
         />
+        <div ref={sectionsContainerRef} className="space-y-4">
+          <GeneralSectionCard
+            label={GENERAL_SETTINGS_LABEL}
+            sectionKey={GENERAL_SECTION_KEY}
+            pathPrefix={`${INSTRUMENTATION_DEV_KEY}.${GENERAL_SUBKEY}`}
+            defaultExpanded={true}
+            emptyMessage="The schema for this version does not expose general instrumentation settings."
+          >
+            {generalNode?.children ?? []}
+          </GeneralSectionCard>
+          <InstrumentationBrowser
+            instrumentations={instrumentationsState.data}
+            loading={instrumentationsState.loading}
+            error={instrumentationsState.error}
+            search={search}
+            statusFilter={statusFilter}
+            onJumpToGeneral={scrollToSection}
+          />
+        </div>
+        <PreviewCard schema={schema} javaAgentVersion={javaAgentVersion} activePreviewKey={null} />
       </div>
-      <PreviewCard
-        schema={schema}
-        javaAgentVersion={javaAgentVersion}
-        // Highlighting is currently SDK-only. See #500 for the Instrumentation tab extension.
-        activePreviewKey={null}
-      />
-    </div>
     </>
   );
 }

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -125,13 +125,9 @@ function SdkTabContent({
       starter={starter}
     >
       <PruneInstrumentationsForAgentVersion javaAgentVersion={javaAgentVersion} />
+
       <div className={BUILDER_GRID}>
-        <ConfigurationTocSidebar
-          activeTab={activeTab}
-          sections={tocSections}
-          activeKey={activeKey}
-          onSectionClick={scrollToSection}
-        />
+        <ConfigurationTocSidebar activeTab={activeTab} sections={tocSections} activeKey={activeKey} onSectionClick={scrollToSection} />
         <div ref={sectionsContainerRef} className="space-y-4">
           {hasGeneralLeaves && (
             <GeneralSectionCard label={GENERAL_SECTION_LABEL}>{leafChildren}</GeneralSectionCard>
@@ -201,6 +197,7 @@ function InstrumentationTabBody({
 }: InstrumentationTabBodyProps) {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [tocOpen, setTocOpen] = useState(false);
 
   const tocSections: TocSection[] = useMemo(
     () => [
@@ -250,7 +247,49 @@ function InstrumentationTabBody({
   }, [hasDistributionContent, isDistributionEnabled, setEnabled]);
 
   return (
-    <div className={BUILDER_GRID}>
+    <>
+      <div className="mb-3 flex justify-end lg:hidden">
+        <button
+          type="button"
+          aria-expanded={tocOpen}
+          onClick={() => setTocOpen(true)}
+          className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/70 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          Navigation
+        </button>
+      </div>
+      {tocOpen && (
+        <div className="fixed inset-0 z-50 flex lg:hidden">
+          <div className="fixed inset-0 bg-black/50 backdrop-blur-[1px]" onClick={() => setTocOpen(false)} />
+          <div className="relative z-50 ml-auto h-full w-full max-w-sm overflow-y-auto border-l border-border/60 bg-background p-4 shadow-2xl">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-lg font-medium">Navigation</h3>
+              <button type="button" onClick={() => setTocOpen(false)} className="text-muted-foreground">
+                Close
+              </button>
+            </div>
+            <ConfigurationTocSidebar
+              activeTab={activeTab}
+              sections={tocSections}
+              activeKey={activeKey}
+              onSectionClick={(k: string) => {
+                scrollToSection(k);
+                setTocOpen(false);
+              }}
+              search={search}
+              onSearchChange={setSearch}
+              statusFilter={statusFilter}
+              onStatusFilterChange={setStatusFilter}
+              customizationCount={customizationCount}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className={BUILDER_GRID}>
       <ConfigurationTocSidebar
         activeTab={activeTab}
         sections={tocSections}
@@ -283,6 +322,7 @@ function InstrumentationTabBody({
       </div>
       <PreviewCard schema={schema} javaAgentVersion={javaAgentVersion} />
     </div>
+    </>
   );
 }
 

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -151,7 +151,7 @@ function SdkTabContent({
           activeKey={activeKey}
           onSectionClick={scrollToSection}
         />
-        <div ref={sectionsContainerRef} className="space-y-4">
+        <div ref={sectionsContainerRef} className="space-y-4" onClick={handleInteraction}>
           {hasGeneralLeaves && (
             <GeneralSectionCard label={GENERAL_SECTION_LABEL}>{leafChildren}</GeneralSectionCard>
           )}

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -17,6 +17,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { BackButton } from "@/components/ui/back-button";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { PageContainer } from "@/components/layout/page-container";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import {
@@ -224,7 +231,6 @@ function InstrumentationTabBody({
 }: InstrumentationTabBodyProps) {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [tocOpen, setTocOpen] = useState(false);
 
   const tocSections: TocSection[] = useMemo(
     () => [
@@ -276,63 +282,51 @@ function InstrumentationTabBody({
   return (
     <>
       <div className="mb-3 flex justify-end lg:hidden">
-        <button
-          type="button"
-          aria-expanded={tocOpen}
-          onClick={() => setTocOpen(true)}
-          className="border-border/60 bg-card/70 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm shadow-sm backdrop-blur"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-          Navigation
-        </button>
-      </div>
-      {tocOpen && (
-        <div className="fixed inset-0 z-50 flex lg:hidden">
-          <div
-            className="fixed inset-0 bg-black/50 backdrop-blur-[1px]"
-            onClick={() => setTocOpen(false)}
-          />
-          <div className="border-border/60 bg-background relative z-50 ml-auto h-full w-full max-w-sm overflow-y-auto border-l p-4 shadow-2xl">
-            <div className="mb-3 flex items-center justify-between">
-              <h3 className="text-lg font-medium">Navigation</h3>
-              <button
-                type="button"
-                onClick={() => setTocOpen(false)}
-                className="text-muted-foreground"
+        <Dialog>
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="border-border/60 bg-card/70 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm shadow-sm backdrop-blur"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
               >
-                Close
-              </button>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+              Navigation
+            </button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-sm">
+            <DialogTitle>Navigation</DialogTitle>
+            <DialogDescription>
+              Browse configuration sections, search instrumentations, and filter customized entries.
+            </DialogDescription>
+            <div className="mt-4 max-h-[70dvh] overflow-y-auto pr-1">
+              <ConfigurationTocSidebar
+                activeTab={activeTab}
+                sections={tocSections}
+                activeKey={activeKey}
+                onSectionClick={scrollToSection}
+                search={search}
+                onSearchChange={setSearch}
+                statusFilter={statusFilter}
+                onStatusFilterChange={setStatusFilter}
+                customizationCount={customizationCount}
+                className="border-0 p-0"
+              />
             </div>
-            <ConfigurationTocSidebar
-              activeTab={activeTab}
-              sections={tocSections}
-              activeKey={activeKey}
-              onSectionClick={(k: string) => {
-                scrollToSection(k);
-                setTocOpen(false);
-              }}
-              search={search}
-              onSearchChange={setSearch}
-              statusFilter={statusFilter}
-              onStatusFilterChange={setStatusFilter}
-              customizationCount={customizationCount}
-            />
-          </div>
-        </div>
-      )}
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <div className={BUILDER_GRID}>
         <ConfigurationTocSidebar
@@ -345,6 +339,7 @@ function InstrumentationTabBody({
           statusFilter={statusFilter}
           onStatusFilterChange={setStatusFilter}
           customizationCount={customizationCount}
+          className="hidden lg:block"
         />
         <div ref={sectionsContainerRef} className="space-y-4">
           <GeneralSectionCard


### PR DESCRIPTION
## Summary

Improved the mobile UX of the configuration page by adding a responsive navigation drawer for the sidebar/TOC and refining the mobile browsing experience.

Fixes #574

## Changes Made

- Added a mobile-friendly drawer for sidebar navigation
- Improved accessibility and usability of the TOC on smaller screens
- Enabled easier navigation between configuration sections on mobile
- Re-used the existing sidebar component to avoid additional data-fetching overhead
- Improved overall layout consistency for smaller viewports

## Notes

- The live YAML preview was not relocated or collapsed on mobile and still remains in the DOM. A future enhancement could move the preview below the controls on mobile or introduce a compact “Preview” toggle to reduce page length.
- Since the drawer re-uses the existing sidebar component, there is no new performance overhead from additional fetching.

## Testing

### Manual Testing
- Verified drawer opens and closes correctly on mobile widths
- Verified TOC navigation scrolls to the correct section
- Verified search functionality continues to work properly
- Checked responsiveness across smaller screen sizes

### Future Improvements
- Add lightweight integration tests for:
  - Drawer open/close behavior
  - Search interaction
  - TOC item scrolling behavior