### PR TITLE
Improve mobile responsiveness for configuration option explorer cards

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -69,7 +69,7 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
             <div data-testid="config-name" className="min-w-0 flex-1">
               <YamlCodeBlock
                 code={yamlCode}
-                className="bg-background/60 text-foreground rounded-md p-3 font-mono text-xs whitespace-pre-wrap break-words"
+                className="bg-background/60 text-foreground rounded-md p-3 font-mono text-xs break-words whitespace-pre-wrap"
               />
             </div>
           ) : (

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -64,7 +64,7 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
       </div>
 
       <div className="space-y-3">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           {showDeclarative ? (
             <div data-testid="config-name" className="min-w-0 flex-1">
               <YamlCodeBlock
@@ -75,12 +75,12 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
           ) : (
             <code
               data-testid="config-name"
-              className="text-primary flex-1 font-mono text-sm break-all"
+              className="text-primary min-w-0 flex-1 font-mono text-sm break-all"
             >
               {flatName}
             </code>
           )}
-          <div className="flex shrink-0 flex-wrap items-center gap-1">
+          <div className="flex w-full flex-wrap items-center gap-1 sm:w-auto sm:justify-end">
             <GlowBadge variant="info" withGlow>
               {config.type}
             </GlowBadge>

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -69,7 +69,7 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
             <div data-testid="config-name" className="min-w-0 flex-1">
               <YamlCodeBlock
                 code={yamlCode}
-                className="bg-background/60 text-foreground rounded-md p-3 font-mono text-xs"
+                className="bg-background/60 text-foreground rounded-md p-3 font-mono text-xs whitespace-pre-wrap break-words"
               />
             </div>
           ) : (

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/yaml-code-block.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/yaml-code-block.tsx
@@ -76,7 +76,7 @@ export function YamlCodeBlock({
 
   return (
     <pre
-      className={`max-w-full overflow-x-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] ${className ?? ""}`}
+      className={`max-w-full overflow-x-auto [overflow-wrap:anywhere] break-words whitespace-pre-wrap ${className ?? ""}`}
     >
       {headerLines.length > 0 && (
         <span className="block">

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/yaml-code-block.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/yaml-code-block.tsx
@@ -75,7 +75,9 @@ export function YamlCodeBlock({
   };
 
   return (
-    <pre className={className}>
+    <pre
+      className={`max-w-full overflow-x-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] ${className ?? ""}`}
+    >
       {headerLines.length > 0 && (
         <span className="block">
           {renderLines(headerLines)}


### PR DESCRIPTION
## Description 

- Updated the card header layout to stack vertically on smaller screens.
- Kept the YAML/code block on top while moving badges and the copy action below it.
- Preserved the existing side-by-side layout on larger screens.
- Added wrapping and width adjustments to prevent the metadata/actions row from compressing the code block on mobile devices.

## Screenshot
<img width="1355" height="1149" alt="img" src="https://github.com/user-attachments/assets/ec6dd778-d9bc-4160-9732-9e72a38cf241" />

## Result
Configuration cards are now more readable and properly spaced on narrow viewports.