### PR TITLE
feat(config-builder): add Import YAML dialog for loading existing configurations

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.test.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportYamlDialog } from "./import-yaml-dialog";
+
+const loadFromYaml = vi.fn();
+
+vi.mock("@/hooks/use-configuration-builder", () => ({
+  useConfigurationBuilder: () => ({
+    state: {
+      values: {},
+      enabledSections: {},
+      validationErrors: {},
+      version: "1.0.0",
+      isDirty: false,
+    },
+    loadFromYaml: (...args: unknown[]) => loadFromYaml(...args),
+    setValue: vi.fn(),
+  }),
+}));
+
+function openDialog() {
+  fireEvent.click(screen.getByRole("button", { name: /import/i }));
+}
+
+describe("ImportYamlDialog", () => {
+  beforeEach(() => {
+    loadFromYaml.mockReset();
+    loadFromYaml.mockResolvedValue(undefined);
+  });
+
+  it("renders the Import trigger button", () => {
+    render(<ImportYamlDialog />);
+    expect(screen.getByRole("button", { name: /import/i })).toBeInTheDocument();
+  });
+
+  it("opens the dialog when the trigger is clicked", () => {
+    render(<ImportYamlDialog />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    openDialog();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Import YAML Configuration")).toBeInTheDocument();
+  });
+
+  it("shows the textarea and Upload file button inside the dialog", () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    expect(screen.getByRole("textbox", { name: /yaml content/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /upload file/i })).toBeInTheDocument();
+  });
+
+  it("shows an error when importing with an empty textarea", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /paste a yaml configuration or upload a file/i
+      );
+    });
+    expect(loadFromYaml).not.toHaveBeenCalled();
+  });
+
+  it("shows a syntax error when the YAML is malformed", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "key: [\nbad yaml" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid yaml syntax/i);
+    });
+    expect(loadFromYaml).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the YAML is a plain list, not a mapping", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "- item1\n- item2\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/key-value mapping/i);
+    });
+    expect(loadFromYaml).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the YAML is a plain scalar, not a mapping", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "just a string\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/key-value mapping/i);
+    });
+    expect(loadFromYaml).not.toHaveBeenCalled();
+  });
+
+  it("calls loadFromYaml and closes the dialog on a valid import", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    const validYaml = "exporters:\n  otlp:\n    endpoint: http://localhost:4317\n";
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: validYaml },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(loadFromYaml).toHaveBeenCalledWith(validYaml.trim());
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows an error if loadFromYaml rejects", async () => {
+    loadFromYaml.mockRejectedValue(new Error("Schema mismatch"));
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "key: value\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Schema mismatch");
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("clears the error when the user edits the textarea after a failed import", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "k: v" },
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("resets textarea and error when the dialog is closed and reopened", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    fireEvent.change(screen.getByRole("textbox", { name: /yaml content/i }), {
+      target: { value: "some: yaml" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    openDialog();
+    expect(screen.getByRole("textbox", { name: /yaml content/i })).toHaveValue("");
+  });
+
+  it("populates the textarea when a file is uploaded via FileReader", async () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+
+    const fileContent = "resource:\n  attributes:\n    service.name: my-service\n";
+    const file = new File([fileContent], "otel-config.yaml", { type: "text/yaml" });
+
+    const originalFileReader = globalThis.FileReader;
+    class MockFileReader {
+      onload: ((ev: ProgressEvent<FileReader>) => void) | null = null;
+      readAsText() {
+        setTimeout(() => {
+          if (this.onload) {
+            this.onload({ target: { result: fileContent } } as ProgressEvent<FileReader>);
+          }
+        }, 0);
+      }
+    }
+    globalThis.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /yaml content/i })).toHaveValue(fileContent);
+    });
+
+    globalThis.FileReader = originalFileReader;
+  });
+
+  it("has an accessible file input with aria-label", () => {
+    render(<ImportYamlDialog />);
+    openDialog();
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    expect(fileInput?.getAttribute("aria-label")).toBe("Upload YAML file");
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.tsx
@@ -89,9 +89,7 @@ export function ImportYamlDialog(): JSX.Element {
       await loadFromYaml(yaml.trim());
       setOpen(false);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to import the YAML configuration."
-      );
+      setError(err instanceof Error ? err.message : "Failed to import the YAML configuration.");
     } finally {
       setIsLoading(false);
     }
@@ -118,7 +116,7 @@ export function ImportYamlDialog(): JSX.Element {
           <p
             role="alert"
             id="import-yaml-error"
-            className="border-red-500/30 bg-red-500/10 rounded-md border px-3 py-2 text-sm text-red-400"
+            className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400"
           >
             {error}
           </p>
@@ -142,7 +140,7 @@ export function ImportYamlDialog(): JSX.Element {
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                className="border-border/60 text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+                className="border-border/60 text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
               >
                 <Upload className="h-3 w-3" aria-hidden="true" />
                 Upload file
@@ -160,7 +158,7 @@ export function ImportYamlDialog(): JSX.Element {
             spellCheck={false}
             aria-invalid={error !== null}
             aria-describedby={error ? "import-yaml-error" : undefined}
-            className="bg-background/60 border-border/30 text-foreground placeholder:text-muted-foreground/50 focus:ring-primary/20 min-h-[240px] flex-1 resize-none rounded-md border p-3 font-mono text-xs focus:outline-none focus:ring-2"
+            className="bg-background/60 border-border/30 text-foreground placeholder:text-muted-foreground/50 focus:ring-primary/20 min-h-[240px] flex-1 resize-none rounded-md border p-3 font-mono text-xs focus:ring-2 focus:outline-none"
           />
         </div>
 
@@ -168,7 +166,7 @@ export function ImportYamlDialog(): JSX.Element {
           <button
             type="button"
             onClick={() => handleOpenChange(false)}
-            className="border-border/60 bg-card text-foreground hover:bg-card/80 inline-flex cursor-pointer items-center rounded-md border px-3 py-1.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+            className="border-border/60 bg-card text-foreground hover:bg-card/80 inline-flex cursor-pointer items-center rounded-md border px-3 py-1.5 text-xs focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
           >
             Cancel
           </button>
@@ -176,7 +174,7 @@ export function ImportYamlDialog(): JSX.Element {
             type="button"
             onClick={handleImport}
             disabled={isLoading}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex cursor-pointer items-center rounded-md px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex cursor-pointer items-center rounded-md px-3 py-1.5 text-xs font-medium focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isLoading ? "Importing…" : "Import"}
           </button>

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/import-yaml-dialog.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, useRef, type JSX } from "react";
+import { Upload } from "lucide-react";
+import { load as parseYaml } from "js-yaml";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useConfigurationBuilder } from "@/hooks/use-configuration-builder";
+
+const TRIGGER_CLASS =
+  "border-border/60 bg-card text-foreground hover:bg-card/80 focus-visible:ring-primary inline-flex cursor-pointer items-center gap-1 rounded-md border px-3 py-1.5 text-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none";
+
+function validateYaml(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "Paste a YAML configuration or upload a file before importing.";
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(trimmed);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return `Invalid YAML syntax: ${detail}`;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return "The YAML must be a key-value mapping at the top level, not a list or plain value.";
+  }
+  return null;
+}
+
+export function ImportYamlDialog(): JSX.Element {
+  const { loadFromYaml } = useConfigurationBuilder();
+  const [open, setOpen] = useState(false);
+  const [yaml, setYaml] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const resetState = () => {
+    setYaml("");
+    setError(null);
+    setIsLoading(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) resetState();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      setYaml((ev.target?.result as string) ?? "");
+      setError(null);
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handleImport = async () => {
+    const validationError = validateYaml(yaml);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      await loadFromYaml(yaml.trim());
+      setOpen(false);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to import the YAML configuration."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button type="button" className={TRIGGER_CLASS}>
+          <Upload className="h-3 w-3" aria-hidden="true" />
+          Import
+        </button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[85dvh] w-[90vw] max-w-2xl flex-col gap-4">
+        <header className="border-border/30 space-y-1 border-b pr-8 pb-3">
+          <DialogTitle className="text-xl font-semibold">Import YAML Configuration</DialogTitle>
+          <DialogDescription className="text-muted-foreground text-xs">
+            Paste an existing OpenTelemetry Java Agent YAML configuration below, or upload a file.
+            All recognised fields will be loaded into the form.
+          </DialogDescription>
+        </header>
+
+        {error && (
+          <p
+            role="alert"
+            id="import-yaml-error"
+            className="border-red-500/30 bg-red-500/10 rounded-md border px-3 py-2 text-sm text-red-400"
+          >
+            {error}
+          </p>
+        )}
+
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <label htmlFor="import-yaml-textarea" className="text-foreground text-xs font-medium">
+              YAML content
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".yaml,.yml,.txt"
+                className="sr-only"
+                tabIndex={-1}
+                aria-label="Upload YAML file"
+                onChange={handleFileChange}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="border-border/60 text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+              >
+                <Upload className="h-3 w-3" aria-hidden="true" />
+                Upload file
+              </button>
+            </div>
+          </div>
+          <textarea
+            id="import-yaml-textarea"
+            value={yaml}
+            onChange={(e) => {
+              setYaml(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="# Paste your otel-config.yaml content here&#8230;"
+            spellCheck={false}
+            aria-invalid={error !== null}
+            aria-describedby={error ? "import-yaml-error" : undefined}
+            className="bg-background/60 border-border/30 text-foreground placeholder:text-muted-foreground/50 focus:ring-primary/20 min-h-[240px] flex-1 resize-none rounded-md border p-3 font-mono text-xs focus:outline-none focus:ring-2"
+          />
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={() => handleOpenChange(false)}
+            className="border-border/60 bg-card text-foreground hover:bg-card/80 inline-flex cursor-pointer items-center rounded-md border px-3 py-1.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleImport}
+            disabled={isLoading}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex cursor-pointer items-center rounded-md px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+          >
+            {isLoading ? "Importing…" : "Import"}
+          </button>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/hooks/use-configuration-builder", () => ({
     setEnabled: vi.fn(),
     selectPlugin: vi.fn(),
     validateAll: (...a: unknown[]) => validateAll(...a),
+    loadFromYaml: vi.fn().mockResolvedValue(undefined),
   }),
 }));
 
@@ -134,6 +135,19 @@ describe("PreviewCard", () => {
     expect(body).toContain("Schema version: 1.0.0");
     expect(body).toContain("Java agent: 2.27.0");
     expect(mime).toBe("text/yaml");
+  });
+
+  it("renders the Import button in the preview card header", () => {
+    render(<PreviewCard schema={schema} javaAgentVersion="2.27.0" activePreviewKey={null} />);
+    expect(screen.getByRole("button", { name: /import/i })).toBeInTheDocument();
+  });
+
+  it("opens the Import YAML dialog when the Import button is clicked", () => {
+    render(<PreviewCard schema={schema} javaAgentVersion="2.27.0" activePreviewKey={null} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /import/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Import YAML Configuration")).toBeInTheDocument();
   });
 
   it("renders expand preview button and opens dialog with controls when clicked", () => {

--- a/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/components/preview-card.tsx
@@ -28,6 +28,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { YamlCodeBlock } from "./yaml-code-block";
+import { ImportYamlDialog } from "./import-yaml-dialog";
 
 interface HeaderActionButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>;
@@ -118,6 +119,7 @@ export function PreviewCard({
         <div className="flex flex-wrap items-center gap-2">
           <PreviewActions yaml={yaml} filename={filename} onValidate={validateAll} />
           <span className="bg-border/60 mx-1 h-4 w-px" aria-hidden="true" />
+          <ImportYamlDialog />
           <HeaderActionButton icon={ListPlus} label="Add all" onClick={enableAllSections} />
           <HeaderActionButton icon={RefreshCcw} label="Reset" onClick={handleReset} />
           <span className="bg-border/60 mx-1 h-4 w-px" aria-hidden="true" />


### PR DESCRIPTION
## What this PR does

Adds an **Import** button to the configuration builder's preview panel header. Clicking it opens a dialog where users can paste an existing `otel-config.yaml` or upload a file, and the form fills in automatically with all recognised fields.

Closes #540.

## How it works

- A new `ImportYamlDialog` component handles everything: trigger button, dialog open/close state, textarea, file upload via `FileReader`, and error reporting.
- Before handing off to the existing `loadFromYaml` hook the dialog runs its own validation pass using `js-yaml`:
  - Empty input shows a clear prompt to paste or upload.
  - Syntax errors surface the parser message so the user knows exactly what went wrong.
  - YAML that parses to a list or scalar (not a mapping) is rejected with a plain-language explanation.
- On a successful import the dialog closes and the builder reflects the loaded values immediately.
- Hook rejections (e.g. version mismatches surfaced by the hook in future) are caught and displayed as an inline error without closing the dialog.

## UX

The Import button sits alongside the existing Add all, Reset, and expand controls so it feels like a natural part of the panel rather than a bolt-on.

## Testing

13 new unit tests cover: trigger rendering, dialog open, all validation error cases, successful import, hook rejection, error clearing on edit, state reset on reopen, file upload via `FileReader`, and the file input aria-label. Two additional tests in `preview-card.test.tsx` verify the button renders and the dialog opens from the card.

All existing tests continue to pass (967 unit tests, 45 integration tests).