### PR TITLE
Fix configuration examples rendering and watcher sync atomicity

### DIFF
--- a/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
+++ b/ecosystem-automation/configuration-watcher/src/configuration_watcher/configuration_sync.py
@@ -63,12 +63,17 @@ class ConfigurationSync:
 
         Returns:
             List of copied filenames
+
+        Raises:
+            ValueError: If no schema files were found. A zero-file copy is treated as a hard error
+                rather than a silent no-op so callers never report an empty version as written.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             copied = self.schema_copier.copy_schemas(self.repo_path, tmp_path)
-            if copied:
-                self.inventory_manager.save_versioned_schemas(version, tmp_path)
+            if not copied:
+                raise ValueError(f"No schema files found for {version}; refusing to write an empty version")
+            self.inventory_manager.save_versioned_schemas(version, tmp_path)
             return copied
 
     def process_latest_release(self) -> Version | None:
@@ -103,8 +108,12 @@ class ConfigurationSync:
         This:
         1. Determines next snapshot version
         2. Checks out main branch
-        3. Cleans up old snapshots
-        4. Copies schema files
+        3. Copies schema files (writing the replacement snapshot)
+        4. Cleans up old snapshots
+
+        The replacement is written before old snapshots are removed: copy_schemas_to_inventory
+        raises on an empty copy, so a failed sync leaves the existing snapshot intact instead of
+        deleting it with nothing to replace it.
 
         Returns:
             Snapshot version that was created
@@ -115,14 +124,14 @@ class ConfigurationSync:
 
         self.version_detector.checkout_main()
 
-        logger.info("")
-        logger.info("Cleaning up old snapshots...")
-        removed = self.inventory_manager.cleanup_snapshots()
-        if removed > 0:
-            logger.info("  Removed %d old snapshot(s)", removed)
-
         copied = self.copy_schemas_to_inventory(snapshot_version)
         logger.info("  Copied %d schema files", len(copied))
+
+        logger.info("")
+        logger.info("Cleaning up old snapshots...")
+        removed = self.inventory_manager.cleanup_snapshots_except(snapshot_version)
+        if removed > 0:
+            logger.info("  Removed %d old snapshot(s)", removed)
 
         return snapshot_version
 
@@ -197,15 +206,14 @@ class ConfigurationSync:
             logger.info("")
             logger.info("Backfilling %s...", version)
 
-            deleted = self.inventory_manager.delete_version(version)
-            if deleted:
-                logger.info("  Deleted existing data")
-
             if version.prerelease:
                 self.version_detector.checkout_main()
             else:
                 self.version_detector.checkout_version(version)
 
+            # No pre-emptive delete: save_versioned_schemas replaces the version directory, and
+            # copy_schemas_to_inventory raises on an empty copy, so a failed backfill leaves the
+            # existing version intact instead of destroying it with no replacement.
             copied = self.copy_schemas_to_inventory(version)
             logger.info("  Copied %d schema files", len(copied))
             processed.append(str(version))

--- a/ecosystem-automation/configuration-watcher/src/configuration_watcher/inventory_manager.py
+++ b/ecosystem-automation/configuration-watcher/src/configuration_watcher/inventory_manager.py
@@ -47,3 +47,26 @@ class InventoryManager(BaseInventoryManager):
             shutil.rmtree(version_dir)
         shutil.copytree(source_dir, version_dir)
         logger.info("Saved schemas for v%s to %s", version, version_dir)
+
+    def cleanup_snapshots_except(self, keep: Version) -> int:
+        """
+        Remove all snapshot versions except the given one.
+
+        Snapshot cleanup must run only after a replacement snapshot has been written, so this
+        preserves `keep` (the freshly written snapshot) while removing any stale ones.
+
+        Args:
+            keep: Snapshot version to preserve
+
+        Returns:
+            Number of snapshot versions removed
+        """
+        removed = 0
+        for snapshot in self.list_snapshot_versions():
+            if snapshot == keep:
+                continue
+            snapshot_dir = self.get_version_dir(snapshot)
+            if snapshot_dir.exists():
+                shutil.rmtree(snapshot_dir)
+                removed += 1
+        return removed

--- a/ecosystem-automation/configuration-watcher/tests/test_configuration_sync.py
+++ b/ecosystem-automation/configuration-watcher/tests/test_configuration_sync.py
@@ -146,3 +146,35 @@ class TestConfigurationSync:
         result = config_sync.backfill()
 
         assert len(result["versions_processed"]) >= 1
+
+
+class TestEmptyCopySafety:
+    """A copy that yields zero schema files must fail loudly and never destroy existing data."""
+
+    def test_process_latest_release_raises_on_empty_copy(self, config_sync, monkeypatch):
+        monkeypatch.setattr(config_sync.schema_copier, "copy_schemas", lambda *a, **k: [])
+
+        with pytest.raises(ValueError):
+            config_sync.process_latest_release()
+
+    def test_update_snapshot_preserves_existing_on_empty_copy(self, config_sync, monkeypatch):
+        config_sync.update_snapshot()
+        existing = config_sync.inventory_manager.list_snapshot_versions()
+        assert existing
+
+        monkeypatch.setattr(config_sync.schema_copier, "copy_schemas", lambda *a, **k: [])
+        with pytest.raises(ValueError):
+            config_sync.update_snapshot()
+
+        for snapshot in existing:
+            assert config_sync.inventory_manager.version_exists(snapshot)
+
+    def test_backfill_preserves_existing_version_on_empty_copy(self, config_sync, monkeypatch):
+        config_sync.sync()
+        assert config_sync.inventory_manager.version_exists(Version("1.0.0"))
+
+        monkeypatch.setattr(config_sync.schema_copier, "copy_schemas", lambda *a, **k: [])
+        with pytest.raises(ValueError):
+            config_sync.backfill([Version("1.0.0")])
+
+        assert config_sync.inventory_manager.version_exists(Version("1.0.0"))

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/configuration_aggregator.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/configuration_aggregator.py
@@ -20,10 +20,10 @@ DatabaseWriter writes the file.
 
 from typing import Any
 
-# Scalar fields filled from older versions when missing on the newest (seed) entry. "example" is
-# singular on purpose: the data uses "examples" (plural), so this fill is a no-op and "examples" is
-# reconciled across versions upstream by metadata_backfiller.
-_MERGE_FIELDS = ("declarative_name", "description", "default", "type", "example")
+# Fields filled from other occurrences (older versions or sibling instrumentations sharing the same
+# config name) when missing on the newest (seed) entry. "examples" is included so a seed entry that
+# lacks examples inherits them from a sibling/older occurrence rather than dropping them.
+_MERGE_FIELDS = ("declarative_name", "description", "default", "type", "examples")
 
 
 def _collect_items(inventory: dict[str, Any]) -> list[dict[str, Any]]:

--- a/ecosystem-automation/explorer-db-builder/tests/test_configuration_aggregator.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_configuration_aggregator.py
@@ -182,7 +182,7 @@ class TestBuildGlobalConfigurationsEdgeCases:
 
         assert build_global_configurations(inventories) == []
 
-    def test_only_declared_scalar_fields_are_filled_from_older_versions(self):
+    def test_only_declared_fields_are_filled_from_older_versions(self):
         """Fields outside the merge set are NOT backfilled from older versions."""
         inventories = [
             _inventory(libraries=[{"name": "ext", "configurations": [_config("otel.c")]}]),
@@ -190,7 +190,7 @@ class TestBuildGlobalConfigurationsEdgeCases:
                 libraries=[
                     {
                         "name": "ext",
-                        "configurations": [_config("otel.c", description="d", examples="ex", extra="x")],
+                        "configurations": [_config("otel.c", description="d", extra="x")],
                     }
                 ]
             ),
@@ -200,9 +200,38 @@ class TestBuildGlobalConfigurationsEdgeCases:
 
         # description IS in the merge set, so it fills from the older version.
         assert result[0]["description"] == "d"
-        # examples / extra are NOT in the merge set, so they do not fill from older versions.
-        assert "examples" not in result[0]
+        # extra is NOT in the merge set, so it does not fill from older versions.
         assert "extra" not in result[0]
+
+    def test_examples_filled_from_older_version_when_missing_on_newest(self):
+        """examples is in the merge set, so a newest entry lacking it fills from an older version."""
+        inventories = [
+            _inventory(libraries=[{"name": "ext", "configurations": [_config("otel.c")]}]),
+            _inventory(libraries=[{"name": "ext", "configurations": [_config("otel.c", examples=["a", "b"])]}]),
+        ]
+
+        result = build_global_configurations(inventories)
+
+        assert result[0]["examples"] == ["a", "b"]
+
+    def test_examples_filled_from_sibling_instrumentation_in_same_version(self):
+        """A config name shared across instrumentations fills examples from a sibling when the
+        seed instrumentation lacks them."""
+        inventories = [
+            _inventory(
+                libraries=[
+                    # seed: first occurrence has no examples
+                    {"name": "servlet-2.2", "configurations": [_config("otel.shared")]},
+                    {"name": "servlet-3.0", "configurations": [_config("otel.shared", examples=["x"])]},
+                ]
+            )
+        ]
+
+        result = build_global_configurations(inventories)
+
+        assert len(result) == 1
+        assert result[0]["examples"] == ["x"]
+        assert result[0]["instrumentations"] == ["servlet-2.2", "servlet-3.0"]
 
     def test_seed_fields_outside_merge_set_are_preserved(self):
         """Fields on the newest (seed) entry that aren't in the merge set still survive to output."""

--- a/ecosystem-explorer/public/schemas/javaagent-instrumentation.schema.json
+++ b/ecosystem-explorer/public/schemas/javaagent-instrumentation.schema.json
@@ -103,7 +103,7 @@
             "description": "The default value if not specified.",
             "type": ["string", "number", "boolean"]
           },
-          "example": {
+          "examples": {
             "description": "Example values for this configuration option.",
             "type": "array",
             "items": {
@@ -111,7 +111,7 @@
             }
           }
         },
-        "propertyOrder": ["name", "declarative_name", "description", "type", "default", "example"],
+        "propertyOrder": ["name", "declarative_name", "description", "type", "default", "examples"],
         "required": ["default", "description", "name", "type"]
       }
     },

--- a/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/configuration-card.tsx
@@ -100,10 +100,10 @@ export function ConfigurationCard({ config, format, instrumentations }: Configur
           <code className="flex-1 text-xs break-all">{defaultValue}</code>
         </div>
 
-        {config.example && config.example.length > 0 && (
+        {config.examples && config.examples.length > 0 && (
           <div className="space-y-1">
             <span className="text-muted-foreground text-xs font-medium">Examples:</span>
-            {config.example.map((ex, i) => (
+            {config.examples.map((ex, i) => (
               <div key={i} className="border-border/30 bg-muted/30 rounded-lg border px-3 py-2">
                 <code className="text-xs break-all">{ex}</code>
               </div>

--- a/ecosystem-explorer/src/features/java-agent/components/instrumentation-configuration-tab.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/instrumentation-configuration-tab.test.tsx
@@ -60,7 +60,7 @@ const exampleConfig: Configuration = {
   description: "Example field.",
   type: "string",
   default: "x",
-  example: ["foo", "bar"],
+  examples: ["foo", "bar"],
 };
 
 // Mirrors the real JDBC instrumentation dataset (no declarative_name on any
@@ -139,14 +139,14 @@ describe("InstrumentationConfigurationTab", () => {
     expect(screen.getByText("false")).toBeInTheDocument();
   });
 
-  it("renders an Examples section when example array is non-empty", () => {
+  it("renders an Examples section when the examples array is non-empty", () => {
     render(<InstrumentationConfigurationTab configurations={[exampleConfig]} />);
     expect(screen.getByText("Examples:")).toBeInTheDocument();
     expect(screen.getByText("foo")).toBeInTheDocument();
     expect(screen.getByText("bar")).toBeInTheDocument();
   });
 
-  it("does not render Examples section when example is missing", () => {
+  it("does not render Examples section when examples is missing", () => {
     render(<InstrumentationConfigurationTab configurations={[baseConfig]} />);
     expect(screen.queryByText("Examples:")).not.toBeInTheDocument();
   });

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -93,7 +93,7 @@ export interface Configuration {
   /** The default value if not specified. */
   default: string | boolean | number;
   /** Example values for this configuration option. */
-  example?: string[];
+  examples?: string[];
 }
 
 /**


### PR DESCRIPTION
Two fixes.

- Configuration examples never rendered: the UI read `example` but the data uses `examples`. Aligned the type, card, generated schema, and aggregator.
- The configuration watcher could delete a snapshot or version before a non-empty replacement was confirmed. Empty copies are now a hard error and replacements are written before cleanup.