### PR TITLE
fix(explorer): edge function turned 304 into 404 for data files

### DIFF
--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from "vitest";
+import handler from "../agent-negotiation";
+
+type Rewrite = (path: string) => Promise<Response>;
+
+function contextWith(rewrite: Rewrite) {
+  return { rewrite: vi.fn(rewrite) } as unknown as Parameters<typeof handler>[1];
+}
+
+function get(path: string, headers?: Record<string, string>) {
+  return new Request(`https://explorer.opentelemetry.io${path}`, { headers });
+}
+
+describe("agent-negotiation edge function", () => {
+  it("passes a 304 Not Modified through for /data instead of converting it to 404", async () => {
+    const context = contextWith(async () => new Response(null, { status: 304 }));
+    const res = await handler(get("/data/configuration/versions-index.json"), context);
+    expect(res?.status).toBe(304);
+  });
+
+  it("returns the JSON asset with application/json on a 200 rewrite", async () => {
+    const context = contextWith(
+      async () =>
+        new Response('{"versions":[]}', {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        })
+    );
+    const res = await handler(get("/data/configuration/versions-index.json"), context);
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("returns 404 when the rewrite falls back to the SPA HTML shell", async () => {
+    const context = contextWith(
+      async () =>
+        new Response("<!doctype html><html></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        })
+    );
+    const res = await handler(get("/data/configuration/versions-index.json"), context);
+    expect(res?.status).toBe(404);
+  });
+
+  it("passes a 304 Not Modified through for a markdown agent route", async () => {
+    const context = contextWith(async () => new Response(null, { status: 304 }));
+    const res = await handler(get("/agent/javaagent"), context);
+    expect(res?.status).toBe(304);
+  });
+});

--- a/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
+++ b/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
@@ -16,6 +16,37 @@
 
 import type { Context } from "@netlify/edge-functions";
 
+const notFound = () => new Response("Not Found", { status: 404 });
+
+// Rewrites to a static asset and normalizes its Content-Type. Returns null when
+// the rewrite resolves to the SPA HTML shell (the catch-all redirect serves
+// /index.html with status 200 for unknown paths), so the caller can 404.
+// Any non-200 status is returned untouched: a 304 from a conditional
+// (If-None-Match) request must stay a 304 — collapsing it to 404 is what broke
+// data loading on revalidation. The same applies to 3xx, 206, and real errors.
+async function serveAsset(
+  context: Context,
+  path: string,
+  contentType: string,
+  extraHeaders?: Record<string, string>
+): Promise<Response | null> {
+  const response = await context.rewrite(path);
+  if (response.status !== 200) {
+    return response;
+  }
+
+  const originContentType = response.headers.get("content-type") ?? "";
+  if (originContentType.includes("text/html")) {
+    return null;
+  }
+
+  response.headers.set("Content-Type", contentType);
+  for (const [key, value] of Object.entries(extraHeaders ?? {})) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);
   const { pathname } = url;
@@ -24,17 +55,10 @@ export default async (request: Request, context: Context) => {
 
   // Documentation root files
   if (pathname === "/llms.txt" || pathname === "/llms-full.txt") {
-    const response = await context.rewrite(pathname);
-    if (response.status === 200) {
-      const contentType = response.headers.get("content-type");
-      if (contentType && contentType.includes("text/html")) {
-        return new Response("Not Found", { status: 404 });
-      }
-      response.headers.set("Content-Type", "text/plain; charset=UTF-8");
-      response.headers.set("Vary", "Accept");
-      return response;
-    }
-    return new Response("Not Found", { status: 404 });
+    return (
+      (await serveAsset(context, pathname, "text/plain; charset=UTF-8", { Vary: "Accept" })) ??
+      notFound()
+    );
   }
 
   // Content negotiation for AI agents
@@ -49,22 +73,16 @@ export default async (request: Request, context: Context) => {
     }
 
     if (mdPath) {
-      const response = await context.rewrite(mdPath);
-      if (response.status === 200) {
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.includes("text/html")) {
-          return new Response("Not Found", { status: 404 });
-        }
-        const finalContentType = mdPath.endsWith(".md")
-          ? "text/markdown; charset=UTF-8"
-          : "text/plain; charset=UTF-8";
-        response.headers.set("Content-Type", finalContentType);
-        response.headers.set("Vary", "Accept");
+      const finalContentType = mdPath.endsWith(".md")
+        ? "text/markdown; charset=UTF-8"
+        : "text/plain; charset=UTF-8";
+      const response = await serveAsset(context, mdPath, finalContentType, { Vary: "Accept" });
+      if (response) {
         return response;
       }
     }
     // Strict 404 for unrecognized Markdown requests (Copilot feedback)
-    return new Response("Not Found", { status: 404 });
+    return notFound();
   }
 
   // Explicit agent documentation routes
@@ -82,47 +100,24 @@ export default async (request: Request, context: Context) => {
   const resolvedPath = agentPathMap[pathname] || pathname;
   if (resolvedPath.endsWith(".md") || resolvedPath.startsWith("/agent/")) {
     if (resolvedPath.endsWith(".md")) {
-      const response = await context.rewrite(resolvedPath);
-      if (response.status === 200) {
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.includes("text/html")) {
-          return new Response("Not Found", { status: 404 });
-        }
-        response.headers.set("Content-Type", "text/markdown; charset=UTF-8");
+      const response = await serveAsset(context, resolvedPath, "text/markdown; charset=UTF-8");
+      if (response) {
         return response;
       }
     }
-    return new Response("Not Found", { status: 404 });
+    return notFound();
   }
 
   // JSON schemas and metadata
   if (pathname.startsWith("/schemas/") || pathname.startsWith("/data/")) {
-    const response = await context.rewrite(pathname);
-    if (response.status === 200) {
-      const contentType = response.headers.get("content-type");
-      if (contentType && contentType.includes("text/html")) {
-        return new Response("Not Found", { status: 404 });
-      }
-      const finalContentType = pathname.endsWith(".json") ? "application/json" : "text/plain";
-      response.headers.set("Content-Type", finalContentType);
-      return response;
-    }
-    return new Response("Not Found", { status: 404 });
+    const finalContentType = pathname.endsWith(".json") ? "application/json" : "text/plain";
+    return (await serveAsset(context, pathname, finalContentType)) ?? notFound();
   }
 
   // Sitemap and Robots
   if (pathname === "/sitemap.xml" || pathname === "/robots.txt") {
-    const response = await context.rewrite(pathname);
-    if (response.status === 200) {
-      const contentType = response.headers.get("content-type");
-      if (contentType && contentType.includes("text/html")) {
-        return new Response("Not Found", { status: 404 });
-      }
-      const finalContentType = pathname.endsWith(".xml") ? "application/xml" : "text/plain";
-      response.headers.set("Content-Type", finalContentType);
-      return response;
-    }
-    return new Response("Not Found", { status: 404 });
+    const finalContentType = pathname.endsWith(".xml") ? "application/xml" : "text/plain";
+    return (await serveAsset(context, pathname, finalContentType)) ?? notFound();
   }
 
   return undefined;

--- a/ecosystem-explorer/src/lib/api/configuration-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/configuration-data.test.ts
@@ -78,6 +78,22 @@ describe("configuration-data", () => {
       expect(result).toEqual(mockVersionsIndex);
       expect(global.fetch).not.toHaveBeenCalled();
     });
+
+    it("should bypass cache and re-fetch when cached versions list is empty", async () => {
+      const staleData: ConfigVersionsIndex = { versions: [] };
+      vi.spyOn(idbCache, "getCached").mockResolvedValue(staleData);
+      vi.spyOn(idbCache, "setCached").mockResolvedValue();
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => mockVersionsIndex,
+      });
+
+      const result = await configData.loadConfigVersions();
+
+      expect(result).toEqual(mockVersionsIndex);
+      expect(global.fetch).toHaveBeenCalledWith("/data/configuration/versions-index.json");
+    });
   });
 
   describe("loadConfigSchema", () => {

--- a/ecosystem-explorer/src/lib/api/configuration-data.ts
+++ b/ecosystem-explorer/src/lib/api/configuration-data.ts
@@ -23,7 +23,8 @@ export async function loadConfigVersions(): Promise<ConfigVersionsIndex> {
   const data = await fetchWithCache<ConfigVersionsIndex>(
     "config-versions-index",
     `${BASE_PATH}/versions-index.json`,
-    STORES.CONFIGURATION
+    STORES.CONFIGURATION,
+    { validate: (d) => Array.isArray(d.versions) && d.versions.length > 0 }
   );
   if (!data) throw new Error("Versions index returned null unexpectedly");
   return data;

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.test.ts
@@ -207,6 +207,44 @@ describe("fetchWithCache", () => {
     });
   });
 
+  it("recovers from a transient 404 via an unconditional cache-busting reload", async () => {
+    vi.spyOn(idbCache, "getCached").mockResolvedValue(null);
+    vi.spyOn(idbCache, "setCached").mockResolvedValue();
+
+    const data = { test: "fresh-after-reload" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("not found", { status: 404, statusText: "Not Found" }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchWithCache("test-transient-404", "/url", STORES.CONFIGURATION);
+
+    expect(result).toEqual(data);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/url");
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/url", { cache: "reload" });
+  });
+
+  it("surfaces a genuine 404 when the cache-busting reload also returns 404", async () => {
+    vi.spyOn(idbCache, "getCached").mockResolvedValue(null);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("nope", { status: 404, statusText: "Not Found" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(fetchWithCache("test-genuine-404", "/url", STORES.CONFIGURATION)).rejects.toThrow(
+      /404/
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/url", { cache: "reload" });
+  });
+
   it("serves stale cache when response is 200 but content-type is text/html", async () => {
     const staleData = { test: "stale-html-fallback" };
     vi.spyOn(idbCache, "getCached").mockImplementation(async (_key, _store, options) => {

--- a/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
+++ b/ecosystem-explorer/src/lib/api/fetch-with-cache.ts
@@ -54,9 +54,16 @@ async function fetchWithRetry(
   let lastError: unknown;
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      // HTTP responses (ok or non-ok) are returned immediately - no retry.
+      const response = await fetch(url);
+      // A 404 can be a false negative: a conditional (If-None-Match) request
+      // whose 304 was mistranslated to 404 upstream. Retry once with no cache
+      // (cache:"reload" sends no validators) so a genuine 404 still surfaces.
+      if (response.status === 404) {
+        return await fetch(url, { cache: "reload" });
+      }
+      // Other HTTP responses (ok or non-ok) are returned immediately - no retry.
       // Only real network failures (catch block) trigger retries.
-      return await fetch(url);
+      return response;
     } catch (error) {
       lastError = error;
       if (i === maxAttempts - 1) throw error;


### PR DESCRIPTION
The agent-negotiation edge function turned the 304 from conditional revalidation into a 404, so the config builder intermittently failed to load versions.

- edge function passes non-200 responses through instead of forcing 404
- fetchWithRetry retries a 404 once with a cache-busting reload
- loadConfigVersions validates cached versions like loadVersions

Fixes #632