### PR TITLE
feat(i18n): extract collector namespace strings

### DIFF
--- a/ecosystem-explorer/public/locales/en/collector.json
+++ b/ecosystem-explorer/public/locales/en/collector.json
@@ -1,0 +1,133 @@
+{
+  "page": {
+    "title": "OpenTelemetry Collector",
+    "description": "A vendor-agnostic implementation for receiving, processing, and exporting telemetry data.",
+    "unavailableTitle": "Collector explorer unavailable",
+    "unavailableDescription": "The Collector ecosystem explorer is not enabled for this deployment."
+  },
+  "header": {
+    "title": "Collector",
+    "titleAccent": "Components",
+    "description": "Navigate the OpenTelemetry Collector ecosystem. Discover receivers, processors, exporters, and extensions across different distributions.",
+    "comingSoon": "We're currently building the Collector component explorer. Stay tuned for a comprehensive view of receivers, processors, and more!"
+  },
+  "filters": {
+    "search": {
+      "label": "Search",
+      "placeholder": "Filter by name or description..."
+    },
+    "type": {
+      "label": "Type",
+      "all": "All Types",
+      "receiver": "Receivers",
+      "processor": "Processors",
+      "exporter": "Exporters",
+      "extension": "Extensions",
+      "connector": "Connectors"
+    },
+    "version": {
+      "label": "Version",
+      "latest": "(latest)"
+    },
+    "distribution": {
+      "label": "Distribution",
+      "all": "All Distributions",
+      "core": "Core",
+      "contrib": "Contrib"
+    }
+  },
+  "results": {
+    "showingCount_one": "Showing {{count}} component",
+    "showingCount_other": "Showing {{count}} components"
+  },
+  "card": {
+    "defaultDescription": "Browse technical details and configuration options for this component.",
+    "empty": {
+      "title": "No components found",
+      "description": "We couldn't find any components matching your search criteria.",
+      "clearFilters": "Clear all filters"
+    }
+  },
+  "states": {
+    "loading": "Loading components...",
+    "error": {
+      "title": "Error loading data",
+      "description": "Please try refreshing the page."
+    }
+  },
+  "detail": {
+    "loading": {
+      "title": "Loading component...",
+      "description": "This may take a moment"
+    },
+    "error": {
+      "title": "Error loading component",
+      "fallback": "Component not found",
+      "goBack": "Go back"
+    },
+    "tabs": {
+      "details": "Details",
+      "stability": "Stability"
+    },
+    "sections": {
+      "componentInfo": "Component Info",
+      "linksResources": "Links & Resources",
+      "stabilityLevels": "Stability Levels",
+      "stabilityLegend": "Stability Legend",
+      "distributionAvailability": "Distribution Availability"
+    },
+    "labels": {
+      "type": "Type",
+      "version": "Version",
+      "distribution": "Distribution"
+    },
+    "links": {
+      "sourceCode": "Source Code",
+      "viewOnGithub": "View on GitHub",
+      "viewDocumentation": "View Documentation"
+    },
+    "typeDescriptions": {
+      "receiver": "Receivers collect telemetry data from various sources and formats.",
+      "processor": "Processors transform, filter, or enrich telemetry data between receivers and exporters.",
+      "exporter": "Exporters send telemetry data to one or more backends or destinations.",
+      "extension": "Extensions provide additional capabilities to the collector without processing telemetry data.",
+      "connector": "Connectors act as both an exporter and a receiver, joining two pipelines together."
+    },
+    "stabilityLabels": {
+      "alpha": "Alpha",
+      "beta": "Beta",
+      "stable": "Stable",
+      "deprecated": "Deprecated",
+      "unmaintained": "Unmaintained",
+      "development": "In Development"
+    },
+    "stabilityDescriptions": {
+      "development": "Not all pieces of the component are in place yet. The component should not be used in production.",
+      "alpha": "The component is ready to be used for limited non-critical workloads and the authors of this component would welcome your feedback.",
+      "beta": "Same as Alpha, but the configuration options are deemed stable. Suitable for broader usage.",
+      "stable": "The component is ready for general availability. Breaking changes are not expected to happen without prior notice.",
+      "deprecated": "The component is planned to be removed in a future version and no further support will be provided.",
+      "unmaintained": "The component is no longer actively maintained. New issues will likely not be worked on."
+    },
+    "distributions": {
+      "packaged": "This component is packaged within the following distributions:",
+      "noInfo": "No distribution information is currently available for this component.",
+      "contrib": {
+        "name": "OpenTelemetry Collector Contrib",
+        "desc": "The community-driven distribution containing third-party plugins, specialized receivers, and experimental components."
+      },
+      "core": {
+        "name": "OpenTelemetry Collector Core",
+        "desc": "The core distribution containing only the most essential, officially supported telemetry components."
+      },
+      "k8s": {
+        "name": "OpenTelemetry Operator for Kubernetes",
+        "desc": "The official Kubernetes Operator designed to manage and provision the OpenTelemetry Collector."
+      },
+      "generic": {
+        "desc": "A specialized OpenTelemetry distribution."
+      }
+    },
+    "noStability": "No stability information available for this version."
+  }
+}

--- a/ecosystem-explorer/public/locales/es/collector.json
+++ b/ecosystem-explorer/public/locales/es/collector.json
@@ -1,0 +1,133 @@
+{
+  "page": {
+    "title": "OpenTelemetry Collector",
+    "description": "Una implementación agnóstica al proveedor para recibir, procesar y exportar datos de telemetría.",
+    "unavailableTitle": "Explorador del Collector no disponible",
+    "unavailableDescription": "El explorador del ecosistema del Collector no está habilitado en este despliegue."
+  },
+  "header": {
+    "title": "Collector",
+    "titleAccent": "Componentes",
+    "description": "Navega el ecosistema del OpenTelemetry Collector. Descubre receptores, procesadores, exportadores y extensiones en diferentes distribuciones.",
+    "comingSoon": "Actualmente estamos construyendo el explorador de componentes del Collector. ¡Pronto habrá una vista completa de receptores, procesadores y más!"
+  },
+  "filters": {
+    "search": {
+      "label": "Buscar",
+      "placeholder": "Filtrar por nombre o descripción..."
+    },
+    "type": {
+      "label": "Tipo",
+      "all": "Todos los tipos",
+      "receiver": "Receptores",
+      "processor": "Procesadores",
+      "exporter": "Exportadores",
+      "extension": "Extensiones",
+      "connector": "Conectores"
+    },
+    "version": {
+      "label": "Versión",
+      "latest": "(más reciente)"
+    },
+    "distribution": {
+      "label": "Distribución",
+      "all": "Todas las distribuciones",
+      "core": "Core",
+      "contrib": "Contrib"
+    }
+  },
+  "results": {
+    "showingCount_one": "Mostrando {{count}} componente",
+    "showingCount_other": "Mostrando {{count}} componentes"
+  },
+  "card": {
+    "defaultDescription": "Consulta los detalles técnicos y opciones de configuración de este componente.",
+    "empty": {
+      "title": "No se encontraron componentes",
+      "description": "No encontramos ningún componente que coincida con tu búsqueda.",
+      "clearFilters": "Limpiar todos los filtros"
+    }
+  },
+  "states": {
+    "loading": "Cargando componentes...",
+    "error": {
+      "title": "Error al cargar datos",
+      "description": "Intenta recargar la página."
+    }
+  },
+  "detail": {
+    "loading": {
+      "title": "Cargando componente...",
+      "description": "Esto puede tardar un momento"
+    },
+    "error": {
+      "title": "Error al cargar componente",
+      "fallback": "Componente no encontrado",
+      "goBack": "Volver"
+    },
+    "tabs": {
+      "details": "Detalles",
+      "stability": "Estabilidad"
+    },
+    "sections": {
+      "componentInfo": "Información del componente",
+      "linksResources": "Enlaces y recursos",
+      "stabilityLevels": "Niveles de estabilidad",
+      "stabilityLegend": "Leyenda de estabilidad",
+      "distributionAvailability": "Disponibilidad por distribución"
+    },
+    "labels": {
+      "type": "Tipo",
+      "version": "Versión",
+      "distribution": "Distribución"
+    },
+    "links": {
+      "sourceCode": "Código fuente",
+      "viewOnGithub": "Ver en GitHub",
+      "viewDocumentation": "Ver documentación"
+    },
+    "typeDescriptions": {
+      "receiver": "Los receptores recopilan datos de telemetría de diversas fuentes y formatos.",
+      "processor": "Los procesadores transforman, filtran o enriquecen datos de telemetría entre receptores y exportadores.",
+      "exporter": "Los exportadores envían datos de telemetría a uno o más backends o destinos.",
+      "extension": "Las extensiones proporcionan capacidades adicionales al collector sin procesar datos de telemetría.",
+      "connector": "Los conectores actúan como exportador y receptor a la vez, uniendo dos pipelines."
+    },
+    "stabilityLabels": {
+      "alpha": "Alfa",
+      "beta": "Beta",
+      "stable": "Estable",
+      "deprecated": "Obsoleto",
+      "unmaintained": "Sin mantenimiento",
+      "development": "En desarrollo"
+    },
+    "stabilityDescriptions": {
+      "development": "Aún no están todos los componentes en su lugar. Este componente no debe usarse en producción.",
+      "alpha": "El componente está listo para ser usado en cargas de trabajo limitadas no críticas, y los autores agradecen tus comentarios.",
+      "beta": "Igual que Alfa, pero las opciones de configuración se consideran estables. Adecuado para un uso más amplio.",
+      "stable": "El componente está listo para disponibilidad general. No se esperan cambios incompatibles sin previo aviso.",
+      "deprecated": "Se planea eliminar el componente en una versión futura y no se proporcionará más soporte.",
+      "unmaintained": "El componente ya no se mantiene activamente. Es probable que los nuevos problemas no se aborden."
+    },
+    "distributions": {
+      "packaged": "Este componente está incluido en las siguientes distribuciones:",
+      "noInfo": "No hay información de distribución disponible para este componente.",
+      "contrib": {
+        "name": "OpenTelemetry Collector Contrib",
+        "desc": "La distribución impulsada por la comunidad que contiene plugins de terceros, receptores especializados y componentes experimentales."
+      },
+      "core": {
+        "name": "OpenTelemetry Collector Core",
+        "desc": "La distribución principal que contiene solo los componentes de telemetría más esenciales y con soporte oficial."
+      },
+      "k8s": {
+        "name": "OpenTelemetry Operator para Kubernetes",
+        "desc": "El Operador oficial de Kubernetes diseñado para gestionar y proveer el OpenTelemetry Collector."
+      },
+      "generic": {
+        "desc": "Una distribución especializada de OpenTelemetry."
+      }
+    },
+    "noStability": "No hay información de estabilidad disponible para esta versión."
+  }
+}

--- a/ecosystem-explorer/src/features/collector/collector-components-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.tsx
@@ -15,6 +15,7 @@
  */
 import { useMemo, useState } from "react";
 import { useParams, useNavigate, Link, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
   Search,
   Loader2,
@@ -84,6 +85,7 @@ const getIcon = (type: string) => {
 };
 
 function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
+  const { t } = useTranslation("collector");
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const typeQuery = searchParams.get("type");
@@ -182,7 +184,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
         <div className="relative z-10 flex flex-col gap-6 md:flex-row md:items-end">
           <div className="flex-1 space-y-2">
             <label htmlFor="search" className="text-muted-foreground text-sm font-medium">
-              Search
+              {t("filters.search.label")}
             </label>
             <div className="relative">
               <Search
@@ -192,7 +194,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
               <input
                 id="search"
                 type="text"
-                placeholder="Filter by name or description..."
+                placeholder={t("filters.search.placeholder")}
                 className="border-border/60 bg-background/80 focus:border-primary/50 focus:ring-primary/20 w-full rounded-lg border py-2.5 pr-4 pl-10 text-sm backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
                 value={searchQuery}
                 onChange={(e) => {
@@ -218,7 +220,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
           <div className="flex flex-wrap gap-4">
             <div className="space-y-2">
               <label htmlFor="type-filter" className="text-muted-foreground text-sm font-medium">
-                Type
+                {t("filters.type.label")}
               </label>
               <div className="relative">
                 <select
@@ -227,12 +229,12 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                   onChange={(e) => handleTypeFilterChange(e.target.value)}
                   className="border-border/60 bg-background/80 focus:border-primary/50 focus:ring-primary/20 w-[160px] cursor-pointer appearance-none rounded-lg border py-2.5 pr-10 pl-3 text-sm font-medium backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
                 >
-                  <option value="all">All Types</option>
-                  <option value="receiver">Receivers</option>
-                  <option value="processor">Processors</option>
-                  <option value="exporter">Exporters</option>
-                  <option value="extension">Extensions</option>
-                  <option value="connector">Connectors</option>
+                  <option value="all">{t("filters.type.all")}</option>
+                  <option value="receiver">{t("filters.type.receiver")}</option>
+                  <option value="processor">{t("filters.type.processor")}</option>
+                  <option value="exporter">{t("filters.type.exporter")}</option>
+                  <option value="extension">{t("filters.type.extension")}</option>
+                  <option value="connector">{t("filters.type.connector")}</option>
                 </select>
                 <ChevronDown
                   className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
@@ -243,7 +245,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
 
             <div className="space-y-2">
               <label htmlFor="version-select" className="text-muted-foreground text-sm font-medium">
-                Version
+                {t("filters.version.label")}
               </label>
               <div className="relative">
                 <select
@@ -255,7 +257,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                 >
                   {versionData?.versions.map((v) => (
                     <option key={v.version} value={v.version}>
-                      v{v.version} {v.is_latest ? "(latest)" : ""}
+                      v{v.version} {v.is_latest ? t("filters.version.latest") : ""}
                     </option>
                   ))}
                 </select>
@@ -271,7 +273,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                 htmlFor="distribution-filter"
                 className="text-muted-foreground text-sm font-medium"
               >
-                Distribution
+                {t("filters.distribution.label")}
               </label>
               <div className="relative">
                 <select
@@ -280,9 +282,9 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                   onChange={(e) => handleDistributionFilterChange(e.target.value)}
                   className="border-border/60 bg-background/80 focus:border-primary/50 focus:ring-primary/20 w-[160px] cursor-pointer appearance-none rounded-lg border py-2.5 pr-10 pl-3 text-sm font-medium backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
                 >
-                  <option value="all">All Distributions</option>
-                  <option value="core">Core</option>
-                  <option value="contrib">Contrib</option>
+                  <option value="all">{t("filters.distribution.all")}</option>
+                  <option value="core">{t("filters.distribution.core")}</option>
+                  <option value="contrib">{t("filters.distribution.contrib")}</option>
                 </select>
                 <ChevronDown
                   className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
@@ -297,22 +299,21 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
       {componentsError || versionsError ? (
         <div className="flex flex-col items-center justify-center space-y-4 py-32 text-center text-red-500">
           <AlertCircle className="mx-auto h-12 w-12 opacity-50" aria-hidden="true" />
-          <h3 className="text-xl font-semibold">Error loading data</h3>
-          <p className="text-muted-foreground">Please try refreshing the page.</p>
+          <h3 className="text-xl font-semibold">{t("states.error.title")}</h3>
+          <p className="text-muted-foreground">{t("states.error.description")}</p>
         </div>
       ) : componentsLoading || versionsLoading || !currentVersion ? (
         <div className="flex flex-col items-center justify-center space-y-4 py-32">
           <div className="inline-flex animate-pulse rounded-full p-4 shadow-[0_0_60px_hsl(var(--primary-hsl)/0.2)]">
             <Loader2 className="text-primary h-10 w-10 animate-spin" aria-hidden="true" />
           </div>
-          <p className="text-muted-foreground text-sm font-medium">Loading components...</p>
+          <p className="text-muted-foreground text-sm font-medium">{t("states.loading")}</p>
         </div>
       ) : (
         <div className="space-y-6">
           <div className="border-border/40 flex items-center justify-between border-b pb-4">
             <div className="text-muted-foreground text-sm font-medium">
-              Showing <span className="text-foreground">{filteredComponents.length}</span>{" "}
-              components
+              {t("results.showingCount", { count: filteredComponents.length })}
             </div>
           </div>
 
@@ -364,8 +365,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                       </div>
 
                       <p className="text-muted-foreground/80 line-clamp-3 flex-1 text-sm leading-relaxed">
-                        {comp.description ||
-                          "Browse technical details and configuration options for this component."}
+                        {comp.description || t("card.defaultDescription")}
                       </p>
 
                       <div className="border-border/10 flex items-center gap-2 border-t pt-2">
@@ -387,9 +387,9 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                 <div className="bg-muted/10 mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full">
                   <Search className="text-muted-foreground/30 h-8 w-8" aria-hidden="true" />
                 </div>
-                <h3 className="text-foreground text-xl font-semibold">No components found</h3>
+                <h3 className="text-foreground text-xl font-semibold">{t("card.empty.title")}</h3>
                 <p className="text-muted-foreground mx-auto mt-2 max-w-xs">
-                  We couldn't find any components matching your search criteria.
+                  {t("card.empty.description")}
                 </p>
                 <button
                   onClick={() => {
@@ -398,7 +398,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                   }}
                   className="text-primary mt-6 text-sm font-semibold hover:underline"
                 >
-                  Clear all filters
+                  {t("card.empty.clearFilters")}
                 </button>
               </div>
             )}
@@ -410,6 +410,7 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
 }
 
 export function CollectorComponentsPage() {
+  const { t } = useTranslation("collector");
   const { version: urlVersion } = useParams<{ version: string }>();
 
   return (
@@ -418,14 +419,13 @@ export function CollectorComponentsPage() {
         <BackButton />
         <header className="space-y-4">
           <h1 className="text-foreground text-4xl font-bold tracking-tight sm:text-5xl">
-            Collector{" "}
+            {t("header.title")}{" "}
             <span className="from-secondary to-primary bg-gradient-to-r bg-clip-text text-transparent">
-              Components
+              {t("header.titleAccent")}
             </span>
           </h1>
           <p className="text-muted-foreground max-w-2xl text-lg leading-relaxed">
-            Navigate the OpenTelemetry Collector ecosystem. Discover receivers, processors,
-            exporters, and extensions across different distributions.
+            {t("header.description")}
           </p>
         </header>
 

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -15,6 +15,7 @@
  */
 import { useState } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Info, ExternalLink, AlertCircle, Check } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
 import { GitHubIcon } from "@/components/icons/github-icon";
@@ -26,89 +27,6 @@ import { DetailCard } from "@/components/ui/detail-card";
 import { SectionHeader } from "@/components/ui/section-header";
 import { PageContainer } from "@/components/layout/page-container";
 import { useCollectorComponent, useCollectorVersions } from "@/hooks/use-collector-data";
-
-const COMPONENT_TYPE_DESCRIPTIONS: Record<string, string> = {
-  receiver: "Receivers collect telemetry data from various sources and formats.",
-  processor:
-    "Processors transform, filter, or enrich telemetry data between receivers and exporters.",
-  exporter: "Exporters send telemetry data to one or more backends or destinations.",
-  extension:
-    "Extensions provide additional capabilities to the collector without processing telemetry data.",
-  connector: "Connectors act as both an exporter and a receiver, joining two pipelines together.",
-};
-
-const STABILITY_DEFINITIONS: Record<string, { label: string; desc: string; color: string }> = {
-  development: {
-    label: "Development",
-    desc: "Not all pieces of the component are in place yet. The component should not be used in production.",
-    color: "text-blue-500",
-  },
-  alpha: {
-    label: "Alpha",
-    desc: "The component is ready to be used for limited non-critical workloads and the authors of this component would welcome your feedback.",
-    color: "text-purple-500",
-  },
-  beta: {
-    label: "Beta",
-    desc: "Same as Alpha, but the configuration options are deemed stable. Suitable for broader usage.",
-    color: "text-green-500",
-  },
-  stable: {
-    label: "Stable",
-    desc: "The component is ready for general availability. Breaking changes are not expected to happen without prior notice.",
-    color: "text-emerald-600 dark:text-emerald-500",
-  },
-  deprecated: {
-    label: "Deprecated",
-    desc: "The component is planned to be removed in a future version and no further support will be provided.",
-    color: "text-red-500",
-  },
-  unmaintained: {
-    label: "Unmaintained",
-    desc: "The component is no longer actively maintained. New issues will likely not be worked on.",
-    color: "text-red-600",
-  },
-};
-
-const getDistributionInfo = (distroName: string) => {
-  const lower = distroName.toLowerCase();
-  if (lower.includes("contrib")) {
-    return {
-      name: "OpenTelemetry Collector Contrib",
-      desc: "The community-driven distribution containing third-party plugins, specialized receivers, and experimental components.",
-      cmdLabel: "# Docker",
-      cmd: "docker pull otel/opentelemetry-collector-contrib:latest",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-contrib",
-    };
-  }
-  if (lower.includes("core")) {
-    return {
-      name: "OpenTelemetry Collector Core",
-      desc: "The core distribution containing only the most essential, officially supported telemetry components.",
-      cmdLabel: "# Docker",
-      cmd: "docker pull otel/opentelemetry-collector:latest",
-      url: "https://github.com/open-telemetry/opentelemetry-collector",
-    };
-  }
-
-  if (lower === "k8s" || lower.includes("kubernetes")) {
-    return {
-      name: "OpenTelemetry Operator for Kubernetes",
-      desc: "The official Kubernetes Operator designed to manage and provision the OpenTelemetry Collector.",
-      cmdLabel: "# kubectl",
-      cmd: "kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml",
-      url: "https://github.com/open-telemetry/opentelemetry-operator",
-    };
-  }
-
-  return {
-    name: distroName,
-    desc: "A specialized OpenTelemetry distribution.",
-    cmdLabel: null,
-    cmd: null,
-    url: "https://opentelemetry.io/docs/collector/installation/",
-  };
-};
 
 const getBadgeVariant = (level: string): "success" | "info" | "warning" | "muted" => {
   const lower = level.toLowerCase();
@@ -126,6 +44,7 @@ const getBadgeVariant = (level: string): "success" | "info" | "warning" | "muted
 };
 
 export function CollectorDetailPage() {
+  const { t } = useTranslation("collector");
   const { distribution, name } = useParams<{ distribution: string; name: string }>();
 
   const [searchParams] = useSearchParams();
@@ -143,10 +62,51 @@ export function CollectorDetailPage() {
   } = useCollectorComponent(distribution ?? "", name ?? "", version);
   const [activeTab, setActiveTab] = useState("details");
 
+  const getStabilityLabel = (level: string) =>
+    t(`detail.stabilityLabels.${level.toLowerCase()}`, { defaultValue: level });
+
+  const getDistributionInfo = (distroName: string) => {
+    const lower = distroName.toLowerCase();
+    if (lower.includes("contrib")) {
+      return {
+        name: t("detail.distributions.contrib.name"),
+        desc: t("detail.distributions.contrib.desc"),
+        cmdLabel: "# Docker",
+        cmd: "docker pull otel/opentelemetry-collector-contrib:latest",
+        url: "https://github.com/open-telemetry/opentelemetry-collector-contrib",
+      };
+    }
+    if (lower.includes("core")) {
+      return {
+        name: t("detail.distributions.core.name"),
+        desc: t("detail.distributions.core.desc"),
+        cmdLabel: "# Docker",
+        cmd: "docker pull otel/opentelemetry-collector:latest",
+        url: "https://github.com/open-telemetry/opentelemetry-collector",
+      };
+    }
+    if (lower === "k8s" || lower.includes("kubernetes")) {
+      return {
+        name: t("detail.distributions.k8s.name"),
+        desc: t("detail.distributions.k8s.desc"),
+        cmdLabel: "# kubectl",
+        cmd: "kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml",
+        url: "https://github.com/open-telemetry/opentelemetry-operator",
+      };
+    }
+    return {
+      name: distroName,
+      desc: t("detail.distributions.generic.desc"),
+      cmdLabel: null,
+      cmd: null,
+      url: "https://opentelemetry.io/docs/collector/installation/",
+    };
+  };
+
   if (loading || versionLoading) {
     return (
       <PageContainer>
-        <Loader label="Loading component..." />
+        <Loader label={t("detail.loading.title")} />
       </PageContainer>
     );
   }
@@ -164,16 +124,16 @@ export function CollectorDetailPage() {
               />
               <div className="flex-1 space-y-2">
                 <h3 className="font-semibold text-red-600 dark:text-red-400">
-                  Error loading component
+                  {t("detail.error.title")}
                 </h3>
                 <p className="text-sm text-red-600/90 dark:text-red-400/90">
-                  {error?.message || "Component not found"}
+                  {error?.message || t("detail.error.fallback")}
                 </p>
                 <button
                   onClick={() => navigate(-1)}
                   className="text-sm font-medium text-red-600 hover:underline dark:text-red-400"
                 >
-                  Go back
+                  {t("detail.error.goBack")}
                 </button>
               </div>
             </div>
@@ -198,6 +158,8 @@ export function CollectorDetailPage() {
   const activeStabilityLevels = component.status?.stability
     ? Object.keys(component.status.stability)
     : [];
+
+  const typeDesc = t(`detail.typeDescriptions.${component.type}`, { defaultValue: "" });
 
   return (
     <PageContainer>
@@ -251,12 +213,12 @@ export function CollectorDetailPage() {
                 tabs={[
                   {
                     value: "details",
-                    label: "Details",
+                    label: t("detail.tabs.details"),
                     icon: <Info className="h-4 w-4" aria-hidden="true" />,
                   },
                   {
                     value: "status",
-                    label: "Stability",
+                    label: t("detail.tabs.stability"),
                     icon: <Check className="h-4 w-4" aria-hidden="true" />,
                   },
                 ]}
@@ -268,11 +230,11 @@ export function CollectorDetailPage() {
                 <DetailCard withGrid>
                   <div className="space-y-4">
                     <h3 className="border-border/50 mb-4 border-b pb-2 text-lg font-semibold">
-                      Component Info
+                      {t("detail.sections.componentInfo")}
                     </h3>
                     <div>
                       <h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-                        Type
+                        {t("detail.labels.type")}
                       </h4>
                       <div className="mt-1 flex items-start gap-2 text-sm">
                         <Check
@@ -281,23 +243,21 @@ export function CollectorDetailPage() {
                         />
                         <div>
                           <span className="font-medium capitalize">{component.type}</span>
-                          {COMPONENT_TYPE_DESCRIPTIONS[component.type] && (
-                            <p className="text-muted-foreground mt-0.5 text-xs">
-                              {COMPONENT_TYPE_DESCRIPTIONS[component.type]}
-                            </p>
+                          {typeDesc && (
+                            <p className="text-muted-foreground mt-0.5 text-xs">{typeDesc}</p>
                           )}
                         </div>
                       </div>
                     </div>
                     <div>
                       <h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-                        Version
+                        {t("detail.labels.version")}
                       </h4>
                       <p className="mt-1 text-sm font-medium">{version}</p>
                     </div>
                     <div>
                       <h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-                        Distribution
+                        {t("detail.labels.distribution")}
                       </h4>
                       <p className="mt-1 text-sm font-medium capitalize">
                         {component.distribution}
@@ -309,7 +269,7 @@ export function CollectorDetailPage() {
                 <DetailCard>
                   <div className="space-y-4">
                     <h3 className="border-border/50 mb-4 border-b pb-2 text-lg font-semibold">
-                      Links & Resources
+                      {t("detail.sections.linksResources")}
                     </h3>
                     <a
                       href={`https://github.com/open-telemetry/${component.repository}/tree/main/${component.type}/${component.name}`}
@@ -319,8 +279,10 @@ export function CollectorDetailPage() {
                     >
                       <GitHubIcon className="text-secondary h-5 w-5 transition-transform group-hover:scale-110" />
                       <div>
-                        <p className="text-sm font-medium">Source Code</p>
-                        <p className="text-muted-foreground text-xs">View on GitHub</p>
+                        <p className="text-sm font-medium">{t("detail.links.sourceCode")}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {t("detail.links.viewOnGithub")}
+                        </p>
                       </div>
                       <ExternalLink className="text-muted-foreground ml-auto h-4 w-4" />
                     </a>
@@ -333,7 +295,7 @@ export function CollectorDetailPage() {
               {component.status ? (
                 <div className="space-y-10">
                   <div className="space-y-6">
-                    <SectionHeader>Stability Levels</SectionHeader>
+                    <SectionHeader>{t("detail.sections.stabilityLevels")}</SectionHeader>
                     <div className="border-border/60 bg-card overflow-x-auto rounded-lg border shadow-sm">
                       <table className="w-full text-left text-sm">
                         <thead className="bg-muted/30">
@@ -360,7 +322,7 @@ export function CollectorDetailPage() {
                                       variant={getBadgeVariant(level)}
                                       className="text-xs capitalize"
                                     >
-                                      {level}
+                                      {getStabilityLabel(level)}
                                     </GlowBadge>
                                   ) : (
                                     <span className="text-muted-foreground/50 font-mono">-</span>
@@ -376,11 +338,15 @@ export function CollectorDetailPage() {
 
                   {activeStabilityLevels.length > 0 && (
                     <div className="space-y-4">
-                      <h4 className="text-lg font-semibold">Stability Legend</h4>
+                      <h4 className="text-lg font-semibold">
+                        {t("detail.sections.stabilityLegend")}
+                      </h4>
                       <div className="grid gap-4 md:grid-cols-2">
                         {activeStabilityLevels.map((level) => {
-                          const def = STABILITY_DEFINITIONS[level.toLowerCase()];
-                          if (!def) return null;
+                          const desc = t(`detail.stabilityDescriptions.${level.toLowerCase()}`, {
+                            defaultValue: "",
+                          });
+                          if (!desc) return null;
                           return (
                             <div
                               key={level}
@@ -390,9 +356,9 @@ export function CollectorDetailPage() {
                                 variant={getBadgeVariant(level)}
                                 className="w-fit text-xs capitalize"
                               >
-                                {level}
+                                {getStabilityLabel(level)}
                               </GlowBadge>
-                              <p className="text-muted-foreground mt-2 text-sm">{def.desc}</p>
+                              <p className="text-muted-foreground mt-2 text-sm">{desc}</p>
                             </div>
                           );
                         })}
@@ -404,9 +370,11 @@ export function CollectorDetailPage() {
                   {component.status.distributions && component.status.distributions.length > 0 ? (
                     <div className="space-y-6">
                       <div>
-                        <SectionHeader>Distribution Availability</SectionHeader>
+                        <SectionHeader>
+                          {t("detail.sections.distributionAvailability")}
+                        </SectionHeader>
                         <p className="text-muted-foreground mt-2 text-sm">
-                          This component is packaged within the following distributions:
+                          {t("detail.distributions.packaged")}
                         </p>
                       </div>
 
@@ -444,7 +412,8 @@ export function CollectorDetailPage() {
                                     rel="noopener noreferrer"
                                     className="text-primary inline-flex items-center gap-1 text-sm font-medium hover:underline"
                                   >
-                                    View Documentation <ExternalLink className="h-3 w-3" />
+                                    {t("detail.links.viewDocumentation")}{" "}
+                                    <ExternalLink className="h-3 w-3" />
                                   </a>
                                 )}
                               </div>
@@ -455,10 +424,10 @@ export function CollectorDetailPage() {
                     </div>
                   ) : (
                     <div className="space-y-6">
-                      <SectionHeader>Distribution Availability</SectionHeader>
+                      <SectionHeader>{t("detail.sections.distributionAvailability")}</SectionHeader>
                       <div className="border-border/60 bg-card flex items-center justify-center rounded-lg border p-8 shadow-sm">
                         <p className="text-muted-foreground text-sm">
-                          No distribution information is currently available for this component.
+                          {t("detail.distributions.noInfo")}
                         </p>
                       </div>
                     </div>
@@ -467,9 +436,7 @@ export function CollectorDetailPage() {
               ) : (
                 <div className="py-12 text-center">
                   <AlertCircle className="text-muted-foreground/30 mx-auto h-12 w-12" />
-                  <p className="text-muted-foreground mt-4">
-                    No stability information available for this version.
-                  </p>
+                  <p className="text-muted-foreground mt-4">{t("detail.noStability")}</p>
                 </div>
               )}
             </TabsContent>

--- a/ecosystem-explorer/src/features/collector/collector-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useTranslation } from "react-i18next";
 import { PageContainer } from "@/components/layout/page-container";
 import { BackButton } from "@/components/ui/back-button";
 import { CollectorExploreLanding } from "@/features/collector/components/collector-explore-landing.tsx";
 import { isEnabled } from "@/lib/feature-flags";
 
 export function CollectorPage() {
+  const { t } = useTranslation("collector");
   const collectorPageEnabled = isEnabled("COLLECTOR_PAGE");
 
   return (
@@ -28,21 +30,18 @@ export function CollectorPage() {
         <div>
           <h1 className="mb-2 text-3xl font-bold md:text-4xl">
             <span className="bg-gradient-to-r from-[hsl(var(--secondary-hsl))] to-[hsl(var(--primary-hsl))] bg-clip-text text-transparent">
-              OpenTelemetry Collector
+              {t("page.title")}
             </span>
           </h1>
-          <p className="text-muted-foreground">
-            A vendor-agnostic implementation for receiving, processing, and exporting telemetry
-            data.
-          </p>
+          <p className="text-muted-foreground">{t("page.description")}</p>
         </div>
         {collectorPageEnabled ? (
           <CollectorExploreLanding />
         ) : (
           <section className="border-border/60 bg-card/80 rounded-lg border p-8 text-center">
-            <h2 className="text-foreground text-2xl font-bold">Collector explorer unavailable</h2>
+            <h2 className="text-foreground text-2xl font-bold">{t("page.unavailableTitle")}</h2>
             <p className="text-muted-foreground mx-auto mt-3 max-w-2xl leading-relaxed">
-              The Collector ecosystem explorer is not enabled for this deployment.
+              {t("page.unavailableDescription")}
             </p>
           </section>
         )}

--- a/ecosystem-explorer/src/test/setup.ts
+++ b/ecosystem-explorer/src/test/setup.ts
@@ -21,17 +21,19 @@ import { initReactI18next } from "react-i18next";
 import commonEn from "../../public/locales/en/common.json";
 import layoutEn from "../../public/locales/en/layout.json";
 import homeEn from "../../public/locales/en/home.json";
+import collectorEn from "../../public/locales/en/collector.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
-  ns: ["common", "layout", "home"],
+  ns: ["common", "layout", "home", "collector"],
   defaultNS: "common",
   resources: {
     en: {
       common: commonEn,
       layout: layoutEn,
       home: homeEn,
+      collector: collectorEn,
     },
   },
 });


### PR DESCRIPTION
## Summary

- Adds \`en/collector.json\` and \`es/collector.json\` covering all three Collector pages: intro, components list, and detail view
- Wires \`useTranslation("collector")\` into \`collector-page.tsx\`, \`collector-components-page.tsx\`, and \`collector-detail-page.tsx\`
- Replaces \`COMPONENT_TYPE_DESCRIPTIONS\` and \`STABILITY_DEFINITIONS\` module-level constants with locale keys — strings are identical, now translatable
- Converts \`getDistributionInfo\` from a module-level function to an in-component helper so it can call \`t()\` for distribution names and descriptions
- Adds new locale keys for strings introduced by PR #399: stability legend section, per-level stability descriptions (\`detail.stabilityDescriptions.*\`), and distribution info cards (\`detail.distributions.*\`)

> **Note on prior Copilot review comments:** The comments on \`config.ts\`, \`header.tsx\`, and the Suspense boundary were all addressed in #649 (now merged). The \`setup.ts\` async-init comment is a known non-blocking issue — tests pass in practice.

## Test plan

- [x] \`bun run typecheck\` passes
- [x] \`bun run test\` passes (1023 tests)
- [ ] Collector pages render correctly in both English and Spanish

Assisted-By: This contribution was prepared with the assistance of an AI development tool.