### PR TITLE
feat(i18n): extract about namespace strings

### DIFF
--- a/ecosystem-explorer/public/locales/en/about.json
+++ b/ecosystem-explorer/public/locales/en/about.json
@@ -1,0 +1,35 @@
+{
+  "intro": {
+    "heading": "About",
+    "description": "The OpenTelemetry Ecosystem Explorer is a community-driven tool for discovering and exploring projects, instrumentations, and components across the <otelLink>OpenTelemetry</otelLink> ecosystem."
+  },
+  "goals": {
+    "heading": "Goals",
+    "body1": "The ecosystem is large and growing. Finding what instrumentation exists, what it produces, and how to configure it can be difficult. This project aims to make that information accessible and easy to navigate.",
+    "body2": "By building a structured registry and an interactive explorer, we help developers understand what is available, what signals each component emits, and how components relate to OpenTelemetry semantic conventions."
+  },
+  "getInvolved": {
+    "heading": "Get Involved",
+    "sourceCode": {
+      "title": "Source Code",
+      "description": "Browse the repository, review open issues, and submit pull requests."
+    },
+    "docs": {
+      "title": "OpenTelemetry Docs",
+      "description": "Learn about OpenTelemetry concepts, APIs, and SDKs at opentelemetry.io."
+    },
+    "reportBug": {
+      "title": "Report a Bug",
+      "description": "Found something wrong? Open an issue on GitHub and let us know."
+    },
+    "requestFeature": {
+      "title": "Request a Feature",
+      "description": "Have an idea? Open an issue to discuss it with the maintainers."
+    }
+  },
+  "contributing": {
+    "heading": "Contributing",
+    "body1": "Contributions of all sizes are welcome — from fixing a typo to adding new ecosystem coverage. To get started, read the <guideLink>contributing guide</guideLink>.",
+    "body2": "The project is part of the <slackLink>#otel-ecosystem-explorer</slackLink> channel on CNCF Slack. Join us there for questions, discussions, and updates."
+  }
+}

--- a/ecosystem-explorer/public/locales/es/about.json
+++ b/ecosystem-explorer/public/locales/es/about.json
@@ -1,0 +1,35 @@
+{
+  "intro": {
+    "heading": "Acerca de",
+    "description": "El OpenTelemetry Ecosystem Explorer es una herramienta impulsada por la comunidad para descubrir y explorar proyectos, instrumentaciones y componentes en el ecosistema de <otelLink>OpenTelemetry</otelLink>."
+  },
+  "goals": {
+    "heading": "Objetivos",
+    "body1": "El ecosistema es grande y está en crecimiento. Encontrar qué instrumentación existe, qué produce y cómo configurarla puede ser difícil. Este proyecto busca hacer esa información accesible y fácil de navegar.",
+    "body2": "Al construir un registro estructurado y un explorador interactivo, ayudamos a los desarrolladores a entender qué está disponible, qué señales emite cada componente y cómo se relacionan con las convenciones semánticas de OpenTelemetry."
+  },
+  "getInvolved": {
+    "heading": "Participa",
+    "sourceCode": {
+      "title": "Código fuente",
+      "description": "Explora el repositorio, revisa los issues abiertos y envía pull requests."
+    },
+    "docs": {
+      "title": "Documentación de OpenTelemetry",
+      "description": "Aprende sobre los conceptos, APIs y SDKs de OpenTelemetry en opentelemetry.io."
+    },
+    "reportBug": {
+      "title": "Reportar un error",
+      "description": "¿Encontraste algo incorrecto? Abre un issue en GitHub y cuéntanos."
+    },
+    "requestFeature": {
+      "title": "Solicitar una función",
+      "description": "¿Tienes una idea? Abre un issue para discutirla con los mantenedores."
+    }
+  },
+  "contributing": {
+    "heading": "Cómo contribuir",
+    "body1": "Son bienvenidas contribuciones de todos los tamaños — desde corregir un error tipográfico hasta agregar nueva cobertura del ecosistema. Para comenzar, lee la <guideLink>guía de contribución</guideLink>.",
+    "body2": "El proyecto forma parte del canal <slackLink>#otel-ecosystem-explorer</slackLink> en CNCF Slack. Únete ahí para preguntas, discusiones y actualizaciones."
+  }
+}

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useTranslation, Trans } from "react-i18next";
 import { BookOpen, Bug, MessageSquare } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import { BackButton } from "@/components/ui/back-button";
@@ -21,46 +22,42 @@ import { PageContainer } from "@/components/layout/page-container";
 const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
 
 export function AboutPage() {
+  const { t } = useTranslation("about");
   return (
     <PageContainer>
       <div className="space-y-6">
         <BackButton />
         <div className="mx-auto max-w-4xl space-y-10 py-12">
           <div className="space-y-3">
-            <h1 className="text-foreground text-3xl font-bold">About</h1>
+            <h1 className="text-foreground text-3xl font-bold">{t("intro.heading")}</h1>
             <p className="text-muted-foreground text-base leading-relaxed">
-              The OpenTelemetry Ecosystem Explorer is a community-driven tool for discovering and
-              exploring projects, instrumentations, and components across the{" "}
-              <a
-                href="https://opentelemetry.io"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                OpenTelemetry
-              </a>{" "}
-              ecosystem.
+              <Trans
+                i18nKey="intro.description"
+                ns="about"
+                components={{
+                  otelLink: (
+                    <a
+                      href="https://opentelemetry.io"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline"
+                    />
+                  ),
+                }}
+              />
             </p>
           </div>
 
           <section className="space-y-4">
-            <h2 className="text-foreground text-xl font-semibold">Goals</h2>
+            <h2 className="text-foreground text-xl font-semibold">{t("goals.heading")}</h2>
             <div className="border-border/50 bg-card/50 text-muted-foreground space-y-3 rounded-lg border p-6 text-sm leading-relaxed">
-              <p>
-                The ecosystem is large and growing. Finding what instrumentation exists, what it
-                produces, and how to configure it can be difficult. This project aims to make that
-                information accessible and easy to navigate.
-              </p>
-              <p>
-                By building a structured registry and an interactive explorer, we help developers
-                understand what is available, what signals each component emits, and how components
-                relate to OpenTelemetry semantic conventions.
-              </p>
+              <p>{t("goals.body1")}</p>
+              <p>{t("goals.body2")}</p>
             </div>
           </section>
 
           <section className="space-y-4">
-            <h2 className="text-foreground text-xl font-semibold">Get Involved</h2>
+            <h2 className="text-foreground text-xl font-semibold">{t("getInvolved.heading")}</h2>
             <div className="grid gap-4 sm:grid-cols-2">
               <a
                 href={REPO_URL}
@@ -73,9 +70,11 @@ export function AboutPage() {
                   aria-hidden="true"
                 />
                 <div className="space-y-1">
-                  <h3 className="text-foreground text-sm font-medium">Source Code</h3>
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("getInvolved.sourceCode.title")}
+                  </h3>
                   <p className="text-muted-foreground text-xs">
-                    Browse the repository, review open issues, and submit pull requests.
+                    {t("getInvolved.sourceCode.description")}
                   </p>
                 </div>
               </a>
@@ -91,9 +90,11 @@ export function AboutPage() {
                   aria-hidden="true"
                 />
                 <div className="space-y-1">
-                  <h3 className="text-foreground text-sm font-medium">OpenTelemetry Docs</h3>
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("getInvolved.docs.title")}
+                  </h3>
                   <p className="text-muted-foreground text-xs">
-                    Learn about OpenTelemetry concepts, APIs, and SDKs at opentelemetry.io.
+                    {t("getInvolved.docs.description")}
                   </p>
                 </div>
               </a>
@@ -106,9 +107,11 @@ export function AboutPage() {
               >
                 <Bug className="text-secondary mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
                 <div className="space-y-1">
-                  <h3 className="text-foreground text-sm font-medium">Report a Bug</h3>
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("getInvolved.reportBug.title")}
+                  </h3>
                   <p className="text-muted-foreground text-xs">
-                    Found something wrong? Open an issue on GitHub and let us know.
+                    {t("getInvolved.reportBug.description")}
                   </p>
                 </div>
               </a>
@@ -124,9 +127,11 @@ export function AboutPage() {
                   aria-hidden="true"
                 />
                 <div className="space-y-1">
-                  <h3 className="text-foreground text-sm font-medium">Request a Feature</h3>
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("getInvolved.requestFeature.title")}
+                  </h3>
                   <p className="text-muted-foreground text-xs">
-                    Have an idea? Open an issue to discuss it with the maintainers.
+                    {t("getInvolved.requestFeature.description")}
                   </p>
                 </div>
               </a>
@@ -134,32 +139,39 @@ export function AboutPage() {
           </section>
 
           <section className="space-y-4">
-            <h2 className="text-foreground text-xl font-semibold">Contributing</h2>
+            <h2 className="text-foreground text-xl font-semibold">{t("contributing.heading")}</h2>
             <div className="border-border/50 bg-card/50 text-muted-foreground space-y-3 rounded-lg border p-6 text-sm leading-relaxed">
               <p>
-                Contributions of all sizes are welcome — from fixing a typo to adding new ecosystem
-                coverage. To get started, read the{" "}
-                <a
-                  href={`${REPO_URL}/blob/main/CONTRIBUTING.md`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  contributing guide
-                </a>
-                .
+                <Trans
+                  i18nKey="contributing.body1"
+                  ns="about"
+                  components={{
+                    guideLink: (
+                      <a
+                        href={`${REPO_URL}/blob/main/CONTRIBUTING.md`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      />
+                    ),
+                  }}
+                />
               </p>
               <p>
-                The project is part of the{" "}
-                <a
-                  href="https://cloud-native.slack.com/archives/C09N6DDGSPQ"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  #otel-ecosystem-explorer
-                </a>{" "}
-                channel on CNCF Slack. Join us there for questions, discussions, and updates.
+                <Trans
+                  i18nKey="contributing.body2"
+                  ns="about"
+                  components={{
+                    slackLink: (
+                      <a
+                        href="https://cloud-native.slack.com/archives/C09N6DDGSPQ"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      />
+                    ),
+                  }}
+                />
               </p>
             </div>
           </section>

--- a/ecosystem-explorer/src/test/integration/setup.ts
+++ b/ecosystem-explorer/src/test/integration/setup.ts
@@ -29,11 +29,12 @@ import layoutEn from "../../../public/locales/en/layout.json";
 import homeEn from "../../../public/locales/en/home.json";
 import collectorEn from "../../../public/locales/en/collector.json";
 import javaAgentEn from "../../../public/locales/en/java-agent.json";
+import aboutEn from "../../../public/locales/en/about.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
-  ns: ["common", "layout", "home", "collector", "java-agent"],
+  ns: ["common", "layout", "home", "collector", "java-agent", "about"],
   defaultNS: "common",
   resources: {
     en: {
@@ -42,6 +43,7 @@ i18n.use(initReactI18next).init({
       home: homeEn,
       collector: collectorEn,
       "java-agent": javaAgentEn,
+      about: aboutEn,
     },
   },
 });

--- a/ecosystem-explorer/src/test/setup.ts
+++ b/ecosystem-explorer/src/test/setup.ts
@@ -24,11 +24,12 @@ import homeEn from "../../public/locales/en/home.json";
 import collectorEn from "../../public/locales/en/collector.json";
 import javaAgentEn from "../../public/locales/en/java-agent.json";
 import ecosystemEn from "../../public/locales/en/ecosystem.json";
+import aboutEn from "../../public/locales/en/about.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
-  ns: ["common", "layout", "home", "collector", "java-agent", "ecosystem"],
+  ns: ["common", "layout", "home", "collector", "java-agent", "ecosystem", "about"],
   defaultNS: "common",
   resources: {
     en: {
@@ -38,6 +39,7 @@ i18n.use(initReactI18next).init({
       collector: collectorEn,
       "java-agent": javaAgentEn,
       ecosystem: ecosystemEn,
+      about: aboutEn,
     },
   },
 });


### PR DESCRIPTION
## Summary

- Adds \`en/about.json\` and \`es/about.json\` with all strings from the About page
- Uses the \`Trans\` component for paragraphs with inline anchor tags (\`intro.description\`, \`contributing.body1\`, \`contributing.body2\`), keeping link markup in JSX and text in the locale files

## Test plan

- [x] \`bun run typecheck\` passes
- [x] \`bun run test\` passes (1040 unit tests)
- [x] \`bun run test:integration\` passes (51 integration tests)
- [x] About page renders correctly in both English and Spanish, including clickable links within translated paragraphs

Assisted-By: This contribution was prepared with the assistance of an AI development tool.