### PR TITLE
Add sdk configuration defaults for schema 1.1.0

### DIFF
--- a/ecosystem-explorer/public/data/configuration/defaults/sdk-configuration-defaults-1.1.0.json
+++ b/ecosystem-explorer/public/data/configuration/defaults/sdk-configuration-defaults-1.1.0.json
@@ -1,0 +1,69 @@
+{
+  "enabledSections": {
+    "resource": true,
+    "propagator": true,
+    "tracer_provider": true,
+    "meter_provider": true,
+    "logger_provider": true
+  },
+  "values": {
+    "resource": {
+      "attributes_list": "${OTEL_RESOURCE_ATTRIBUTES}",
+      "detection/development": {
+        "detectors": [
+          { "service": {} },
+          { "host": {} },
+          { "process": {} },
+          { "container": {} }
+        ]
+      }
+    },
+    "propagator": {
+      "composite": [{ "tracecontext": {} }, { "baggage": {} }]
+    },
+    "tracer_provider": {
+      "processors": [
+        {
+          "batch": {
+            "exporter": {
+              "otlp_http": {
+                "endpoint": "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces"
+              }
+            }
+          }
+        }
+      ],
+      "sampler": {
+        "parent_based": {
+          "root": { "always_on": {} }
+        }
+      }
+    },
+    "meter_provider": {
+      "readers": [
+        {
+          "periodic": {
+            "exporter": {
+              "otlp_http": {
+                "endpoint": "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "logger_provider": {
+      "processors": [
+        {
+          "batch": {
+            "exporter": {
+              "otlp_http": {
+                "endpoint": "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The config builder starter is loaded from `defaults/sdk-configuration-defaults-<version>.json`, which is hand maintained per schema version. With configuration 1.1.0 becoming latest in #660 that file is missing, the fetch 404s silently and the builder starts with no preloaded sections. Same root cause as the integration test failures on #660.

Schema 1.1.0 only adds `tracer_provider/id_generator` on top of 1.0.0, and the upstream examples are unchanged between v1.0.0 and v1.1.0 apart from the `file_format` bump (which the builder already emits on its own), so the 1.0.0 defaults carry over as is.

Verified locally with the #660 data applied: full integration suite passes (51/51).

This should merge before #660, then re-running the failed job there should turn it green.