### PR TITLE
ci: persist otelbot App token so automated PR pushes trigger workflows

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -39,14 +39,6 @@ jobs:
       pull-requests: write # Create or update the automated database-update PR
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Persisted credentials are required so the later `git push -f origin
-          # HEAD:${BRANCH}` step can authenticate.
-          persist-credentials: true
-
       - name: Detect repository type (if on a fork we use different git config)
         id: repo_check
         env:
@@ -58,11 +50,11 @@ jobs:
             echo "is_primary=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Configure git (primary repository)
-        if: steps.repo_check.outputs.is_primary == 'true'
-        run: |
-          .github/scripts/use-cla-approved-bot.sh
-
+      # Mint the otelbot App token BEFORE checkout so it can be persisted as the
+      # git credential. Pushes authenticated with the App token trigger
+      # downstream workflows (e.g. CodeQL on the PR); pushes authenticated with
+      # the default GITHUB_TOKEN do not, which previously left automated-update
+      # PRs blocked waiting for code-scanning results after a branch update.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: steps.repo_check.outputs.is_primary == 'true'
         id: otelbot-token
@@ -70,7 +62,25 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
-          permission-pull-requests: write
+          permission-contents: write # Push the generated database to the update branch
+          permission-pull-requests: write # Create or update the automated PR
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # On the primary repo, persist the otelbot App token so the later
+          # `git push -f origin HEAD:${BRANCH}` authenticates as the App and
+          # triggers downstream workflows. Forks have no App secret and fall
+          # back to GITHUB_TOKEN.
+          token:
+            ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token
+            || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Configure git (primary repository)
+        if: steps.repo_check.outputs.is_primary == 'true'
+        run: |
+          .github/scripts/use-cla-approved-bot.sh
 
       - name: Configure git (fork)
         if: steps.repo_check.outputs.is_primary == 'false'

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -32,14 +32,6 @@ jobs:
       dotnet_result: ${{ steps.dotnet_instrumentation_watcher.outcome }}
       configuration_result: ${{ steps.configuration_watcher.outcome }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Persisted credentials are required so the later `git push -f origin
-          # HEAD:${BRANCH}` step can authenticate.
-          persist-credentials: true
-
       - name: Detect repository type (if on a fork we use different git config)
         id: repo_check
         env:
@@ -51,11 +43,11 @@ jobs:
             echo "is_primary=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Configure git (primary repository)
-        if: steps.repo_check.outputs.is_primary == 'true'
-        run: |
-          .github/scripts/use-cla-approved-bot.sh
-
+      # Mint the otelbot App token BEFORE checkout so it can be persisted as the
+      # git credential. Pushes authenticated with the App token trigger
+      # downstream workflows (e.g. CodeQL on the PR); pushes authenticated with
+      # the default GITHUB_TOKEN do not, which previously left automated-update
+      # PRs blocked waiting for code-scanning results after a branch update.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: steps.repo_check.outputs.is_primary == 'true'
         id: otelbot-token
@@ -63,7 +55,25 @@ jobs:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
-          permission-pull-requests: write
+          permission-contents: write # Push registry updates to the update branch
+          permission-pull-requests: write # Create or update the automated PR
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # On the primary repo, persist the otelbot App token so the later
+          # `git push -f origin HEAD:${BRANCH}` authenticates as the App and
+          # triggers downstream workflows. Forks have no App secret and fall
+          # back to GITHUB_TOKEN.
+          token:
+            ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token
+            || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Configure git (primary repository)
+        if: steps.repo_check.outputs.is_primary == 'true'
+        run: |
+          .github/scripts/use-cla-approved-bot.sh
 
       - name: Configure git (forked repository)
         if: steps.repo_check.outputs.is_primary == 'false'


### PR DESCRIPTION
## What

The **Build Explorer Database** and **Nightly Registry Update** workflows checked out with the default `GITHUB_TOKEN` and persisted it as the git credential, so the `git push -f` to the automated-update branch authenticated as `GITHUB_TOKEN`. The `GH_TOKEN: <otelbot App token>` env on the push step only applies to the `gh` CLI (`gh pr create`/`gh pr edit`), **not** to `git push`.

Pushes authenticated with `GITHUB_TOKEN` [do not trigger downstream workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). So when a second run force-updated an **already-open** PR, CodeQL never re-ran for the new head and the PR stayed blocked on the "Code scanning results" merge rule (most recently #660). The first run only worked because `gh pr create` runs with the App token and fires the `pull_request: opened` event.

## Fix (both workflows)

- Mint the otelbot App token **before** checkout and persist it as the checkout credential on the primary repo, so `git push -f` authenticates as the App and triggers CodeQL on the PR. Forks have no App secret and keep falling back to `GITHUB_TOKEN`.
- Add `permission-contents: write` to the App token. `create-github-app-token` scopes the token to exactly the requested `permission-*` inputs, and the previous config only requested `pull-requests: write` — so the token lacked the `contents: write` the push needs.
- Reorder steps so `Configure git (primary repository)` (which runs `use-cla-approved-bot.sh` against the checked-out repo) now runs after checkout.

## Scope

Only the two PR-creating workflows are affected. The `screenshots-*` workflows push to the `otelbot/screenshots` data branch with `GITHUB_TOKEN` **on purpose** (they must not trigger downstream runs) and are left unchanged.

## Verification

- `python3 -c yaml.safe_load` parses both files.
- Project Prettier (`prettier --check`) passes on both files.

---

> Co-authored with Claude Opus 4.8.