### PR TITLE
feat(v1): add ReleaseCard ecosystem-landing component (Phase 3 - PR 2)

### DIFF
--- a/ecosystem-explorer/public/locales/en/ecosystem.json
+++ b/ecosystem-explorer/public/locales/en/ecosystem.json
@@ -6,7 +6,7 @@
     "added": "added",
     "changed": "changed",
     "deprecated": "deprecated",
-    "changelog": "View changelog →",
+    "changelog": "View changelog",
     "empty": "Release information is not yet available for this ecosystem."
   }
 }

--- a/ecosystem-explorer/public/locales/en/ecosystem.json
+++ b/ecosystem-explorer/public/locales/en/ecosystem.json
@@ -1,0 +1,12 @@
+{
+  "releaseCard": {
+    "eyebrow": "Latest release",
+    "ariaLabel": "Latest release {{version}}",
+    "changesAriaLabel": "Changes in this release",
+    "added": "added",
+    "changed": "changed",
+    "deprecated": "deprecated",
+    "changelog": "View changelog →",
+    "empty": "Release information is not yet available for this ecosystem."
+  }
+}

--- a/ecosystem-explorer/public/locales/es/ecosystem.json
+++ b/ecosystem-explorer/public/locales/es/ecosystem.json
@@ -1,0 +1,12 @@
+{
+  "releaseCard": {
+    "eyebrow": "Última versión",
+    "ariaLabel": "Última versión {{version}}",
+    "changesAriaLabel": "Cambios en esta versión",
+    "added": "añadidos",
+    "changed": "modificados",
+    "deprecated": "obsoletos",
+    "changelog": "Ver registro de cambios →",
+    "empty": "La información de la versión aún no está disponible para este ecosistema."
+  }
+}

--- a/ecosystem-explorer/public/locales/es/ecosystem.json
+++ b/ecosystem-explorer/public/locales/es/ecosystem.json
@@ -6,7 +6,7 @@
     "added": "añadidos",
     "changed": "modificados",
     "deprecated": "obsoletos",
-    "changelog": "Ver registro de cambios →",
+    "changelog": "Ver registro de cambios",
     "empty": "La información de la versión aún no está disponible para este ecosistema."
   }
 }

--- a/ecosystem-explorer/src/i18n/config.ts
+++ b/ecosystem-explorer/src/i18n/config.ts
@@ -31,7 +31,7 @@ if (isEnabled("I18N")) {
 i18nInstance.use(initReactI18next).init({
   ...(isEnabled("I18N") ? {} : { lng: "en" }),
   fallbackLng: "en",
-  ns: ["common", "layout", "home", "collector", "java-agent", "about"],
+  ns: ["common", "layout", "home", "collector", "java-agent", "about", "ecosystem"],
   defaultNS: "common",
   backend: { loadPath: "/locales/{{lng}}/{{ns}}.json" },
   interpolation: { escapeValue: false },

--- a/ecosystem-explorer/src/test/setup.ts
+++ b/ecosystem-explorer/src/test/setup.ts
@@ -23,11 +23,12 @@ import layoutEn from "../../public/locales/en/layout.json";
 import homeEn from "../../public/locales/en/home.json";
 import collectorEn from "../../public/locales/en/collector.json";
 import javaAgentEn from "../../public/locales/en/java-agent.json";
+import ecosystemEn from "../../public/locales/en/ecosystem.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
-  ns: ["common", "layout", "home", "collector", "java-agent"],
+  ns: ["common", "layout", "home", "collector", "java-agent", "ecosystem"],
   defaultNS: "common",
   resources: {
     en: {
@@ -36,6 +37,7 @@ i18n.use(initReactI18next).init({
       home: homeEn,
       collector: collectorEn,
       "java-agent": javaAgentEn,
+      ecosystem: ecosystemEn,
     },
   },
 });

--- a/ecosystem-explorer/src/v1/components/ecosystem/release-card.test.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/release-card.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReleaseCard } from "./release-card";
+
+describe("ReleaseCard", () => {
+  it("renders the version, date, and all three delta counters", () => {
+    render(
+      <ReleaseCard
+        version="v0.150.0"
+        releaseDate="May 2026"
+        deltas={{ added: 4, changed: 12, deprecated: 2 }}
+        hrefChangelog="https://example.com/changelog"
+      />
+    );
+    expect(screen.getByText("v0.150.0")).toBeInTheDocument();
+    expect(screen.getByText("May 2026")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View changelog/i })).toHaveAttribute(
+      "href",
+      "https://example.com/changelog"
+    );
+  });
+
+  it("renders an empty state when no version is provided", () => {
+    render(<ReleaseCard version={null} />);
+    expect(screen.getByText(/Release information is not yet available/i)).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/v1/components/ecosystem/release-card.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/release-card.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ReleaseCard — top-right card on the ecosystem landing hero. Shows the
+ * current/latest version, optional release date, and a small delta strip
+ * (+ added · ⟳ changed · ✕ deprecated). Renders an empty state when no
+ * release info is available.
+ */
+
+import { CircleX, RotateCw, Sparkles } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export interface ReleaseDeltas {
+  added: number;
+  changed: number;
+  deprecated: number;
+}
+
+export interface ReleaseCardProps {
+  version: string | null;
+  releaseDate?: string | null;
+  deltas?: ReleaseDeltas | null;
+  hrefChangelog?: string | null;
+  className?: string;
+}
+
+export function ReleaseCard({
+  version,
+  releaseDate,
+  deltas,
+  hrefChangelog,
+  className,
+}: ReleaseCardProps) {
+  const { t } = useTranslation("ecosystem");
+
+  if (!version) {
+    return (
+      <aside className={`td-release-card td-release-card--empty ${className ?? ""}`}>
+        <div className="td-release-card__eyebrow">{t("releaseCard.eyebrow")}</div>
+        <p className="td-release-card__empty-msg">{t("releaseCard.empty")}</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      className={`td-release-card ${className ?? ""}`}
+      aria-label={t("releaseCard.ariaLabel", { version })}
+    >
+      <div className="td-release-card__eyebrow">{t("releaseCard.eyebrow")}</div>
+      <div className="td-release-card__version">{version}</div>
+      {releaseDate && <div className="td-release-card__date">{releaseDate}</div>}
+      {deltas && (
+        <ul className="td-release-card__deltas" aria-label={t("releaseCard.changesAriaLabel")}>
+          <li className="td-release-card__delta">
+            <Sparkles className="td-release-card__delta-icon" aria-hidden focusable="false" />
+            <strong>{deltas.added}</strong> {t("releaseCard.added")}
+          </li>
+          <li className="td-release-card__delta">
+            <RotateCw className="td-release-card__delta-icon" aria-hidden focusable="false" />
+            <strong>{deltas.changed}</strong> {t("releaseCard.changed")}
+          </li>
+          <li className="td-release-card__delta">
+            <CircleX className="td-release-card__delta-icon" aria-hidden focusable="false" />
+            <strong>{deltas.deprecated}</strong> {t("releaseCard.deprecated")}
+          </li>
+        </ul>
+      )}
+      {hrefChangelog && (
+        <a
+          className="td-release-card__changelog"
+          href={hrefChangelog}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t("releaseCard.changelog")}
+        </a>
+      )}
+    </aside>
+  );
+}

--- a/ecosystem-explorer/src/v1/components/ecosystem/release-card.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/release-card.tsx
@@ -49,7 +49,10 @@ export function ReleaseCard({
 
   if (!version) {
     return (
-      <aside className={`td-release-card td-release-card--empty ${className ?? ""}`}>
+      <aside
+        className={`td-release-card td-release-card--empty ${className ?? ""}`}
+        aria-label={t("releaseCard.eyebrow")}
+      >
         <div className="td-release-card__eyebrow">{t("releaseCard.eyebrow")}</div>
         <p className="td-release-card__empty-msg">{t("releaseCard.empty")}</p>
       </aside>

--- a/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
+++ b/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
@@ -29,6 +29,7 @@
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { StabilityBadge } from "@/components/ui/stability-badge";
 import { type Stability, StatusPill } from "@/components/ui/status-pill";
+import { ReleaseCard } from "@/v1/components/ecosystem/release-card";
 import { CoverBlock } from "@/v1/components/home/cover-block";
 import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { GlobalSearch } from "@/v1/components/home/global-search";
@@ -212,6 +213,29 @@ export function DevComponentsPage() {
         bare
       >
         <RecentActivityRail />
+      </Section>
+
+      <Section id="release-card" title="ReleaseCard (full card + empty state)" bare>
+        {/* Wrapped in a dark surface so the glass-effect card reads correctly;
+            on the real ecosystem-landing page ReleaseCard lives inside the
+            <CoverBlock> aside slot. */}
+        <div
+          style={{
+            background: "hsl(var(--cover-block-bg-from-hsl))",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "1.5rem",
+            padding: "2rem 1.5rem",
+          }}
+        >
+          <ReleaseCard
+            version="v0.150.0"
+            releaseDate="May 2026"
+            deltas={{ added: 4, changed: 12, deprecated: 2 }}
+            hrefChangelog="https://opentelemetry.io/"
+          />
+          <ReleaseCard version={null} />
+        </div>
       </Section>
 
       <Section

--- a/ecosystem-explorer/src/v1/styles/index.css
+++ b/ecosystem-explorer/src/v1/styles/index.css
@@ -28,6 +28,7 @@
  * - signals-row.css  — v1 home signals row (`.td-signals-row`) — Traces/Metrics/Logs/Baggage
  * - global-search.css — v1 home global search input + dropdown (`.td-search*`)
  * - recent-activity-rail.css — v1 home recent-activity rail (`.td-activity-*`, `.td-pill*`)
+ * - release-card.css — v1 ecosystem-landing release card (`.td-release-card*`)
  * - home.css         — v1 home page wrapper + shared `td-box`/`td-two-col` chrome
  * - cncf-callout.css — sitewide CNCF band above the footer
  * - footer.css       — v1 footer (`.td-footer`) — mirrors opentelemetry.io
@@ -48,6 +49,7 @@
 @import "./signals-row.css";
 @import "./global-search.css";
 @import "./recent-activity-rail.css";
+@import "./release-card.css";
 @import "./home.css";
 @import "./cncf-callout.css";
 @import "./footer.css";

--- a/ecosystem-explorer/src/v1/styles/release-card.css
+++ b/ecosystem-explorer/src/v1/styles/release-card.css
@@ -39,7 +39,7 @@
 .td-release-card__version {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #f5a800;
+  color: hsl(var(--otel-orange-hsl));
 }
 
 .td-release-card__date {
@@ -72,10 +72,15 @@
 
 .td-release-card__changelog {
   margin-top: 0.5rem;
-  color: #f5a800;
+  color: hsl(var(--otel-orange-hsl));
   font-weight: 600;
   font-size: 0.875rem;
   text-decoration: none;
+}
+
+/* Decorative trailing arrow — kept out of the link's accessible name. */
+.td-release-card__changelog::after {
+  content: " \2192";
 }
 
 .td-release-card__changelog:hover,

--- a/ecosystem-explorer/src/v1/styles/release-card.css
+++ b/ecosystem-explorer/src/v1/styles/release-card.css
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ---------- Release card ---------- */
+
+.td-release-card {
+  background-color: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  backdrop-filter: blur(8px);
+}
+
+.td-release-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.td-release-card__version {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f5a800;
+}
+
+.td-release-card__date {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.td-release-card__deltas {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.td-release-card__delta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.td-release-card__delta-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.td-release-card__changelog {
+  margin-top: 0.5rem;
+  color: #f5a800;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+}
+
+.td-release-card__changelog:hover,
+.td-release-card__changelog:focus-visible {
+  text-decoration: underline;
+}
+
+.td-release-card__empty-msg {
+  margin: 0;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.65);
+}


### PR DESCRIPTION
Second PR of Phase 3 (ecosystem landing pages). Adds the `<ReleaseCard>` hero card.

Contributes to #372.

## What's in this PR

- Adds `<ReleaseCard>` (`src/v1/components/ecosystem/release-card.tsx`): the top-right hero card showing the latest version, optional release date, a delta strip (added / changed / deprecated), and an optional changelog link. Renders a named empty state when no release info is available
- Adds `src/v1/styles/release-card.css` (imported into the v1 stylesheet); the decorative changelog arrow is a CSS pseudo-element so it stays out of the link's accessible name, and the brand orange comes from the `--otel-orange-hsl` token
- Wires strings through i18next under a new `ecosystem` namespace (`public/locales/{en,es}/ecosystem.json`), registered in `src/i18n/config.ts` and `src/test/setup.ts`, following #650
- Adds the component to the `/_dev/components` showcase (full + empty variants)
- Unit tests for the populated and empty states

## What's not in this PR

- No consumer yet. The Collector and Java Agent landing routes compose it in later PRs
- The `ecosystem` namespace scaffolding (config / test setup / locale files) is shared with the sibling Phase 3 component PRs (PipelineAnatomy, QuickEntryRow); whichever lands first establishes it, the others need a trivial union-merge

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test -t "ReleaseCard"` — 2 tests pass
- `bun run format` — no changes

---

> Co-authored with Claude Opus 4.8.
