### PR TITLE
feat(v1): add PipelineAnatomy ecosystem-landing component (Phase 3 - PR 3)

### DIFF
--- a/ecosystem-explorer/public/locales/en/ecosystem.json
+++ b/ecosystem-explorer/public/locales/en/ecosystem.json
@@ -8,5 +8,9 @@
     "deprecated": "deprecated",
     "changelog": "View changelog",
     "empty": "Release information is not yet available for this ecosystem."
+  },
+  "pipelineAnatomy": {
+    "defaultTitle": "Pipeline anatomy",
+    "stageAriaLabel": "{{label}} — {{count}} components"
   }
 }

--- a/ecosystem-explorer/public/locales/es/ecosystem.json
+++ b/ecosystem-explorer/public/locales/es/ecosystem.json
@@ -8,5 +8,9 @@
     "deprecated": "obsoletos",
     "changelog": "Ver registro de cambios",
     "empty": "La información de la versión aún no está disponible para este ecosistema."
+  },
+  "pipelineAnatomy": {
+    "defaultTitle": "Anatomía del pipeline",
+    "stageAriaLabel": "{{label}} — {{count}} componentes"
   }
 }

--- a/ecosystem-explorer/src/v1/components/ecosystem/pipeline-anatomy.test.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/pipeline-anatomy.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { PipelineAnatomy } from "./pipeline-anatomy";
+
+const STAGES = [
+  {
+    id: "receiver",
+    label: "Receivers",
+    count: 98,
+    description: "Ingest data",
+    href: "/collector/components?type=receiver",
+  },
+  {
+    id: "processor",
+    label: "Processors",
+    count: 28,
+    description: "Transform data",
+    href: "/collector/components?type=processor",
+  },
+];
+
+describe("PipelineAnatomy", () => {
+  it("renders each stage as a link with the count and description", () => {
+    render(
+      <MemoryRouter>
+        <PipelineAnatomy title="Pipeline" stages={STAGES} />
+      </MemoryRouter>
+    );
+    const receiver = screen.getByRole("link", { name: /Receivers — 98 components/i });
+    expect(receiver).toHaveAttribute("href", "/collector/components?type=receiver");
+    expect(screen.getByText("Transform data")).toBeInTheDocument();
+  });
+
+  it("renders the section title and lead when provided", () => {
+    render(
+      <MemoryRouter>
+        <PipelineAnatomy title="Pipeline anatomy" lead="The flow of telemetry." stages={STAGES} />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("heading", { name: /Pipeline anatomy/i })).toBeInTheDocument();
+    expect(screen.getByText(/The flow of telemetry/i)).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/v1/components/ecosystem/pipeline-anatomy.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/pipeline-anatomy.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * PipelineAnatomy — array-driven horizontal stage strip. Each stage is a
+ * deep-link into the list page via the `listFilters` URL contract.
+ *
+ * Collector usage: 5 stages (receiver, processor, exporter, connector,
+ * extension) with the type-stripe color as the left edge. Java Agent uses
+ * the same component with semantic categories (e.g. HTTP / DB / messaging)
+ * — pass any stage IDs, the colors fall through `accentColor`.
+ *
+ * Layout: horizontal row with chevron separators on desktop; stacks
+ * vertically on mobile.
+ */
+
+import { ChevronRight } from "lucide-react";
+import { Fragment } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+export interface PipelineStage {
+  id: string;
+  label: string;
+  count: number | string;
+  description?: string;
+  href: string;
+  /** Optional accent color (CSS color value). Defaults to the foreground token. */
+  accentColor?: string;
+}
+
+export interface PipelineAnatomyProps {
+  /** Pipeline title rendered above the stages. */
+  title?: string;
+  /** Optional lead sentence below the title. */
+  lead?: string;
+  stages: PipelineStage[];
+  /** When true, hides the chevron between stages (use for category grids). */
+  noFlow?: boolean;
+}
+
+export function PipelineAnatomy({ title, lead, stages, noFlow = false }: PipelineAnatomyProps) {
+  const { t } = useTranslation("ecosystem");
+
+  return (
+    <section
+      className="td-pipeline-anatomy"
+      aria-label={title ?? t("pipelineAnatomy.defaultTitle")}
+    >
+      {title && <h2 className="td-pipeline-anatomy__title">{title}</h2>}
+      {lead && <p className="td-pipeline-anatomy__lead">{lead}</p>}
+      <div
+        className={`td-pipeline-anatomy__stages ${
+          noFlow ? "td-pipeline-anatomy__stages--grid" : ""
+        }`}
+      >
+        {stages.map((stage, idx) => (
+          <Fragment key={stage.id}>
+            <Link
+              to={stage.href}
+              className="td-pipeline-stage"
+              style={
+                stage.accentColor
+                  ? ({ ["--td-stage-accent" as never]: stage.accentColor } as React.CSSProperties)
+                  : undefined
+              }
+              aria-label={t("pipelineAnatomy.stageAriaLabel", {
+                label: stage.label,
+                count: stage.count,
+              })}
+            >
+              <span className="td-pipeline-stage__edge" aria-hidden />
+              <div className="td-pipeline-stage__count">{stage.count}</div>
+              <div className="td-pipeline-stage__label">{stage.label}</div>
+              {stage.description && (
+                <div className="td-pipeline-stage__description">{stage.description}</div>
+              )}
+            </Link>
+            {!noFlow && idx < stages.length - 1 && (
+              <ChevronRight
+                className="td-pipeline-anatomy__chevron"
+                aria-hidden
+                focusable="false"
+              />
+            )}
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
+++ b/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
@@ -30,6 +30,7 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { StabilityBadge } from "@/components/ui/stability-badge";
 import { type Stability, StatusPill } from "@/components/ui/status-pill";
 import { ReleaseCard } from "@/v1/components/ecosystem/release-card";
+import { type PipelineStage, PipelineAnatomy } from "@/v1/components/ecosystem/pipeline-anatomy";
 import { CoverBlock } from "@/v1/components/home/cover-block";
 import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { GlobalSearch } from "@/v1/components/home/global-search";
@@ -44,6 +45,84 @@ const STABILITIES: Stability[] = [
   "stable",
   "deprecated",
   "unmaintained",
+];
+
+// Collector pipeline: five stages with type-stripe accent colors and
+// deep-links into the list page via the `?type=` URL contract.
+const COLLECTOR_STAGES: PipelineStage[] = [
+  {
+    id: "receiver",
+    label: "Receivers",
+    count: 98,
+    description: "Ingest data",
+    href: "/collector/components?type=receiver",
+    accentColor: "hsl(200 85% 45%)",
+  },
+  {
+    id: "processor",
+    label: "Processors",
+    count: 28,
+    description: "Transform data",
+    href: "/collector/components?type=processor",
+    accentColor: "hsl(265 70% 55%)",
+  },
+  {
+    id: "exporter",
+    label: "Exporters",
+    count: 64,
+    description: "Send data onward",
+    href: "/collector/components?type=exporter",
+    accentColor: "hsl(150 65% 40%)",
+  },
+  {
+    id: "connector",
+    label: "Connectors",
+    count: 12,
+    description: "Bridge pipelines",
+    href: "/collector/components?type=connector",
+    accentColor: "hsl(35 90% 50%)",
+  },
+  {
+    id: "extension",
+    label: "Extensions",
+    count: 21,
+    description: "Add capabilities",
+    href: "/collector/components?type=extension",
+    accentColor: "hsl(0 75% 55%)",
+  },
+];
+
+// Category grid: stages without chevrons (noFlow) — semantic groupings
+// rather than an ordered pipeline.
+const CATEGORY_STAGES: PipelineStage[] = [
+  {
+    id: "http",
+    label: "HTTP",
+    count: 14,
+    description: "Web frameworks & clients",
+    href: "/java-agent/components?category=http",
+  },
+  {
+    id: "database",
+    label: "Databases",
+    count: 22,
+    description: "JDBC & NoSQL drivers",
+    href: "/java-agent/components?category=database",
+  },
+  {
+    id: "messaging",
+    label: "Messaging",
+    count: 9,
+    description: "Queues & streams",
+    href: "/java-agent/components?category=messaging",
+  },
+  {
+    id: "rpc",
+    label: "RPC",
+    count: 6,
+    description: "gRPC & service calls",
+    href: "/java-agent/components?category=rpc",
+  },
 ];
 
 const GLOW_VARIANTS = [
@@ -236,6 +315,31 @@ export function DevComponentsPage() {
           />
           <ReleaseCard version={null} />
         </div>
+      </Section>
+
+      <Section
+        id="pipeline-anatomy-flow"
+        title="PipelineAnatomy (Collector pipeline — five stages with chevron flow)"
+        bare
+      >
+        <PipelineAnatomy
+          title="Pipeline anatomy"
+          lead="The flow of telemetry through a Collector — receivers ingest, processors transform, exporters emit."
+          stages={COLLECTOR_STAGES}
+        />
+      </Section>
+
+      <Section
+        id="pipeline-anatomy-grid"
+        title="PipelineAnatomy (category grid — noFlow, no chevrons)"
+        bare
+      >
+        <PipelineAnatomy
+          title="Instrumentation categories"
+          lead="Semantic groupings rather than an ordered pipeline."
+          stages={CATEGORY_STAGES}
+          noFlow
+        />
       </Section>
 
       <Section

--- a/ecosystem-explorer/src/v1/styles/index.css
+++ b/ecosystem-explorer/src/v1/styles/index.css
@@ -30,6 +30,7 @@
  * - recent-activity-rail.css — v1 home recent-activity rail (`.td-activity-*`, `.td-pill*`)
  * - release-card.css — v1 ecosystem-landing release card (`.td-release-card*`)
  * - home.css         — v1 home page wrapper + shared `td-box`/`td-two-col` chrome
+ * - pipeline-anatomy.css — v1 ecosystem-landing pipeline strip (`.td-pipeline-anatomy*`, `.td-pipeline-stage*`)
  * - cncf-callout.css — sitewide CNCF band above the footer
  * - footer.css       — v1 footer (`.td-footer`) — mirrors opentelemetry.io
  *
@@ -51,5 +52,6 @@
 @import "./recent-activity-rail.css";
 @import "./release-card.css";
 @import "./home.css";
+@import "./pipeline-anatomy.css";
 @import "./cncf-callout.css";
 @import "./footer.css";

--- a/ecosystem-explorer/src/v1/styles/pipeline-anatomy.css
+++ b/ecosystem-explorer/src/v1/styles/pipeline-anatomy.css
@@ -1,0 +1,126 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ---------- Pipeline anatomy ---------- */
+
+.td-pipeline-anatomy__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.td-pipeline-anatomy__lead {
+  margin: 0 0 1.5rem;
+  color: hsl(var(--muted-foreground-hsl));
+  max-width: 60ch;
+}
+
+.td-pipeline-anatomy__stages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+@media (min-width: 768px) {
+  .td-pipeline-anatomy__stages {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+}
+
+.td-pipeline-anatomy__stages--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .td-pipeline-anatomy__stages--grid {
+    display: grid;
+  }
+}
+
+.td-pipeline-anatomy__chevron {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: hsl(var(--muted-foreground-hsl));
+  align-self: center;
+  flex-shrink: 0;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .td-pipeline-anatomy__chevron {
+    display: inline-block;
+  }
+}
+
+.td-pipeline-stage {
+  --td-stage-accent: hsl(var(--primary-hsl));
+  position: relative;
+  flex: 1 1 0;
+  min-width: 160px;
+  padding: 1rem 1rem 1rem 1.25rem;
+  background-color: hsl(var(--card-hsl));
+  border: 1px solid hsl(var(--border-hsl));
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: hsl(var(--foreground-hsl));
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.td-pipeline-stage:hover,
+.td-pipeline-stage:focus-visible {
+  border-color: var(--td-stage-accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  color: hsl(var(--foreground-hsl));
+}
+
+.td-pipeline-stage__edge {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background-color: var(--td-stage-accent);
+}
+
+.td-pipeline-stage__count {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--td-stage-accent);
+  line-height: 1;
+}
+
+.td-pipeline-stage__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.td-pipeline-stage__description {
+  font-size: 0.8125rem;
+  color: hsl(var(--muted-foreground-hsl));
+}

--- a/ecosystem-explorer/src/v1/styles/pipeline-anatomy.css
+++ b/ecosystem-explorer/src/v1/styles/pipeline-anatomy.css
@@ -49,12 +49,6 @@
   gap: 0.75rem;
 }
 
-@media (min-width: 768px) {
-  .td-pipeline-anatomy__stages--grid {
-    display: grid;
-  }
-}
-
 .td-pipeline-anatomy__chevron {
   width: 1.25rem;
   height: 1.25rem;


### PR DESCRIPTION
Third PR of Phase 3 (ecosystem landing pages). Adds the `<PipelineAnatomy>` stage strip.

Contributes to #372.

## What's in this PR

- Adds `<PipelineAnatomy>` (`src/v1/components/ecosystem/pipeline-anatomy.tsx`): an array-driven horizontal stage strip where each stage is a deep-link into the list page. Chevron separators between stages on desktop; a `noFlow` grid mode for category-style diagrams (Java Agent). Stage accent color is set via an inline CSS custom property
- Adds `src/v1/styles/pipeline-anatomy.css` (imported into the v1 stylesheet)
- Wires strings through i18next under the `ecosystem` namespace (en / es), registered in config + test setup per #650
- Adds the component to the `/_dev/components` showcase (Collector 5-stage flow + a noFlow category grid)
- Unit tests for stage rendering and the title / lead

## What's not in this PR

- Stage `href`s are caller-provided. The Collector and Java Agent routes generate them via the `listFilters` URL contract in later PRs
- The `ecosystem` namespace scaffolding is shared with the sibling Phase 3 component PRs (ReleaseCard, QuickEntryRow); trivial union-merge needed depending on merge order

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test -t "PipelineAnatomy"` — 2 tests pass
- `bun run format` — no changes

---

> Co-authored with Claude Opus 4.8.
