### PR TITLE
feat(v1): add QuickEntryRow ecosystem-landing component (Phase 3 - PR 4)

### DIFF
--- a/ecosystem-explorer/public/locales/en/ecosystem.json
+++ b/ecosystem-explorer/public/locales/en/ecosystem.json
@@ -12,5 +12,8 @@
   "pipelineAnatomy": {
     "defaultTitle": "Pipeline anatomy",
     "stageAriaLabel": "{{label}} — {{count}} components"
+  },
+  "quickEntry": {
+    "defaultTitle": "Quick entries"
   }
 }

--- a/ecosystem-explorer/public/locales/es/ecosystem.json
+++ b/ecosystem-explorer/public/locales/es/ecosystem.json
@@ -12,5 +12,8 @@
   "pipelineAnatomy": {
     "defaultTitle": "Anatomía del pipeline",
     "stageAriaLabel": "{{label}} — {{count}} componentes"
+  },
+  "quickEntry": {
+    "defaultTitle": "Accesos rápidos"
   }
 }

--- a/ecosystem-explorer/src/v1/components/ecosystem/quick-entry-row.test.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/quick-entry-row.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+
+import { QuickEntryRow, type QuickEntryItem } from "./quick-entry-row";
+
+const items: QuickEntryItem[] = [
+  {
+    id: "most-used",
+    title: "Most-used components",
+    description: "Jump to the components the ecosystem leans on most.",
+    href: "/collector/components?sort=updated",
+  },
+  {
+    id: "core-contrib",
+    title: "Core vs. Contrib",
+    description: "Understand the split between core and contrib distributions.",
+    href: "https://opentelemetry.io/",
+    external: true,
+  },
+];
+
+function renderRow() {
+  return render(
+    <MemoryRouter>
+      <QuickEntryRow items={items} />
+    </MemoryRouter>
+  );
+}
+
+describe("QuickEntryRow", () => {
+  it("renders the default title as a heading", () => {
+    renderRow();
+    expect(screen.getByRole("heading", { level: 2, name: "Quick entries" })).toBeInTheDocument();
+  });
+
+  it("renders an internal item as a Link with the right href", () => {
+    renderRow();
+    const link = screen.getByRole("link", { name: /Most-used components/i });
+    expect(link).toHaveAttribute("href", "/collector/components?sort=updated");
+  });
+
+  it("renders an external item as an anchor with target and a safe rel", () => {
+    renderRow();
+    const link = screen.getByRole("link", { name: /Core vs\. Contrib/i });
+    expect(link).toHaveAttribute("href", "https://opentelemetry.io/");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+  });
+});

--- a/ecosystem-explorer/src/v1/components/ecosystem/quick-entry-row.tsx
+++ b/ecosystem-explorer/src/v1/components/ecosystem/quick-entry-row.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * QuickEntryRow — three small "shortcut" cards on the ecosystem landing,
+ * below the pipeline anatomy. Each item is a deep-link (internal or
+ * external) into a curated view (e.g. "Most-used components", "Core vs.
+ * Contrib", "Diff across versions").
+ *
+ * The component accepts 1-4 items; layout collapses to a responsive grid.
+ */
+
+import { ArrowRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+export interface QuickEntryItem {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  external?: boolean;
+  /** Lucide icon component or any ReactNode. */
+  icon?: React.ReactNode;
+}
+
+export interface QuickEntryRowProps {
+  /** Section heading; defaults to the `ecosystem` namespace's `quickEntry.defaultTitle`. */
+  title?: string;
+  items: QuickEntryItem[];
+}
+
+export function QuickEntryRow({ title, items }: QuickEntryRowProps) {
+  const { t } = useTranslation("ecosystem");
+  const heading = title ?? t("quickEntry.defaultTitle");
+
+  return (
+    <section className="td-quick-entry" aria-labelledby="quick-entry-title">
+      <h2 id="quick-entry-title" className="td-quick-entry__title">
+        {heading}
+      </h2>
+      <div className="td-quick-entry__grid">
+        {items.map((item) =>
+          item.external ? (
+            <a
+              key={item.id}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="td-quick-entry__card"
+            >
+              {item.icon && <div className="td-quick-entry__icon">{item.icon}</div>}
+              <div className="td-quick-entry__head">
+                <h3 className="td-quick-entry__card-title">{item.title}</h3>
+                <ArrowRight className="td-quick-entry__arrow" aria-hidden focusable="false" />
+              </div>
+              <p className="td-quick-entry__description">{item.description}</p>
+            </a>
+          ) : (
+            <Link key={item.id} to={item.href} className="td-quick-entry__card">
+              {item.icon && <div className="td-quick-entry__icon">{item.icon}</div>}
+              <div className="td-quick-entry__head">
+                <h3 className="td-quick-entry__card-title">{item.title}</h3>
+                <ArrowRight className="td-quick-entry__arrow" aria-hidden focusable="false" />
+              </div>
+              <p className="td-quick-entry__description">{item.description}</p>
+            </Link>
+          )
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
+++ b/ecosystem-explorer/src/v1/features/_dev/components-page.tsx
@@ -26,11 +26,14 @@
  * FooterV1 + CncfCallout), add its primitive to the relevant section.
  */
 
+import { GitCompare, LayoutGrid, Split } from "lucide-react";
+
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { StabilityBadge } from "@/components/ui/stability-badge";
 import { type Stability, StatusPill } from "@/components/ui/status-pill";
 import { ReleaseCard } from "@/v1/components/ecosystem/release-card";
 import { type PipelineStage, PipelineAnatomy } from "@/v1/components/ecosystem/pipeline-anatomy";
+import { QuickEntryRow } from "@/v1/components/ecosystem/quick-entry-row";
 import { CoverBlock } from "@/v1/components/home/cover-block";
 import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { GlobalSearch } from "@/v1/components/home/global-search";
@@ -339,6 +342,39 @@ export function DevComponentsPage() {
           lead="Semantic groupings rather than an ordered pipeline."
           stages={CATEGORY_STAGES}
           noFlow
+        />
+      </Section>
+
+      <Section
+        id="quick-entry-row"
+        title="QuickEntryRow (ecosystem-landing shortcut cards, internal + external)"
+        bare
+      >
+        <QuickEntryRow
+          items={[
+            {
+              id: "most-used",
+              title: "Most-used components",
+              description: "Jump to the components the ecosystem leans on most.",
+              href: "/collector/components?sort=updated",
+              icon: <LayoutGrid aria-hidden focusable="false" />,
+            },
+            {
+              id: "diff-versions",
+              title: "Diff across versions",
+              description: "Compare what changed between two registry snapshots.",
+              href: "/collector/components?compare=true",
+              icon: <GitCompare aria-hidden focusable="false" />,
+            },
+            {
+              id: "core-contrib",
+              title: "Core vs. Contrib",
+              description: "Understand the split between core and contrib distributions.",
+              href: "https://opentelemetry.io/",
+              external: true,
+              icon: <Split aria-hidden focusable="false" />,
+            },
+          ]}
         />
       </Section>
 

--- a/ecosystem-explorer/src/v1/styles/index.css
+++ b/ecosystem-explorer/src/v1/styles/index.css
@@ -31,6 +31,7 @@
  * - release-card.css — v1 ecosystem-landing release card (`.td-release-card*`)
  * - home.css         — v1 home page wrapper + shared `td-box`/`td-two-col` chrome
  * - pipeline-anatomy.css — v1 ecosystem-landing pipeline strip (`.td-pipeline-anatomy*`, `.td-pipeline-stage*`)
+ * - quick-entry-row.css — v1 ecosystem-landing quick-entry row (`.td-quick-entry*`)
  * - cncf-callout.css — sitewide CNCF band above the footer
  * - footer.css       — v1 footer (`.td-footer`) — mirrors opentelemetry.io
  *
@@ -53,5 +54,6 @@
 @import "./release-card.css";
 @import "./home.css";
 @import "./pipeline-anatomy.css";
+@import "./quick-entry-row.css";
 @import "./cncf-callout.css";
 @import "./footer.css";

--- a/ecosystem-explorer/src/v1/styles/quick-entry-row.css
+++ b/ecosystem-explorer/src/v1/styles/quick-entry-row.css
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ---------- Quick entry ---------- */
+
+.td-quick-entry__title {
+  margin: 0 0 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.td-quick-entry__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .td-quick-entry__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.td-quick-entry__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  background-color: hsl(var(--background-hsl));
+  border: 1px solid hsl(var(--border-hsl));
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: hsl(var(--foreground-hsl));
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.td-quick-entry__card:hover,
+.td-quick-entry__card:focus-visible {
+  border-color: hsl(var(--primary-hsl) / 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  color: hsl(var(--foreground-hsl));
+}
+
+.td-quick-entry__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.375rem;
+  background-color: hsl(var(--primary-hsl) / 0.1);
+  color: hsl(var(--primary-hsl));
+}
+
+.td-quick-entry__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.td-quick-entry__card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.td-quick-entry__arrow {
+  width: 1rem;
+  height: 1rem;
+  color: hsl(var(--muted-foreground-hsl));
+  transition: transform 0.15s ease;
+}
+
+.td-quick-entry__card:hover .td-quick-entry__arrow,
+.td-quick-entry__card:focus-visible .td-quick-entry__arrow {
+  transform: translateX(2px);
+  color: hsl(var(--primary-hsl));
+}
+
+.td-quick-entry__description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground-hsl));
+}


### PR DESCRIPTION
Fourth PR of Phase 3 (ecosystem landing pages). Adds the `<QuickEntryRow>` shortcut cards.

Contributes to #372.

## What's in this PR

- Adds `<QuickEntryRow>` (`src/v1/components/ecosystem/quick-entry-row.tsx`): a row of shortcut cards (internal `<Link>` or external `<a>`) below the pipeline anatomy. Item content is caller-provided; the section title defaults through i18next. External links carry `rel="noopener noreferrer"`
- Adds `src/v1/styles/quick-entry-row.css` (imported into the v1 stylesheet)
- Wires the default title through i18next under the `ecosystem` namespace (en / es), registered in config + test setup per #650
- Adds the component to the `/_dev/components` showcase
- Unit test covering the internal link href and the external link's `target` / `rel`

## What's not in this PR

- No consumer yet; the landing routes supply the curated items in later PRs
- The `ecosystem` namespace scaffolding is shared with the sibling Phase 3 component PRs (ReleaseCard, PipelineAnatomy); trivial union-merge depending on order

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test -t "QuickEntryRow"` — 3 tests pass
- `bun run format` — no changes

---

> Co-authored with Claude Opus 4.8.
