### PR TITLE
Add collector watcher backfill job and fix bug

### DIFF
--- a/.github/workflows/collector-schema-backfill.yml
+++ b/.github/workflows/collector-schema-backfill.yml
@@ -1,0 +1,183 @@
+name: Collector Schema Backfill
+
+# Manually re-extracts collector registry versions with the current watcher
+# logic and opens a PR with the result. Use this after a change to how the
+# schema hash is computed (e.g. normalization or dump-option changes), or after
+# adding a metadata parser, so historical versions are re-stamped and the schema
+# store stays deduplicated. The diff on the PR is the review surface — eyeball
+# the per-version `schema_hash` changes before merging.
+
+on:
+  workflow_dispatch:
+    inputs:
+      distribution:
+        description: "Distribution to backfill"
+        type: choice
+        default: all
+        options:
+          - all
+          - core
+          - contrib
+      versions:
+        description:
+          "Comma-separated versions (e.g. 0.144.0,0.145.0). Empty = all existing versions."
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read # Default minimum; the job declares its own elevated scopes below
+
+concurrency:
+  # Single in-flight run since all runs target the shared backfill branch.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill collector schema hashes
+    permissions:
+      contents: write # Push the backfill result to the otelbot/collector-schema-backfill branch
+      pull-requests: write # Create or update the backfill PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect repository type (if on a fork we use different git config)
+        id: repo_check
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$REPO" == "open-telemetry/opentelemetry-ecosystem-explorer" ]; then
+            echo "is_primary=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_primary=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Mint the otelbot App token for the PR operations below. The branch push
+      # authenticates as GITHUB_TOKEN (the App has no `contents: write`); we
+      # re-trigger required checks afterwards by closing and reopening the PR
+      # with this App token (see the "Commit and push changes" step).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: steps.repo_check.outputs.is_primary == 'true'
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-pull-requests: write # Create / edit / reopen the backfill PR
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Persist GITHUB_TOKEN as the git credential for the branch push. A
+          # push authenticated with GITHUB_TOKEN does not start workflows, so the
+          # "Commit and push changes" step re-triggers the required checks by
+          # closing/reopening the PR with the otelbot App token.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Configure git (primary repository)
+        if: steps.repo_check.outputs.is_primary == 'true'
+        run: |
+          .github/scripts/use-cla-approved-bot.sh
+
+      - name: Configure git (forked repository)
+        if: steps.repo_check.outputs.is_primary == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Cache repository clones
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: tmp_repos
+          key: tmp-repos
+          restore-keys: |
+            tmp-repos-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run collector-watcher backfill
+        id: backfill
+        env:
+          DISTRIBUTION: ${{ inputs.distribution }}
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          # Backfill clones both core and contrib regardless of scope, so the
+          # core mdatagen schema is always resolvable at each version's ref.
+          ARGS=(--backfill)
+          if [ "$DISTRIBUTION" != "all" ]; then
+            ARGS+=(--distribution "$DISTRIBUTION")
+          fi
+          if [ -n "$VERSIONS" ]; then
+            ARGS+=(--versions "$VERSIONS")
+          fi
+          echo "Running: uv run collector-watcher ${ARGS[*]}"
+          uv run collector-watcher "${ARGS[@]}"
+
+      - name: Check for registry changes
+        id: check_changes
+        run: |
+          git add -N ecosystem-registry/ 2>/dev/null || true
+          if git diff --quiet ecosystem-registry/ && [ -z "$(git ls-files --others --exclude-standard ecosystem-registry/)" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: No changes
+        if: steps.check_changes.outputs.has_changes == 'false'
+        run: echo "Backfill produced no registry changes — nothing to open a PR for."
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN:
+            ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token
+            || secrets.GITHUB_TOKEN }}
+          DISTRIBUTION: ${{ inputs.distribution }}
+          VERSIONS: ${{ inputs.versions }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          BRANCH="otelbot/collector-schema-backfill"
+
+          git add ecosystem-registry/
+          git commit -m "Backfill collector schema hashes (${DISTRIBUTION}${VERSIONS:+: $VERSIONS})"
+          git push -f origin HEAD:${BRANCH}
+
+          PR_TITLE="[automated] Backfill collector schema hashes"
+          PR_BODY="Re-extracted collector registry versions via \`collector-watcher --backfill\`.
+
+          - **Distribution:** ${DISTRIBUTION}
+          - **Versions:** ${VERSIONS:-all existing}
+
+          Review the per-version \`schema_hash\` changes in the diff. Contrib versions must carry the *same* hash as the matching core version; if every contrib version shares one hash, that is the bug this workflow's fix guards against.
+
+          See [workflow run](https://github.com/${REPO}/actions/runs/${RUN_ID}).
+
+          ---
+          _Generated by the Collector Schema Backfill workflow._"
+
+          if gh pr list --head ${BRANCH} --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "Open PR already exists, updating..."
+            gh pr edit ${BRANCH} --title "${PR_TITLE}" --body "${PR_BODY}"
+            # The force-push above is authenticated with GITHUB_TOKEN, which does
+            # not start workflows. Closing and reopening with the otelbot App
+            # token re-runs the required checks against the updated head.
+            gh pr close ${BRANCH}
+            gh pr reopen ${BRANCH}
+          else
+            echo "Creating new PR..."
+            gh pr create --title "${PR_TITLE}" --body "${PR_BODY}" --base main --head ${BRANCH}
+          fi

--- a/.github/workflows/collector-schema-backfill.yml
+++ b/.github/workflows/collector-schema-backfill.yml
@@ -10,17 +10,10 @@ name: Collector Schema Backfill
 on:
   workflow_dispatch:
     inputs:
-      distribution:
-        description: "Distribution to backfill"
-        type: choice
-        default: all
-        options:
-          - all
-          - core
-          - contrib
       versions:
         description:
-          "Comma-separated versions (e.g. 0.144.0,0.145.0). Empty = all existing versions."
+          "Optional comma-separated versions to scope the backfill (e.g. 0.144.0,0.145.0). Empty =
+          all existing versions, both distributions."
         type: string
         required: false
         default: ""
@@ -110,15 +103,12 @@ jobs:
       - name: Run collector-watcher backfill
         id: backfill
         env:
-          DISTRIBUTION: ${{ inputs.distribution }}
           VERSIONS: ${{ inputs.versions }}
         run: |
-          # Backfill clones both core and contrib regardless of scope, so the
-          # core mdatagen schema is always resolvable at each version's ref.
+          # Backfill re-extracts both core and contrib. Contrib's schema is
+          # resolved from the core clone at each version's ref, so both
+          # distributions stay in sync regardless of scope.
           ARGS=(--backfill)
-          if [ "$DISTRIBUTION" != "all" ]; then
-            ARGS+=(--distribution "$DISTRIBUTION")
-          fi
           if [ -n "$VERSIONS" ]; then
             ARGS+=(--versions "$VERSIONS")
           fi
@@ -145,7 +135,6 @@ jobs:
           GH_TOKEN:
             ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token
             || secrets.GITHUB_TOKEN }}
-          DISTRIBUTION: ${{ inputs.distribution }}
           VERSIONS: ${{ inputs.versions }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
@@ -153,13 +142,12 @@ jobs:
           BRANCH="otelbot/collector-schema-backfill"
 
           git add ecosystem-registry/
-          git commit -m "Backfill collector schema hashes (${DISTRIBUTION}${VERSIONS:+: $VERSIONS})"
+          git commit -m "Backfill collector schema hashes${VERSIONS:+ ($VERSIONS)}"
           git push -f origin HEAD:${BRANCH}
 
           PR_TITLE="[automated] Backfill collector schema hashes"
           PR_BODY="Re-extracted collector registry versions via \`collector-watcher --backfill\`.
 
-          - **Distribution:** ${DISTRIBUTION}
           - **Versions:** ${VERSIONS:-all existing}
 
           Review the per-version \`schema_hash\` changes in the diff. Contrib versions must carry the *same* hash as the matching core version; if every contrib version shares one hash, that is the bug this workflow's fix guards against.

--- a/.github/workflows/regenerate-collector-registry.yml
+++ b/.github/workflows/regenerate-collector-registry.yml
@@ -1,11 +1,10 @@
-name: Collector Schema Backfill
+name: Regenerate Collector Registry
 
-# Manually re-extracts collector registry versions with the current watcher
+# Re-generate collector registry versions with the current watcher
 # logic and opens a PR with the result. Use this after a change to how the
 # schema hash is computed (e.g. normalization or dump-option changes), or after
 # adding a metadata parser, so historical versions are re-stamped and the schema
-# store stays deduplicated. The diff on the PR is the review surface — eyeball
-# the per-version `schema_hash` changes before merging.
+# store stays deduplicated.
 
 on:
   workflow_dispatch:
@@ -28,9 +27,9 @@ concurrency:
 
 jobs:
   backfill:
-    name: Backfill collector schema hashes
+    name: Regenerate collector registry and open PR
     permissions:
-      contents: write # Push the backfill result to the otelbot/collector-schema-backfill branch
+      contents: write # Push the backfill result to the otelbot/collector-registry-regenerate branch
       pull-requests: write # Create or update the backfill PR
     runs-on: ubuntu-latest
     steps:
@@ -139,18 +138,16 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
         run: |
-          BRANCH="otelbot/collector-schema-backfill"
+          BRANCH="otelbot/collector-registry-regenerate"
 
           git add ecosystem-registry/
-          git commit -m "Backfill collector schema hashes${VERSIONS:+ ($VERSIONS)}"
+          git commit -m "Backfill collector registry${VERSIONS:+ ($VERSIONS)}"
           git push -f origin HEAD:${BRANCH}
 
-          PR_TITLE="[automated] Backfill collector schema hashes"
+          PR_TITLE="[automated] Regenerate Collector Registry"
           PR_BODY="Re-extracted collector registry versions via \`collector-watcher --backfill\`.
 
           - **Versions:** ${VERSIONS:-all existing}
-
-          Review the per-version \`schema_hash\` changes in the diff. Contrib versions must carry the *same* hash as the matching core version; if every contrib version shares one hash, that is the bug this workflow's fix guards against.
 
           See [workflow run](https://github.com/${REPO}/actions/runs/${RUN_ID}).
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -63,6 +63,10 @@ class CollectorSync:
         self.deprecations = inventory_manager.load_deprecations()
         self.previous_versions: dict[DistributionName, Version | None] = {}
         self.previous_components: dict[DistributionName, dict[str, list[dict[str, Any]]]] = {}
+        # Cache of core release tags for the lifetime of the sync run. get_all_release_tags()
+        # shells out to `git tag --list`, and _core_schema_refs() is called once per version;
+        # caching avoids an extra git process per saved version during a backfill.
+        self._core_release_tags: list[Version] | None = None
 
     @staticmethod
     def get_repository_name(distribution: DistributionName) -> str:
@@ -241,8 +245,11 @@ class CollectorSync:
         if version.prerelease:
             return ["main"]
 
+        if self._core_release_tags is None:
+            self._core_release_tags = self.version_detectors["core"].get_all_release_tags()
+
         refs = [f"v{version}"]
-        earlier = [v for v in self.version_detectors["core"].get_all_release_tags() if not v.prerelease and v < version]
+        earlier = [v for v in self._core_release_tags if not v.prerelease and v < version]
         if earlier:
             refs.append(f"v{max(earlier)}")
         refs.append("main")

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -15,7 +15,6 @@
 """Collector metadata synchronization to registry."""
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from semantic_version import Version
@@ -24,7 +23,7 @@ from watcher_common.version_detector import VersionDetector
 from .component_scanner import ComponentScanner
 from .deprecation_detector import DeprecationDetector
 from .inventory_manager import InventoryManager
-from .schema_copier import CollectorSchemaCopier
+from .schema_copier import SCHEMA_RELATIVE_PATH, UNKNOWN_HASH, CollectorSchemaCopier
 from .type_defs import DistributionName
 
 logger = logging.getLogger(__name__)
@@ -59,6 +58,7 @@ class CollectorSync:
         self.repos = repos
         self.inventory_manager = inventory_manager
         self.version_detectors = {dist: VersionDetector(path) for dist, path in repos.items()}
+        self.schema_copier = CollectorSchemaCopier()
         self.deprecation_detector = DeprecationDetector()
         self.deprecations = inventory_manager.load_deprecations()
         self.previous_versions: dict[DistributionName, Version | None] = {}
@@ -172,7 +172,9 @@ class CollectorSync:
 
         Schema is always read from the core repo: ``mdatagen`` lives only in
         ``opentelemetry-collector``, and the schema is identical across
-        distributions, so contrib carries the same ``schema_hash`` as core.
+        distributions, so contrib carries the same ``schema_hash`` as core. The
+        schema is resolved at ``version``'s ref (see ``_resolve_schema_hash``),
+        not the core clone's current checkout.
 
         Registry layout after this call:
             ecosystem-registry/collector/
@@ -184,10 +186,7 @@ class CollectorSync:
             version: Version being saved
             components: Scanned components
         """
-        copier = CollectorSchemaCopier()
-        core_repo_path = Path(self.repos["core"])
-        stored_hash = copier.store_schema(core_repo_path, self.inventory_manager.meta_schemas_dir())
-        schema_hash = stored_hash if stored_hash is not None else "unknown"
+        schema_hash = self._resolve_schema_hash(version)
 
         repository = self.get_repository_name(distribution)
         self.inventory_manager.save_versioned_inventory(
@@ -199,6 +198,74 @@ class CollectorSync:
         )
 
         logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
+
+    def _resolve_schema_hash(self, version: Version) -> str:
+        """Store and return the core ``metadata-schema.yaml`` hash for ``version``.
+
+        ``mdatagen`` lives only in ``opentelemetry-collector``, so every
+        distribution records the *core* schema at the matching version. The
+        schema is read from the core repo *at that version's git ref* rather than
+        the clone's current checkout: a backfill processes core fully and then
+        contrib fully, leaving the core clone on ``main``, so a checkout-dependent
+        read would stamp every contrib version with the latest schema instead of
+        its own (see issue #583 follow-up).
+
+        Falls back through ``_core_schema_refs`` when the exact tag is missing,
+        logging which ref was actually used. Returns ``UNKNOWN_HASH`` when no
+        core ref yields the schema (older tags that pre-date the file).
+
+        Args:
+            version: Version being saved.
+
+        Returns:
+            The 12-char schema hash, or ``UNKNOWN_HASH``.
+        """
+        core = self.version_detectors["core"]
+        schemas_dir = self.inventory_manager.meta_schemas_dir()
+
+        candidate_refs = self._core_schema_refs(version)
+        for index, ref in enumerate(candidate_refs):
+            content = core.read_file_at_ref(ref, SCHEMA_RELATIVE_PATH)
+            if content is None:
+                continue
+            if index > 0:
+                logger.warning(
+                    "Core schema not found at %s for %s; using %s instead",
+                    candidate_refs[0],
+                    version,
+                    ref,
+                )
+            stored = self.schema_copier.store_schema_content(content, schemas_dir)
+            return stored if stored is not None else UNKNOWN_HASH
+
+        logger.warning(
+            "No core schema found for %s (tried: %s); recording %s",
+            version,
+            ", ".join(candidate_refs),
+            UNKNOWN_HASH,
+        )
+        return UNKNOWN_HASH
+
+    def _core_schema_refs(self, version: Version) -> list[str]:
+        """Ordered core git refs to try when resolving the schema for ``version``.
+
+        Exact version tag first; then the nearest *earlier* core release (covers
+        versions core never tagged, e.g. a contrib release whose core counterpart
+        is a different patch); ``main`` last so a brand-new version still resolves
+        to the current schema rather than ``UNKNOWN_HASH``.
+
+        Prereleases (SNAPSHOTs) are built from ``main``, so they resolve to
+        ``main`` only.
+        """
+        if version.prerelease:
+            return ["main"]
+
+        refs = [f"v{version}"]
+        earlier = [v for v in self.version_detectors["core"].get_all_release_tags() if not v.prerelease and v < version]
+        if earlier:
+            refs.append(f"v{max(earlier)}")
+        refs.append("main")
+        return refs
 
     def initialize_previous_version(self, distribution: DistributionName) -> None:
         """
@@ -341,9 +408,9 @@ class CollectorSync:
 
     def _process_distribution_sync(self, distribution: DistributionName) -> tuple[Version | None, Version]:
         latest = self.process_latest_release(distribution)
-        
+
         snapshot = self.update_snapshot(distribution)
-        
+
         return (latest, snapshot)
 
     def sync(self) -> dict[str, Any]:
@@ -376,7 +443,7 @@ class CollectorSync:
 
                 latest, snapshot = self._process_distribution_sync(distribution)
                 distribution_results[distribution] = (latest, snapshot)
-                
+
         except Exception as e:
             logger.error("Error processing distributions: %s", e)
             raise

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -172,9 +172,7 @@ class CollectorSync:
 
         Schema is always read from the core repo: ``mdatagen`` lives only in
         ``opentelemetry-collector``, and the schema is identical across
-        distributions, so contrib carries the same ``schema_hash`` as core. The
-        schema is resolved at ``version``'s ref (see ``_resolve_schema_hash``),
-        not the core clone's current checkout.
+        distributions, so contrib carries the same ``schema_hash`` as core.
 
         Registry layout after this call:
             ecosystem-registry/collector/
@@ -200,25 +198,14 @@ class CollectorSync:
         logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
 
     def _resolve_schema_hash(self, version: Version) -> str:
-        """Store and return the core ``metadata-schema.yaml`` hash for ``version``.
+        """Store and return the core schema hash for ``version``.
 
-        ``mdatagen`` lives only in ``opentelemetry-collector``, so every
-        distribution records the *core* schema at the matching version. The
-        schema is read from the core repo *at that version's git ref* rather than
-        the clone's current checkout: a backfill processes core fully and then
-        contrib fully, leaving the core clone on ``main``, so a checkout-dependent
-        read would stamp every contrib version with the latest schema instead of
-        its own (see issue #583 follow-up).
-
-        Falls back through ``_core_schema_refs`` when the exact tag is missing,
-        logging which ref was actually used. Returns ``UNKNOWN_HASH`` when no
-        core ref yields the schema (older tags that pre-date the file).
-
-        Args:
-            version: Version being saved.
-
-        Returns:
-            The 12-char schema hash, or ``UNKNOWN_HASH``.
+        ``mdatagen`` lives only in core, so every distribution records the core
+        schema at its version. The schema is read from the core repo at that
+        version's git ref, not the clone's current checkout — a backfill leaves
+        the core clone on ``main``, which would otherwise stamp every version
+        with the latest schema. Falls back through ``_core_schema_refs`` (with a
+        warning) and returns ``UNKNOWN_HASH`` if no ref yields the schema.
         """
         core = self.version_detectors["core"]
         schemas_dir = self.inventory_manager.meta_schemas_dir()
@@ -247,15 +234,9 @@ class CollectorSync:
         return UNKNOWN_HASH
 
     def _core_schema_refs(self, version: Version) -> list[str]:
-        """Ordered core git refs to try when resolving the schema for ``version``.
-
-        Exact version tag first; then the nearest *earlier* core release (covers
-        versions core never tagged, e.g. a contrib release whose core counterpart
-        is a different patch); ``main`` last so a brand-new version still resolves
-        to the current schema rather than ``UNKNOWN_HASH``.
-
-        Prereleases (SNAPSHOTs) are built from ``main``, so they resolve to
-        ``main`` only.
+        """Ordered core refs to try for ``version``'s schema: exact tag, then the
+        nearest earlier core release (for versions core never tagged), then
+        ``main``. Prereleases (SNAPSHOTs) are built from ``main`` only.
         """
         if version.prerelease:
             return ["main"]

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/schema_copier.py
@@ -22,7 +22,6 @@ holding that schema (no version directory lookup required).
 """
 
 import logging
-import shutil
 from pathlib import Path
 
 import yaml
@@ -36,62 +35,86 @@ UNKNOWN_HASH = "unknown"
 
 
 class CollectorSchemaCopier:
-    """Stores metadata-schema.yaml from a collector repo into content-addressable storage."""
+    """Stores metadata-schema.yaml content into content-addressable storage.
 
-    def store_schema(self, repo_path: Path, schemas_dir: Path) -> str | None:
+    The hash is computed from the *normalized* YAML representation of the schema
+    (``yaml.safe_load`` then ``yaml.safe_dump`` with stable options), so
+    comment-only, formatting, and key-order changes upstream do not churn the
+    store. The stored file keeps the original content verbatim — only the file
+    *name* is derived from the normalized hash.
+
+    Callers pass the schema *content* (read from a pinned git ref via
+    ``VersionDetector.read_file_at_ref``) rather than a working-tree path, so the
+    hash is a pure function of the content and never depends on which revision a
+    clone happens to be checked out to.
+    """
+
+    def store_schema_content(self, content: str | None, schemas_dir: Path) -> str | None:
         """
-        Copy metadata-schema.yaml from the upstream repo into a hash-named file.
+        Store schema content into a hash-named file under ``schemas_dir``.
 
         The destination is ``schemas_dir / f"{schema_hash}.yaml"``. If a file
-        with that name already exists (because the same schema content was
-        stored previously), the copy is skipped — the existing file is the
-        canonical record. Returns the schema hash on success. The schema hash
-        is computed from the normalized YAML content (ignoring comments and key order).
+        with that name already exists (the same schema content was stored
+        previously, possibly by another version or distribution), the write is
+        skipped — the existing file is the canonical record.
 
         Args:
-            repo_path: Path to the checked-out collector repository.
+            content: Raw ``metadata-schema.yaml`` text, or None when the schema
+                file is absent at the requested ref (older tags pre-date it).
             schemas_dir: Content-addressable storage directory (typically
                 ``ecosystem-registry/collector/meta/schemas``).
 
         Returns:
-            The 12-char schema hash on success, or None if the upstream repo
-            does not contain ``cmd/mdatagen/metadata-schema.yaml`` (older tags
-            pre-date the file).
+            The 12-char schema hash on success, or None when ``content`` is None.
         """
-        src = repo_path / SCHEMA_RELATIVE_PATH
-        if not src.exists():
-            logger.debug("Schema file not found in repo at %s, skipping store", src)
+        if content is None:
             return None
 
-        schema_hash = self.compute_schema_hash(src)
+        schema_hash = self.compute_schema_hash(content)
         dst = schemas_dir / f"{schema_hash}.yaml"
         if dst.exists():
-            logger.debug("Schema %s already stored at %s, skipping copy", schema_hash, dst)
+            logger.debug("Schema %s already stored at %s, skipping write", schema_hash, dst)
             return schema_hash
 
         schemas_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dst)
+        dst.write_text(content, encoding="utf-8")
         logger.debug("Stored schema %s at %s", schema_hash, dst)
         return schema_hash
 
-    def compute_schema_hash(self, schema_path: Path) -> str:
+    def compute_schema_hash(self, content: str | None) -> str:
         """
-        Compute the content hash of a schema file, ignoring comments and formatting.
+        Compute the content hash of schema content, ignoring comments and key order.
 
-        The hash is computed from the normalized YAML representation of the schema.
-        Returns ``UNKNOWN_HASH`` when the file is absent — used by component
+        The hash is taken over the normalized YAML representation, so two schemas
+        that differ only in comments, formatting, or key order hash identically.
+
+        Returns ``UNKNOWN_HASH`` when ``content`` is None — used by component
         YAMLs scanned from older collector tags that pre-date the schema file.
 
         Args:
-            schema_path: Path to the schema file.
+            content: Raw schema text, or None.
 
         Returns:
             12-character hex hash, or ``UNKNOWN_HASH``.
         """
-        if not schema_path.exists():
+        if content is None:
             return UNKNOWN_HASH
+        return compute_content_hash(self._normalize(content))
 
-        with open(schema_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        normalized_yaml = yaml.safe_dump(data, sort_keys=True)
-        return compute_content_hash(normalized_yaml)
+    @staticmethod
+    def _normalize(content: str) -> str:
+        """Return a canonical YAML rendering of ``content``.
+
+        Dump options are pinned (not left to PyYAML defaults) so the canonical
+        form — and therefore every schema hash — stays stable across PyYAML
+        upgrades. Changing these options re-hashes every schema and requires a
+        full backfill to keep the store deduplicated.
+        """
+        data = yaml.safe_load(content)
+        return yaml.safe_dump(
+            data,
+            sort_keys=True,
+            default_flow_style=False,
+            allow_unicode=True,
+            width=4096,
+        )

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -14,6 +14,7 @@
 #
 """Tests for collector sync."""
 
+import logging
 import shutil
 import tempfile
 from pathlib import Path
@@ -26,6 +27,24 @@ from collector_watcher.collector_sync import CollectorSync
 from collector_watcher.inventory_manager import InventoryManager
 from semantic_version import Version
 from watcher_common.testing import init_repo, run_git
+
+
+def set_core_schema(repo_path, content, tag=None):
+    """Commit ``content`` as core's metadata-schema.yaml and optionally (re)tag.
+
+    The schema is now read from a pinned git ref (``git show {ref}:...``), not
+    the working tree, so tests must commit it. When ``tag`` is given it is
+    force-created at the new commit so ``git show {tag}:...`` returns ``content``;
+    when omitted, only ``main`` advances (used to simulate a schema that changed
+    on main after a release was tagged).
+    """
+    schema_path = Path(repo_path) / "cmd" / "mdatagen" / "metadata-schema.yaml"
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    schema_path.write_text(content)
+    run_git(repo_path, "add", "-A")
+    run_git(repo_path, "commit", "-m", f"schema {tag or 'main'}")
+    if tag is not None:
+        run_git(repo_path, "tag", "-f", tag)
 
 
 @pytest.fixture
@@ -144,10 +163,8 @@ def test_save_version_writes_schema_hash_when_schema_present(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
     """When the upstream repo has metadata-schema.yaml, schema_hash is a 12-char hex."""
-    # Plant a fake schema file in the repo the sync uses for "core"
-    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+    # Commit a schema into core at the version's tag (read via git ref, not the tree).
+    set_core_schema(temp_git_repos["core"], "type: object\n", tag="v0.112.0")
 
     version = Version("0.112.0")
     collector_sync.save_version("core", version, sample_components)
@@ -166,10 +183,8 @@ def test_save_version_contrib_reads_schema_hash_from_core(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
     """Contrib has no mdatagen — its schema_hash must come from the core repo."""
-    # Plant a schema file in core only. Contrib intentionally has none.
-    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+    # Commit a schema in core only. Contrib intentionally has none.
+    set_core_schema(temp_git_repos["core"], "type: object\n", tag="v0.112.0")
 
     version = Version("0.112.0")
     collector_sync.save_version("core", version, sample_components)
@@ -188,9 +203,7 @@ def test_save_version_stores_schema_in_cas_when_present(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
     """The schema is stored at meta/schemas/{hash}.yaml, not under a distribution directory."""
-    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+    set_core_schema(temp_git_repos["core"], "type: object\n", tag="v0.112.0")
 
     version = Version("0.112.0")
     collector_sync.save_version("core", version, sample_components)
@@ -211,9 +224,7 @@ def test_save_version_cas_dedupes_across_distributions(
     collector_sync, sample_components, temp_inventory_dir, temp_git_repos
 ):
     """Saving core and contrib at the same schema content yields a single CAS file."""
-    schema_dir = Path(temp_git_repos["core"]) / "cmd" / "mdatagen"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    (schema_dir / "metadata-schema.yaml").write_text("type: object\n")
+    set_core_schema(temp_git_repos["core"], "type: object\n", tag="v0.112.0")
 
     version = Version("0.112.0")
     collector_sync.save_version("contrib", version, sample_components)
@@ -232,6 +243,89 @@ def test_save_version_does_not_create_schema_file_when_absent(collector_sync, sa
     schemas_dir = temp_inventory_dir / "meta" / "schemas"
     assert not schemas_dir.exists() or not any(schemas_dir.iterdir())
     assert not (temp_inventory_dir / "core" / "v0.112.0" / "metadata-schema.yaml").exists()
+
+
+def _hash_for(collector_sync, content):
+    return collector_sync.schema_copier.compute_schema_hash(content)
+
+
+def test_save_version_resolves_schema_per_version(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """Each version records the schema committed at its own tag, not a shared one."""
+    set_core_schema(temp_git_repos["core"], "type: object\nv: a\n", tag="v0.111.0")
+    set_core_schema(temp_git_repos["core"], "type: object\nv: b\n", tag="v0.112.0")
+
+    collector_sync.save_version("core", Version("0.111.0"), sample_components)
+    collector_sync.save_version("core", Version("0.112.0"), sample_components)
+
+    with open(temp_inventory_dir / "core" / "v0.111.0" / "receiver.yaml") as f:
+        hash_111 = yaml.safe_load(f)["schema_hash"]
+    with open(temp_inventory_dir / "core" / "v0.112.0" / "receiver.yaml") as f:
+        hash_112 = yaml.safe_load(f)["schema_hash"]
+
+    assert hash_111 == _hash_for(collector_sync, "type: object\nv: a\n")
+    assert hash_112 == _hash_for(collector_sync, "type: object\nv: b\n")
+    assert hash_111 != hash_112
+
+
+def test_save_version_contrib_uses_core_schema_at_version_not_head(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    """Regression: contrib must record core's schema *at its version*, not whatever
+    core is currently checked out to. A backfill processes core then contrib,
+    leaving the core clone on main — a checkout-dependent read would stamp every
+    contrib version with main's schema."""
+    at_version = "type: object\nv: release\n"
+    at_head = "type: object\nv: main-moved-ahead\n"
+    set_core_schema(temp_git_repos["core"], at_version, tag="v0.112.0")
+    set_core_schema(temp_git_repos["core"], at_head, tag=None)  # main now differs from v0.112.0
+
+    # Leave the core clone checked out on main, mimicking the backfill end state.
+    collector_sync.version_detectors["core"].checkout_main()
+
+    collector_sync.save_version("contrib", Version("0.112.0"), sample_components)
+
+    with open(temp_inventory_dir / "contrib" / "v0.112.0" / "receiver.yaml") as f:
+        contrib_hash = yaml.safe_load(f)["schema_hash"]
+
+    assert contrib_hash == _hash_for(collector_sync, at_version)
+    assert contrib_hash != _hash_for(collector_sync, at_head)
+
+
+def test_save_version_falls_back_to_earlier_core_release(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos, caplog
+):
+    """When core has no schema at the exact tag, fall back to the nearest earlier
+    core release (not main), and warn about it."""
+    earlier = "type: object\nv: earlier-release\n"
+    set_core_schema(temp_git_repos["core"], earlier, tag="v0.111.0")
+    set_core_schema(temp_git_repos["core"], "type: object\nv: main\n", tag=None)  # main differs
+    # v0.112.0 tag (from the fixture) has no schema, so resolution must fall back.
+
+    with caplog.at_level(logging.WARNING):
+        collector_sync.save_version("contrib", Version("0.112.0"), sample_components)
+
+    with open(temp_inventory_dir / "contrib" / "v0.112.0" / "receiver.yaml") as f:
+        contrib_hash = yaml.safe_load(f)["schema_hash"]
+
+    assert contrib_hash == _hash_for(collector_sync, earlier)
+    assert contrib_hash != _hash_for(collector_sync, "type: object\nv: main\n")
+    assert any("falling back" in r.message.lower() or "using" in r.message.lower() for r in caplog.records)
+
+
+def test_core_schema_refs_release_orders_exact_then_earlier_then_main(collector_sync):
+    refs = collector_sync._core_schema_refs(Version("0.112.0"))
+
+    assert refs[0] == "v0.112.0"  # exact tag first
+    assert "v0.111.0" in refs  # nearest earlier core release
+    assert refs[-1] == "main"  # main as last resort
+
+
+def test_core_schema_refs_prerelease_uses_main_only(collector_sync):
+    snapshot = Version(major=0, minor=113, patch=0, prerelease=("SNAPSHOT",))
+
+    assert collector_sync._core_schema_refs(snapshot) == ["main"]
 
 
 def test_process_latest_release_already_exists(collector_sync, sample_components, temp_inventory_dir):

--- a/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
+++ b/ecosystem-automation/collector-watcher/tests/test_schema_copier.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Tests for CollectorSchemaCopier."""
+"""Tests for CollectorSchemaCopier (content-addressable, normalized hashing)."""
 
-import hashlib
 import shutil
 import tempfile
 from pathlib import Path
 
 import pytest
-import yaml
 from collector_watcher.schema_copier import (
-    SCHEMA_RELATIVE_PATH,
     UNKNOWN_HASH,
     CollectorSchemaCopier,
 )
+
+# A small but representative schema. Its hash under the pinned normalization is
+# pinned as a literal below so the test fails loudly if the canonical form ever
+# changes (e.g. a PyYAML dump-option drift) — that change requires a backfill.
+SCHEMA_CONTENT = "type: object\nproperties:\n  type:\n    type: string\n"
+SCHEMA_CONTENT_HASH = "688b0c283893"
 
 
 @pytest.fixture
@@ -36,117 +39,78 @@ def temp_dir():
 
 
 @pytest.fixture
-def fake_repo(temp_dir):
-    """Fake repo directory with a metadata-schema.yaml at the expected location."""
-    schema_dir = temp_dir / "cmd" / "mdatagen"
-    schema_dir.mkdir(parents=True)
-    schema_file = schema_dir / "metadata-schema.yaml"
-    schema_file.write_text("type: object\nproperties:\n  type:\n    type: string\n")
-    return temp_dir
-
-
-@pytest.fixture
-def fake_repo_no_schema(temp_dir):
-    """Fake repo directory without a metadata-schema.yaml."""
-    (temp_dir / "cmd" / "mdatagen").mkdir(parents=True)
-    return temp_dir
-
-
-@pytest.fixture
 def schemas_dir(temp_dir):
     return temp_dir / "meta" / "schemas"
 
 
 # ---------------------------------------------------------------------------
-# store_schema
+# store_schema_content
 # ---------------------------------------------------------------------------
 
 
-def test_store_schema_writes_hash_named_file(fake_repo, schemas_dir):
+def test_store_schema_content_writes_hash_named_file(schemas_dir):
     copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+    schema_hash = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
 
-    assert schema_hash is not None
-    assert len(schema_hash) == 12
+    assert schema_hash == SCHEMA_CONTENT_HASH
     assert (schemas_dir / f"{schema_hash}.yaml").exists()
 
 
-def test_store_schema_returns_hash_matching_content(fake_repo, schemas_dir):
+def test_store_schema_content_is_verbatim(schemas_dir):
+    """The stored file keeps the original content; only the name is hashed."""
     copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+    schema_hash = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
 
-    src = fake_repo / SCHEMA_RELATIVE_PATH
-    with open(src, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    normalized = yaml.safe_dump(data, sort_keys=True)
-    expected = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
-    assert schema_hash == expected
-
-
-def test_store_schema_content_is_identical(fake_repo, schemas_dir):
-    copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, schemas_dir)
-
-    src = fake_repo / SCHEMA_RELATIVE_PATH
     dst = schemas_dir / f"{schema_hash}.yaml"
-    assert dst.read_bytes() == src.read_bytes()
+    assert dst.read_text(encoding="utf-8") == SCHEMA_CONTENT
 
 
-def test_store_schema_creates_schemas_dir_if_missing(fake_repo, temp_dir):
+def test_store_schema_content_creates_schemas_dir_if_missing(temp_dir):
     target = temp_dir / "deeply" / "nested" / "schemas"
     assert not target.exists()
 
     copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, target)
+    schema_hash = copier.store_schema_content(SCHEMA_CONTENT, target)
 
     assert schema_hash is not None
     assert (target / f"{schema_hash}.yaml").exists()
 
 
-def test_store_schema_returns_none_when_schema_absent(fake_repo_no_schema, schemas_dir):
+def test_store_schema_content_returns_none_when_content_none(schemas_dir):
     copier = CollectorSchemaCopier()
-    result = copier.store_schema(fake_repo_no_schema, schemas_dir)
+    result = copier.store_schema_content(None, schemas_dir)
 
     assert result is None
-    # No file should be created when source is absent
+    # No file/dir should be created when there is nothing to store.
     assert not schemas_dir.exists() or not any(schemas_dir.iterdir())
 
 
-def test_store_schema_is_idempotent(fake_repo, schemas_dir):
-    """Calling store_schema twice with identical source produces one file."""
+def test_store_schema_content_is_idempotent(schemas_dir):
+    """Storing identical content twice produces a single file."""
     copier = CollectorSchemaCopier()
-    h1 = copier.store_schema(fake_repo, schemas_dir)
-    h2 = copier.store_schema(fake_repo, schemas_dir)
+    h1 = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
+    h2 = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
 
     assert h1 == h2
-    files = list(schemas_dir.glob("*.yaml"))
-    assert len(files) == 1
+    assert len(list(schemas_dir.glob("*.yaml"))) == 1
 
 
-def test_store_schema_does_not_overwrite_existing_file(fake_repo, schemas_dir):
-    """The first stored content wins; later calls must not modify the existing file."""
+def test_store_schema_content_does_not_overwrite_existing_file(schemas_dir):
+    """The first stored content wins; later calls must not rewrite the file."""
     copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+    schema_hash = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
 
     stored_path = schemas_dir / f"{schema_hash}.yaml"
     mtime_before = stored_path.stat().st_mtime_ns
 
-    # A second call with the same source must skip the copy entirely
-    copier.store_schema(fake_repo, schemas_dir)
+    copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
     assert stored_path.stat().st_mtime_ns == mtime_before
 
 
-def test_store_schema_distinct_contents_produce_distinct_files(fake_repo, schemas_dir, temp_dir):
-    """Two repos with different schemas yield two files in CAS."""
+def test_store_schema_content_distinct_contents_produce_distinct_files(schemas_dir):
     copier = CollectorSchemaCopier()
-    h1 = copier.store_schema(fake_repo, schemas_dir)
-
-    other_repo = temp_dir / "other"
-    other_schema_dir = other_repo / "cmd" / "mdatagen"
-    other_schema_dir.mkdir(parents=True)
-    (other_schema_dir / "metadata-schema.yaml").write_text("type: different\n")
-
-    h2 = copier.store_schema(other_repo, schemas_dir)
+    h1 = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
+    h2 = copier.store_schema_content("type: different\n", schemas_dir)
 
     assert h1 != h2
     assert (schemas_dir / f"{h1}.yaml").exists()
@@ -158,80 +122,68 @@ def test_store_schema_distinct_contents_produce_distinct_files(fake_repo, schema
 # ---------------------------------------------------------------------------
 
 
-def test_compute_schema_hash_returns_12_char_hex(fake_repo):
-    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
-    copier = CollectorSchemaCopier()
-    result = copier.compute_schema_hash(schema_path)
+def test_compute_schema_hash_returns_12_char_hex():
+    result = CollectorSchemaCopier().compute_schema_hash(SCHEMA_CONTENT)
 
     assert isinstance(result, str)
     assert len(result) == 12
     assert all(c in "0123456789abcdef" for c in result)
 
 
-def test_compute_schema_hash_matches_sha256(fake_repo):
-    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+def test_compute_schema_hash_pins_known_input():
+    """Guards the canonical form against silent drift (independent expectation)."""
+    assert CollectorSchemaCopier().compute_schema_hash(SCHEMA_CONTENT) == SCHEMA_CONTENT_HASH
+
+
+def test_compute_schema_hash_is_deterministic():
     copier = CollectorSchemaCopier()
-    result = copier.compute_schema_hash(schema_path)
-
-    with open(schema_path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    normalized = yaml.safe_dump(data, sort_keys=True)
-    expected = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
-    assert result == expected
+    assert copier.compute_schema_hash(SCHEMA_CONTENT) == copier.compute_schema_hash(SCHEMA_CONTENT)
 
 
-def test_compute_schema_hash_is_deterministic(fake_repo):
-    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+def test_compute_schema_hash_changes_with_content():
     copier = CollectorSchemaCopier()
-
-    h1 = copier.compute_schema_hash(schema_path)
-    h2 = copier.compute_schema_hash(schema_path)
-    assert h1 == h2
-
-
-def test_compute_schema_hash_changes_with_content(fake_repo):
-    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
-    copier = CollectorSchemaCopier()
-
-    h1 = copier.compute_schema_hash(schema_path)
-    schema_path.write_text("type: object\nnewfield: added\n")
-    h2 = copier.compute_schema_hash(schema_path)
+    h1 = copier.compute_schema_hash(SCHEMA_CONTENT)
+    h2 = copier.compute_schema_hash("type: object\nnewfield: added\n")
 
     assert h1 != h2
 
 
-def test_compute_schema_hash_returns_unknown_when_absent(temp_dir):
-    missing = temp_dir / "does_not_exist.yaml"
+def test_compute_schema_hash_returns_unknown_when_content_none():
+    assert CollectorSchemaCopier().compute_schema_hash(None) == UNKNOWN_HASH
+
+
+def test_compute_schema_hash_ignores_comments():
     copier = CollectorSchemaCopier()
-    result = copier.compute_schema_hash(missing)
+    with_comments = f"# leading comment\n{SCHEMA_CONTENT}\n# trailing comment\n"
 
-    assert result == UNKNOWN_HASH
+    assert copier.compute_schema_hash(with_comments) == copier.compute_schema_hash(SCHEMA_CONTENT)
 
 
-def test_compute_schema_hash_ignores_comments(fake_repo):
-    schema_path = fake_repo / SCHEMA_RELATIVE_PATH
+def test_compute_schema_hash_ignores_key_order():
+    """sort_keys=True must make key ordering irrelevant to the hash."""
     copier = CollectorSchemaCopier()
+    reordered = "properties:\n  type:\n    type: string\ntype: object\n"
 
-    h1 = copier.compute_schema_hash(schema_path)
+    assert copier.compute_schema_hash(reordered) == copier.compute_schema_hash(SCHEMA_CONTENT)
 
-    content = schema_path.read_text(encoding="utf-8")
-    content_with_comments = f"# This is a comment\n{content}\n# Another comment\n"
-    schema_path.write_text(content_with_comments, encoding="utf-8")
 
-    h2 = copier.compute_schema_hash(schema_path)
-    assert h1 == h2
+def test_compute_schema_hash_ignores_formatting():
+    """Flow vs block style is the same data, so it must hash identically."""
+    copier = CollectorSchemaCopier()
+    flow_style = "{type: object, properties: {type: {type: string}}}\n"
+
+    assert copier.compute_schema_hash(flow_style) == copier.compute_schema_hash(SCHEMA_CONTENT)
 
 
 # ---------------------------------------------------------------------------
-# Round-trip: store then hash the stored copy
+# Round-trip: store, then re-hash the stored copy
 # ---------------------------------------------------------------------------
 
 
-def test_hash_of_stored_file_matches_computed_hash(fake_repo, schemas_dir):
-    """The filename of the stored copy must equal the source hash."""
+def test_hash_of_stored_file_matches_computed_hash(schemas_dir):
+    """Re-normalizing the stored (verbatim) file reproduces its filename hash."""
     copier = CollectorSchemaCopier()
-    schema_hash = copier.store_schema(fake_repo, schemas_dir)
+    schema_hash = copier.store_schema_content(SCHEMA_CONTENT, schemas_dir)
 
-    src_hash = copier.compute_schema_hash(fake_repo / SCHEMA_RELATIVE_PATH)
-    assert schema_hash == src_hash
-    assert (schemas_dir / f"{src_hash}.yaml").exists()
+    stored = (schemas_dir / f"{schema_hash}.yaml").read_text(encoding="utf-8")
+    assert copier.compute_schema_hash(stored) == schema_hash

--- a/ecosystem-automation/collector-watcher/tests/test_version_detector.py
+++ b/ecosystem-automation/collector-watcher/tests/test_version_detector.py
@@ -168,6 +168,34 @@ class TestVersionDetector:
         current_branch = run_git(temp_git_repo, "branch", "--show-current")
         assert current_branch == "main"
 
+    def test_read_file_at_ref_returns_content_at_tag(self, temp_git_repo):
+        detector = VersionDetector(temp_git_repo)
+
+        # Each tag pins a different revision of test.txt.
+        assert detector.read_file_at_ref("v0.110.0", "test.txt") == "initial content"
+        assert detector.read_file_at_ref("v0.111.0", "test.txt") == "update 1"
+        assert detector.read_file_at_ref("v0.112.0", "test.txt") == "update 2"
+
+    def test_read_file_at_ref_does_not_change_checkout(self, temp_git_repo):
+        """Reading an old ref must not disturb the working-tree checkout."""
+        detector = VersionDetector(temp_git_repo)
+        detector.checkout_main()
+
+        content = detector.read_file_at_ref("v0.110.0", "test.txt")
+
+        assert content == "initial content"
+        # Still on main, working tree unchanged.
+        assert run_git(temp_git_repo, "branch", "--show-current") == "main"
+        assert (temp_git_repo / "test.txt").read_text() == "update 3"
+
+    def test_read_file_at_ref_missing_path_returns_none(self, temp_git_repo):
+        detector = VersionDetector(temp_git_repo)
+        assert detector.read_file_at_ref("v0.110.0", "does/not/exist.yaml") is None
+
+    def test_read_file_at_ref_missing_ref_returns_none(self, temp_git_repo):
+        detector = VersionDetector(temp_git_repo)
+        assert detector.read_file_at_ref("v9.9.9", "test.txt") is None
+
     def test_determine_next_snapshot_version(self, temp_git_repo):
         detector = VersionDetector(temp_git_repo)
         next_version = detector.determine_next_snapshot_version()

--- a/ecosystem-automation/watcher-common/src/watcher_common/version_detector.py
+++ b/ecosystem-automation/watcher-common/src/watcher_common/version_detector.py
@@ -116,6 +116,35 @@ class VersionDetector:
         except subprocess.CalledProcessError as e:
             raise ValueError(f"Failed to checkout main branch: {e.stderr}") from e
 
+    def read_file_at_ref(self, ref: str, rel_path: str) -> str | None:
+        """Return the text content of ``rel_path`` at git ``ref``.
+
+        Reads the blob directly via ``git show`` without touching the working
+        tree, so the result depends only on ``ref`` — not on whatever revision
+        the repository is currently checked out to. This makes it safe to read a
+        file at one version while the clone is checked out to another (e.g.
+        resolving a per-version schema during a multi-version backfill).
+
+        Args:
+            ref: Git ref to read from (tag like ``v0.145.0``, branch like
+                ``main``, or any commit-ish).
+            rel_path: Repository-relative path to the file.
+
+        Returns:
+            The file's text content, or None if ``ref`` does not exist or the
+            file is absent at that ref.
+        """
+        result = subprocess.run(
+            [_GIT, "show", f"{ref}:{rel_path}"],
+            cwd=self.repo_path,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
     def determine_next_snapshot_version(self) -> Version:
         """Determine the next snapshot version based on latest release.
 

--- a/ecosystem-automation/watcher-common/src/watcher_common/version_detector.py
+++ b/ecosystem-automation/watcher-common/src/watcher_common/version_detector.py
@@ -140,6 +140,8 @@ class VersionDetector:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         if result.returncode != 0:
             return None


### PR DESCRIPTION
While validating #691 i found a bug in the collector watcher where when running a backfill it was attributing the wrong schema hash to the contrib versions. This fixes that and adds a github action so we can run a fresh backfill of the collector registry with the updated schema hash logic