### PR TITLE
feat(v1): add Collector and Java Agent landing pages

### DIFF
--- a/ecosystem-explorer/src/v1/V1App.tsx
+++ b/ecosystem-explorer/src/v1/V1App.tsx
@@ -45,10 +45,14 @@ const HomePage = lazy(() =>
   import("@/v1/features/home/home-page").then((m) => ({ default: m.HomeV1 }))
 );
 const JavaAgentPage = lazy(() =>
-  import("@/features/java-agent/java-agent-page").then((m) => ({ default: m.JavaAgentPage }))
+  import("@/v1/features/ecosystem/java-agent-landing").then((m) => ({
+    default: m.JavaAgentLandingV1,
+  }))
 );
 const CollectorPage = lazy(() =>
-  import("@/features/collector/collector-page").then((m) => ({ default: m.CollectorPage }))
+  import("@/v1/features/ecosystem/collector-landing").then((m) => ({
+    default: m.CollectorLandingV1,
+  }))
 );
 const CollectorComponentsPage = lazy(() =>
   import("@/features/collector/collector-components-page").then((m) => ({

--- a/ecosystem-explorer/src/v1/features/ecosystem/collector-landing.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/collector-landing.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EcosystemPage } from "./ecosystem-page";
+import { collectorConfig } from "./configs";
+
+export function CollectorLandingV1() {
+  return <EcosystemPage config={collectorConfig} />;
+}

--- a/ecosystem-explorer/src/v1/features/ecosystem/configs.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/configs.tsx
@@ -28,6 +28,7 @@ import { ArrowLeftRight, Box, GitCompare, Layers } from "lucide-react";
 import { TYPE_STRIPE_COLORS } from "@/components/ui/type-stripe-colors";
 import { OtelLogo } from "@/components/icons/otel-logo";
 import { JavaIcon } from "@/components/icons/java-icon";
+import { isEnabled } from "@/lib/feature-flags";
 import { filtersToHref } from "@/v1/lib/list-filters";
 import type { EcosystemConfig } from "./types";
 
@@ -35,8 +36,6 @@ const collectorComponentsPath = "/collector/components";
 const javaInstrumentationPath = "/java-agent/instrumentation";
 
 export const collectorConfig: EcosystemConfig = {
-  id: "collector",
-  slug: "collector",
   name: "OpenTelemetry Collector",
   hero: {
     eyebrow: "Infrastructure · Vendor-agnostic agent",
@@ -138,8 +137,6 @@ export const collectorConfig: EcosystemConfig = {
 };
 
 export const javaAgentConfig: EcosystemConfig = {
-  id: "java-agent",
-  slug: "java-agent",
   name: "OpenTelemetry Java Agent",
   hero: {
     eyebrow: "Auto-instrumentation · JVM",
@@ -174,7 +171,7 @@ export const javaAgentConfig: EcosystemConfig = {
       label: "HTTP",
       count: "32",
       description: "Servers & clients",
-      href: `${javaInstrumentationPath}?q=http`,
+      href: `${javaInstrumentationPath}?search=http`,
       accentColor: TYPE_STRIPE_COLORS.receiver,
     },
     {
@@ -182,7 +179,7 @@ export const javaAgentConfig: EcosystemConfig = {
       label: "Databases",
       count: "41",
       description: "JDBC, NoSQL, ORM",
-      href: `${javaInstrumentationPath}?q=db`,
+      href: `${javaInstrumentationPath}?search=db`,
       accentColor: TYPE_STRIPE_COLORS.processor,
     },
     {
@@ -190,7 +187,7 @@ export const javaAgentConfig: EcosystemConfig = {
       label: "Messaging",
       count: "21",
       description: "Brokers & queues",
-      href: `${javaInstrumentationPath}?q=messaging`,
+      href: `${javaInstrumentationPath}?search=messaging`,
       accentColor: TYPE_STRIPE_COLORS.exporter,
     },
     {
@@ -198,7 +195,7 @@ export const javaAgentConfig: EcosystemConfig = {
       label: "Frameworks",
       count: "55",
       description: "Spring, Quarkus, …",
-      href: `${javaInstrumentationPath}?q=framework`,
+      href: `${javaInstrumentationPath}?search=framework`,
       accentColor: TYPE_STRIPE_COLORS.connector,
     },
     {
@@ -206,7 +203,7 @@ export const javaAgentConfig: EcosystemConfig = {
       label: "Runtime",
       count: "12",
       description: "JVM, threads, GC",
-      href: `${javaInstrumentationPath}?q=runtime`,
+      href: `${javaInstrumentationPath}?search=runtime`,
       accentColor: TYPE_STRIPE_COLORS.extension,
     },
   ],
@@ -218,13 +215,20 @@ export const javaAgentConfig: EcosystemConfig = {
       href: "/java-agent/configuration/builder",
       icon: <Box className="h-5 w-5" aria-hidden />,
     },
-    {
-      id: "releases",
-      title: "Compare releases",
-      description: "See what's new between two Java Agent versions.",
-      href: "/java-agent/releases",
-      icon: <GitCompare className="h-5 w-5" aria-hidden />,
-    },
+    // Only surface the release-comparison entry when its route is mounted —
+    // `/java-agent/releases` is gated behind JAVA_RELEASE_COMPARISON in V1App,
+    // so without this guard the card would 404 wherever the flag is off.
+    ...(isEnabled("JAVA_RELEASE_COMPARISON")
+      ? [
+          {
+            id: "releases",
+            title: "Compare releases",
+            description: "See what's new between two Java Agent versions.",
+            href: "/java-agent/releases",
+            icon: <GitCompare className="h-5 w-5" aria-hidden />,
+          },
+        ]
+      : []),
     {
       id: "supported-libs",
       title: "Supported libraries",
@@ -239,9 +243,4 @@ export const javaAgentConfig: EcosystemConfig = {
     deltas: { added: 3, changed: 9, deprecated: 1 },
     hrefChangelog: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases",
   },
-};
-
-export const ECOSYSTEMS: Record<string, EcosystemConfig> = {
-  collector: collectorConfig,
-  "java-agent": javaAgentConfig,
 };

--- a/ecosystem-explorer/src/v1/features/ecosystem/configs.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/configs.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Per-ecosystem configs that drive the ecosystem landing pages. New
+ * ecosystems get a new entry here plus a one-line route swap in
+ * `V1App.tsx`.
+ *
+ * Counts and version strings are pulled from the 2026-05-13 mockup;
+ * wiring to live data via `loadAllComponents` / `loadAllInstrumentations`
+ * is a follow-up tracked in the decision log.
+ */
+
+import { ArrowLeftRight, Box, GitCompare, Layers } from "lucide-react";
+import { TYPE_STRIPE_COLORS } from "@/components/ui/type-stripe-colors";
+import { OtelLogo } from "@/components/icons/otel-logo";
+import { JavaIcon } from "@/components/icons/java-icon";
+import { filtersToHref } from "@/v1/lib/list-filters";
+import type { EcosystemConfig } from "./types";
+
+const collectorComponentsPath = "/collector/components";
+const javaInstrumentationPath = "/java-agent/instrumentation";
+
+export const collectorConfig: EcosystemConfig = {
+  id: "collector",
+  slug: "collector",
+  name: "OpenTelemetry Collector",
+  hero: {
+    eyebrow: "Infrastructure · Vendor-agnostic agent",
+    title: (
+      <>
+        OpenTelemetry <span className="td-cover-block__title-accent">Collector</span>
+      </>
+    ),
+    lead: "Receive, process, and export telemetry data. A vendor-agnostic agent for ingesting, processing, and exporting metrics, traces, and logs.",
+    ctas: [
+      { label: "Browse components", href: collectorComponentsPath, primary: true },
+      {
+        label: "Read overview",
+        href: "https://opentelemetry.io/docs/collector/",
+        external: true,
+      },
+      {
+        label: "GitHub",
+        href: "https://github.com/open-telemetry/opentelemetry-collector",
+        external: true,
+      },
+    ],
+    logo: <OtelLogo className="td-cover-block__logo" />,
+  },
+  pipelineTitle: "Pipeline anatomy",
+  pipelineLead:
+    "A Collector pipeline is composed of receivers, processors, exporters, connectors, and extensions. Click any stage to filter the components list.",
+  stages: [
+    {
+      id: "receiver",
+      label: "Receivers",
+      count: "98",
+      description: "Ingest data from sources",
+      href: filtersToHref(collectorComponentsPath, { types: ["receiver"] }),
+      accentColor: TYPE_STRIPE_COLORS.receiver,
+    },
+    {
+      id: "processor",
+      label: "Processors",
+      count: "28",
+      description: "Transform & enrich data",
+      href: filtersToHref(collectorComponentsPath, { types: ["processor"] }),
+      accentColor: TYPE_STRIPE_COLORS.processor,
+    },
+    {
+      id: "exporter",
+      label: "Exporters",
+      count: "47",
+      description: "Send data to backends",
+      href: filtersToHref(collectorComponentsPath, { types: ["exporter"] }),
+      accentColor: TYPE_STRIPE_COLORS.exporter,
+    },
+    {
+      id: "connector",
+      label: "Connectors",
+      count: "9",
+      description: "Bridge between pipelines",
+      href: filtersToHref(collectorComponentsPath, { types: ["connector"] }),
+      accentColor: TYPE_STRIPE_COLORS.connector,
+    },
+    {
+      id: "extension",
+      label: "Extensions",
+      count: "18",
+      description: "Auxiliary capabilities",
+      href: filtersToHref(collectorComponentsPath, { types: ["extension"] }),
+      accentColor: TYPE_STRIPE_COLORS.extension,
+    },
+  ],
+  quickEntries: [
+    {
+      id: "most-used",
+      title: "Most-used components",
+      description: "Receivers, processors, and exporters most commonly deployed.",
+      href: filtersToHref(collectorComponentsPath, { sort: "updated" }),
+      icon: <Layers className="h-5 w-5" aria-hidden />,
+    },
+    {
+      id: "core-vs-contrib",
+      title: "Core vs. Contrib",
+      description: "Compare the core distribution against the contrib add-ons.",
+      href: filtersToHref(collectorComponentsPath, { distributions: ["core", "contrib"] }),
+      icon: <ArrowLeftRight className="h-5 w-5" aria-hidden />,
+    },
+    {
+      id: "diff",
+      title: "Diff across versions",
+      description: "See what changed between two Collector releases.",
+      href: filtersToHref(collectorComponentsPath, { sort: "updated" }),
+      icon: <GitCompare className="h-5 w-5" aria-hidden />,
+    },
+  ],
+  release: {
+    version: "v0.150.0",
+    releaseDate: "May 2026",
+    deltas: { added: 4, changed: 12, deprecated: 2 },
+    hrefChangelog: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases",
+  },
+};
+
+export const javaAgentConfig: EcosystemConfig = {
+  id: "java-agent",
+  slug: "java-agent",
+  name: "OpenTelemetry Java Agent",
+  hero: {
+    eyebrow: "Auto-instrumentation · JVM",
+    title: (
+      <>
+        OpenTelemetry <span className="td-cover-block__title-accent">Java Agent</span>
+      </>
+    ),
+    lead: "Zero-code auto-instrumentation for Java applications. Hundreds of supported libraries and frameworks; configurable via system properties or env vars.",
+    ctas: [
+      { label: "Browse instrumentations", href: javaInstrumentationPath, primary: true },
+      {
+        label: "Read overview",
+        href: "https://opentelemetry.io/docs/zero-code/java/agent/",
+        external: true,
+      },
+      {
+        label: "GitHub",
+        href: "https://github.com/open-telemetry/opentelemetry-java-instrumentation",
+        external: true,
+      },
+    ],
+    logo: <JavaIcon className="td-cover-block__logo" />,
+  },
+  pipelineTitle: "Instrumentation categories",
+  pipelineLead:
+    "Java auto-instrumentations are grouped by category. Click any category to filter the instrumentation list.",
+  pipelineNoFlow: true,
+  stages: [
+    {
+      id: "http",
+      label: "HTTP",
+      count: "32",
+      description: "Servers & clients",
+      href: `${javaInstrumentationPath}?q=http`,
+      accentColor: TYPE_STRIPE_COLORS.receiver,
+    },
+    {
+      id: "db",
+      label: "Databases",
+      count: "41",
+      description: "JDBC, NoSQL, ORM",
+      href: `${javaInstrumentationPath}?q=db`,
+      accentColor: TYPE_STRIPE_COLORS.processor,
+    },
+    {
+      id: "messaging",
+      label: "Messaging",
+      count: "21",
+      description: "Brokers & queues",
+      href: `${javaInstrumentationPath}?q=messaging`,
+      accentColor: TYPE_STRIPE_COLORS.exporter,
+    },
+    {
+      id: "frameworks",
+      label: "Frameworks",
+      count: "55",
+      description: "Spring, Quarkus, …",
+      href: `${javaInstrumentationPath}?q=framework`,
+      accentColor: TYPE_STRIPE_COLORS.connector,
+    },
+    {
+      id: "runtime",
+      label: "Runtime",
+      count: "12",
+      description: "JVM, threads, GC",
+      href: `${javaInstrumentationPath}?q=runtime`,
+      accentColor: TYPE_STRIPE_COLORS.extension,
+    },
+  ],
+  quickEntries: [
+    {
+      id: "config-builder",
+      title: "Configuration builder",
+      description: "Build a declarative agent configuration interactively.",
+      href: "/java-agent/configuration/builder",
+      icon: <Box className="h-5 w-5" aria-hidden />,
+    },
+    {
+      id: "releases",
+      title: "Compare releases",
+      description: "See what's new between two Java Agent versions.",
+      href: "/java-agent/releases",
+      icon: <GitCompare className="h-5 w-5" aria-hidden />,
+    },
+    {
+      id: "supported-libs",
+      title: "Supported libraries",
+      description: "Browse the complete catalog of supported libraries and frameworks.",
+      href: javaInstrumentationPath,
+      icon: <Layers className="h-5 w-5" aria-hidden />,
+    },
+  ],
+  release: {
+    version: "v2.10.0",
+    releaseDate: "May 2026",
+    deltas: { added: 3, changed: 9, deprecated: 1 },
+    hrefChangelog: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases",
+  },
+};
+
+export const ECOSYSTEMS: Record<string, EcosystemConfig> = {
+  collector: collectorConfig,
+  "java-agent": javaAgentConfig,
+};

--- a/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.test.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { CollectorLandingV1 } from "./collector-landing";
+import { JavaAgentLandingV1 } from "./java-agent-landing";
+
+function renderRouter(node: React.ReactNode) {
+  return render(<MemoryRouter>{node}</MemoryRouter>);
+}
+
+describe("Collector ecosystem landing", () => {
+  it("renders the eyebrow, title, lead, and release version", () => {
+    renderRouter(<CollectorLandingV1 />);
+    expect(screen.getByText(/Infrastructure · Vendor-agnostic agent/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /OpenTelemetry Collector/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("v0.150.0")).toBeInTheDocument();
+  });
+
+  it("renders all five collector pipeline stages with deep links into the list page", () => {
+    renderRouter(<CollectorLandingV1 />);
+    expect(screen.getByRole("link", { name: /^Receivers — 98 components$/ })).toHaveAttribute(
+      "href",
+      "/collector/components?type=receiver"
+    );
+    expect(screen.getByRole("link", { name: /^Processors — 28 components$/ })).toHaveAttribute(
+      "href",
+      "/collector/components?type=processor"
+    );
+    expect(screen.getByRole("link", { name: /^Exporters — 47 components$/ })).toHaveAttribute(
+      "href",
+      "/collector/components?type=exporter"
+    );
+    expect(screen.getByRole("link", { name: /^Connectors — 9 components$/ })).toHaveAttribute(
+      "href",
+      "/collector/components?type=connector"
+    );
+    expect(screen.getByRole("link", { name: /^Extensions — 18 components$/ })).toHaveAttribute(
+      "href",
+      "/collector/components?type=extension"
+    );
+  });
+
+  it("renders the three quick-entry cards", () => {
+    renderRouter(<CollectorLandingV1 />);
+    expect(screen.getByRole("heading", { name: /Most-used components/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Core vs\. Contrib/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Diff across versions/i })).toBeInTheDocument();
+  });
+
+  it("renders breadcrumbs Explorer › Ecosystems › Collector", () => {
+    renderRouter(<CollectorLandingV1 />);
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(nav).toHaveTextContent(/Explorer/);
+    expect(nav).toHaveTextContent(/Ecosystems/);
+    expect(nav).toHaveTextContent(/OpenTelemetry Collector/);
+  });
+});
+
+describe("Java Agent ecosystem landing", () => {
+  it("renders the categories pipeline (HTTP / Databases / Messaging / Frameworks / Runtime)", () => {
+    renderRouter(<JavaAgentLandingV1 />);
+    const stageNames = [
+      /^HTTP — 32 components$/,
+      /^Databases — 41 components$/,
+      /^Messaging — 21 components$/,
+      /^Frameworks — 55 components$/,
+      /^Runtime — 12 components$/,
+    ];
+    for (const name of stageNames) {
+      expect(screen.getByRole("link", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("uses Java Agent canonical release v2.10.0", () => {
+    renderRouter(<JavaAgentLandingV1 />);
+    expect(screen.getByText("v2.10.0")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * EcosystemPage — single composition consumed by every per-ecosystem
+ * landing route (Collector, Java Agent, future ecosystems). Driven by an
+ * `EcosystemConfig` so adding a new ecosystem is just a config entry plus
+ * a one-line route swap in `V1App.tsx`.
+ */
+
+import { SubNav } from "@/v1/components/layout/sub-nav";
+import { CoverBlock } from "@/v1/components/home/cover-block";
+import { PipelineAnatomy } from "@/v1/components/ecosystem/pipeline-anatomy";
+import { QuickEntryRow } from "@/v1/components/ecosystem/quick-entry-row";
+import { ReleaseCard } from "@/v1/components/ecosystem/release-card";
+import type { EcosystemConfig } from "./types";
+
+export interface EcosystemPageProps {
+  config: EcosystemConfig;
+}
+
+export function EcosystemPage({ config }: EcosystemPageProps) {
+  const { hero, release, stages, quickEntries, pipelineTitle, pipelineLead, pipelineNoFlow } =
+    config;
+
+  return (
+    <div className="td-ecosystem">
+      <SubNav
+        crumbs={[{ label: "Explorer", href: "/" }, { label: "Ecosystems" }, { label: config.name }]}
+      />
+
+      <CoverBlock
+        logo={hero.logo}
+        eyebrow={hero.eyebrow}
+        title={hero.title}
+        lead={hero.lead}
+        ctas={hero.ctas.map((cta) =>
+          cta.external ? (
+            <a
+              key={cta.label}
+              href={cta.href}
+              target="_blank"
+              rel="noopener"
+              className={`td-btn ${cta.primary ? "td-btn--primary" : "td-btn--outline-light"}`}
+            >
+              {cta.label}
+            </a>
+          ) : (
+            <a
+              key={cta.label}
+              href={cta.href}
+              className={`td-btn ${cta.primary ? "td-btn--primary" : "td-btn--outline-light"}`}
+            >
+              {cta.label}
+            </a>
+          )
+        )}
+        aside={
+          <ReleaseCard
+            version={release.version}
+            releaseDate={release.releaseDate}
+            deltas={release.deltas}
+            hrefChangelog={release.hrefChangelog}
+          />
+        }
+      />
+
+      <section className="td-box td-box--light">
+        <div className="td-box__container">
+          <PipelineAnatomy
+            title={pipelineTitle ?? "Pipeline anatomy"}
+            lead={pipelineLead}
+            stages={stages}
+            noFlow={pipelineNoFlow}
+          />
+        </div>
+      </section>
+
+      <section className="td-box td-box--muted">
+        <div className="td-box__container">
+          <QuickEntryRow items={quickEntries} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/ecosystem-page.tsx
@@ -21,6 +21,8 @@
  * a one-line route swap in `V1App.tsx`.
  */
 
+import { Link } from "react-router-dom";
+
 import { SubNav } from "@/v1/components/layout/sub-nav";
 import { CoverBlock } from "@/v1/components/home/cover-block";
 import { PipelineAnatomy } from "@/v1/components/ecosystem/pipeline-anatomy";
@@ -53,19 +55,19 @@ export function EcosystemPage({ config }: EcosystemPageProps) {
               key={cta.label}
               href={cta.href}
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
               className={`td-btn ${cta.primary ? "td-btn--primary" : "td-btn--outline-light"}`}
             >
               {cta.label}
             </a>
           ) : (
-            <a
+            <Link
               key={cta.label}
-              href={cta.href}
+              to={cta.href}
               className={`td-btn ${cta.primary ? "td-btn--primary" : "td-btn--outline-light"}`}
             >
               {cta.label}
-            </a>
+            </Link>
           )
         )}
         aside={

--- a/ecosystem-explorer/src/v1/features/ecosystem/java-agent-landing.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/java-agent-landing.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EcosystemPage } from "./ecosystem-page";
+import { javaAgentConfig } from "./configs";
+
+export function JavaAgentLandingV1() {
+  return <EcosystemPage config={javaAgentConfig} />;
+}

--- a/ecosystem-explorer/src/v1/features/ecosystem/types.ts
+++ b/ecosystem-explorer/src/v1/features/ecosystem/types.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * EcosystemConfig — declarative shape for every per-ecosystem landing page.
+ * Adding a new ecosystem (Python, Go, …) is a matter of authoring a new
+ * config and a one-line route registration. No per-page component
+ * duplication.
+ */
+
+import type { ReactNode } from "react";
+import type { PipelineStage } from "@/v1/components/ecosystem/pipeline-anatomy";
+import type { QuickEntryItem } from "@/v1/components/ecosystem/quick-entry-row";
+import type { ReleaseDeltas } from "@/v1/components/ecosystem/release-card";
+
+export interface EcosystemHeroCopy {
+  /** Eyebrow text shown above the title — e.g. "Infrastructure · Vendor-agnostic agent". */
+  eyebrow: string;
+  /** The title. Supports rendered React (e.g. with a gradient accent span). */
+  title: ReactNode;
+  /** Lead paragraph below the title. */
+  lead: string;
+  /** Three CTA hrefs+labels. The first is rendered as primary (orange). */
+  ctas: Array<{ label: string; href: string; external?: boolean; primary?: boolean }>;
+  /** Logo / mark rendered above the eyebrow. */
+  logo: ReactNode;
+}
+
+export interface EcosystemReleaseInfo {
+  version: string | null;
+  releaseDate?: string | null;
+  deltas?: ReleaseDeltas | null;
+  hrefChangelog?: string | null;
+}
+
+export interface EcosystemConfig {
+  id: string;
+  slug: string;
+  name: string;
+  hero: EcosystemHeroCopy;
+  /** Pipeline anatomy title — defaults to "Pipeline anatomy". */
+  pipelineTitle?: string;
+  /** Pipeline anatomy lead sentence. */
+  pipelineLead?: string;
+  /**
+   * When true, the pipeline renders as a grid (no chevrons) — used by
+   * Java Agent's category-style diagram where order doesn't imply flow.
+   */
+  pipelineNoFlow?: boolean;
+  stages: PipelineStage[];
+  quickEntries: QuickEntryItem[];
+  /**
+   * Static release fallback shown when the data layer is unavailable. The
+   * actual latest version may be loaded asynchronously by the page; this
+   * is the v1 baseline pulled from the mockup / opentelemetry.io.
+   */
+  release: EcosystemReleaseInfo;
+}

--- a/ecosystem-explorer/src/v1/features/ecosystem/types.ts
+++ b/ecosystem-explorer/src/v1/features/ecosystem/types.ts
@@ -47,8 +47,6 @@ export interface EcosystemReleaseInfo {
 }
 
 export interface EcosystemConfig {
-  id: string;
-  slug: string;
   name: string;
   hero: EcosystemHeroCopy;
   /** Pipeline anatomy title — defaults to "Pipeline anatomy". */


### PR DESCRIPTION
## What changed

- Adds a declarative `EcosystemConfig` schema and a single `EcosystemPage` composition that renders every per-ecosystem landing: a hero with a release card, the pipeline-anatomy strip, and a quick-entry row. 
- Ships the Collector and Java Agent configs and points the `/collector` and `/java-agent` routes at the new V1 landings. 
- The route swap lives inside `V1App`, so the pages surface only behind `V1_REDESIGN`.

## Why

Contributes to #372. This bundles PRs 5, 6, and 7 from that issue so the routes render something real rather than landing a types-only contract on its own.

## How it was tested

- `bun run test` - 1057 pass, including 6 new cases in `ecosystem-page.test.tsx` (hero/release, the five Collector stage deep-links, quick-entries, breadcrumbs, Java Agent categories + release)
- `bun run typecheck`, `bun run lint`, `prettier --check` - clean
- Manual, with `V1_REDESIGN` on: `/collector` and `/java-agent` render the landings; clicking a pipeline stage deep-links into the filtered list

## Is this a breaking change?

No. The route swaps live inside `V1App`, gated by `V1_REDESIGN` (off by default), so the legacy pages keep serving every user until the flag flips.

## Special notes for your reviewer

- Java Agent category stages deep-link via `?search=` (the param the instrumentation list actually reads). Match quality for terms like "framework" is a follow-up once a real category facet exists.
- The "Compare releases" quick-entry is gated on `JAVA_RELEASE_COMPARISON`, so it stays hidden when that route is disabled instead of 404ing.
- Per-ecosystem copy is hardcoded in `configs.tsx` (the content layer). Moving it into locale files for non-English ecosystems is a later step.

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [ ] I wrote this PR description myself (AI tools must not check this box on behalf of the author)

---

> Co-authored with Claude Opus 4.8.
> Co-reviewed by Claude Opus 4.8.
