### PR TITLE
fix: use route parameter as telemetry comparison identifier

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -15,6 +15,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { InstrumentationDetailPage } from "./instrumentation-detail-page";
 import type { InstrumentationData } from "@/types/javaagent";
@@ -28,6 +29,10 @@ vi.mock("@/components/ui/back-button", () => ({
   BackButton: () => <button>Back</button>,
 }));
 
+vi.mock("./components/telemetry-comparison/telemetry-comparison-section", () => ({
+  TelemetryComparisonSection: vi.fn(() => <div data-testid="telemetry-comparison-mock" />),
+}));
+
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
   return {
@@ -37,6 +42,7 @@ vi.mock("react-router-dom", async () => {
 });
 
 import { useVersions, useInstrumentation } from "@/hooks/use-javaagent-data";
+import { TelemetryComparisonSection } from "./components/telemetry-comparison/telemetry-comparison-section";
 
 const mockVersionsData = {
   versions: [
@@ -266,5 +272,32 @@ describe("InstrumentationDetailPage", () => {
     renderWithRouter("/java-agent/instrumentation/2.0.0/jdbc");
 
     expect(screen.queryByRole("heading", { name: "Semantic Conventions" })).not.toBeInTheDocument();
+  });
+
+  it("passes correct instrumentationName to TelemetryComparisonSection from route parameter", async () => {
+    vi.mocked(useInstrumentation).mockReturnValue({
+      data: {
+        ...mockInstrumentation,
+        telemetry: [{ when: "always", metrics: [] }]
+      },
+      loading: false,
+      error: null,
+    });
+
+    renderWithRouter("/java-agent/instrumentation/my-test-identifier");
+
+    const user = userEvent.setup();
+    const telemetryTab = screen.getByRole("tab", { name: /Telemetry/i });
+    await user.click(telemetryTab);
+
+    const comparisonButton = await screen.findByRole("button", { name: /Comparison/i });
+    await user.click(comparisonButton);
+
+    expect(TelemetryComparisonSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instrumentationName: "my-test-identifier",
+      }),
+      undefined
+    );
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.test.tsx
@@ -278,7 +278,7 @@ describe("InstrumentationDetailPage", () => {
     vi.mocked(useInstrumentation).mockReturnValue({
       data: {
         ...mockInstrumentation,
-        telemetry: [{ when: "always", metrics: [] }]
+        telemetry: [{ when: "always", metrics: [] }],
       },
       loading: false,
       error: null,

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -613,7 +613,7 @@ export function InstrumentationDetailPage() {
                   ) : (
                     versionsData && (
                       <TelemetryComparisonSection
-                        instrumentationName={name ?? ""}
+                        instrumentationName={param ?? ""}
                         versions={versionsData.versions}
                         currentVersion={version ?? ""}
                       />


### PR DESCRIPTION
## What changed

This PR fixes the telemetry comparison view by passing the route-derived instrumentation identifier (`param`) to `TelemetryComparisonSection` instead of the incorrectly referenced variable.

### Files changed

#### `src/features/java-agent/instrumentation-detail-page.tsx`

Changed:

```tsx
instrumentationName={name ?? ""}
```

to:

```tsx
instrumentationName={param ?? ""}
```

This ensures the comparison view receives the correct instrumentation identifier from the current route.

#### `src/features/java-agent/instrumentation-detail-page.test.tsx`

Added a regression test that verifies:

- The Telemetry Comparison view receives the route parameter as `instrumentationName`
- The correct identifier is passed through when the comparison flow is enabled
- Future regressions in this data flow are detected by the test suite

## Why

The comparison flow depends on a valid `instrumentationName` to load telemetry comparison data.

The route parameter is already available via:

```tsx
const { param } = useParams<{ param: string }>();
```

However, `TelemetryComparisonSection` was receiving:

```tsx
instrumentationName={name ?? ""}
```

instead of the route-derived identifier.

As a result, the comparison component could receive an invalid/empty identifier and fail to load comparison data correctly.

Fixes #721

## How it was tested

- Verified the Telemetry Comparison view receives the expected route identifier
- Added a regression test covering the comparison flow
- Ran TypeScript type checking successfully
- Ran the affected test suite successfully

## Is this a breaking change?

No.

## Special notes for reviewers

This is a small, isolated fix that only affects the identifier passed to the telemetry comparison view. No application architecture, state management, routing behavior, or APIs were modified.

## Checklist

- [x] Tests added or updated for new behavior
- [x] I wrote this PR description myself