### PR TITLE
Reduce log warnings in integration tests

### DIFF
--- a/ecosystem-explorer/src/lib/api/idb-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.test.ts
@@ -234,5 +234,24 @@ describe("idb-cache", () => {
       await pruneOldEntries(7);
       expect(await db.get(STORES.METADATA, "old-2")).toBeUndefined();
     });
+
+    it("does not log when the connection is closed mid-prune", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Seed stale data so a real prune would have work to do.
+      const now = Date.now();
+      vi.setSystemTime(now - 10 * 24 * 60 * 60 * 1000);
+      await setCached("stale", { d: 1 }, STORES.METADATA);
+      vi.setSystemTime(now);
+
+      // Start the background prune but close the connection underneath it,
+      // mirroring page unload / test teardown. It must resolve quietly.
+      const pruning = pruneOldEntries(7);
+      closeDB();
+      await expect(pruning).resolves.toBeUndefined();
+
+      expect(consoleError).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
   });
 });

--- a/ecosystem-explorer/src/lib/api/idb-cache.test.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.test.ts
@@ -237,21 +237,23 @@ describe("idb-cache", () => {
 
     it("does not log when the connection is closed mid-prune", async () => {
       const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        // Seed stale data so a real prune would have work to do.
+        const now = Date.now();
+        vi.setSystemTime(now - 10 * 24 * 60 * 60 * 1000);
+        await setCached("stale", { d: 1 }, STORES.METADATA);
+        vi.setSystemTime(now);
 
-      // Seed stale data so a real prune would have work to do.
-      const now = Date.now();
-      vi.setSystemTime(now - 10 * 24 * 60 * 60 * 1000);
-      await setCached("stale", { d: 1 }, STORES.METADATA);
-      vi.setSystemTime(now);
+        // Start the background prune but close the connection underneath it,
+        // mirroring page unload / test teardown. It must resolve quietly.
+        const pruning = pruneOldEntries(7);
+        closeDB();
+        await expect(pruning).resolves.toBeUndefined();
 
-      // Start the background prune but close the connection underneath it,
-      // mirroring page unload / test teardown. It must resolve quietly.
-      const pruning = pruneOldEntries(7);
-      closeDB();
-      await expect(pruning).resolves.toBeUndefined();
-
-      expect(consoleError).not.toHaveBeenCalled();
-      consoleError.mockRestore();
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
     });
   });
 });

--- a/ecosystem-explorer/src/lib/api/idb-cache.ts
+++ b/ecosystem-explorer/src/lib/api/idb-cache.ts
@@ -47,6 +47,21 @@ function isExpired(cachedAt: number): boolean {
   return now - cachedAt > CACHE_EXPIRATION_MS;
 }
 
+/**
+ * Returns true when an error is the benign consequence of the database
+ * connection being closed underneath an in-flight operation — for example when
+ * the page unloads, or when test teardown calls closeDB() while a fire-and-forget
+ * prune is still running. The browser surfaces these as InvalidStateError (the
+ * connection is closing) or AbortError (an open transaction was aborted). They
+ * are not actionable for a best-effort background task, so callers swallow them.
+ */
+function isConnectionClosedError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "InvalidStateError" || error.name === "AbortError")
+  );
+}
+
 export async function initDB(): Promise<IDBPDatabase> {
   if (!isIDBAvailable()) {
     throw new Error("IndexedDB is not available in this environment");
@@ -162,6 +177,11 @@ export async function pruneOldEntries(maxAgeDays = 7): Promise<void> {
     const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
 
     for (const store of Object.values(STORES)) {
+      // The connection may have been closed underneath us between stores (e.g.
+      // page unload or test teardown calling closeDB() during this background
+      // task). closeDB() nulls/replaces dbInstance, so a mismatch means our
+      // handle is stale — stop quietly rather than throwing InvalidStateError.
+      if (dbInstance !== db) return;
       const tx = db.transaction(store, "readwrite");
       let cursor = await tx.store.openCursor();
 
@@ -188,6 +208,9 @@ export async function pruneOldEntries(maxAgeDays = 7): Promise<void> {
       lastAccessedAt: now,
     });
   } catch (error) {
+    // A closed connection mid-prune is expected and harmless for this
+    // best-effort background task; only surface genuine failures.
+    if (isConnectionClosedError(error)) return;
     console.error("Failed to prune old cache entries:", error);
   }
 }


### PR DESCRIPTION
Noticed that the [CI logs ](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/actions/runs/28023777712/job/82946358774?pr=504)were full of things like:

> Failed to prune old cache entries: InvalidStateError [DOMException] { code: 11 }

This was due to a benign race in tests, and not a real bug. This change gets rid of those warnings

