### PR TITLE
fix(telemetry): prevent inverted comparison results for oldest version

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
@@ -50,6 +50,7 @@ const versions: VersionInfo[] = [
 
 describe("TelemetryComparisonSection — defaultFromVersion", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue(
       noopHookReturn
     );

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
@@ -51,9 +51,7 @@ const versions: VersionInfo[] = [
 describe("TelemetryComparisonSection — defaultFromVersion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue(
-      noopHookReturn
-    );
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue(noopHookReturn);
   });
 
   it("uses the next-older version as From when viewing the latest version", () => {

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TelemetryComparisonSection } from "./telemetry-comparison-section";
+import * as useTelemetryComparisonModule from "../../hooks/use-telemetry-comparison";
+import type { VersionInfo } from "@/types/javaagent";
+
+vi.mock("../../hooks/use-telemetry-comparison", () => ({
+  useTelemetryComparison: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const noopHookReturn: useTelemetryComparisonModule.UseTelemetryComparisonResult = {
+  fromVersion: "1.0.0",
+  toVersion: "1.0.0",
+  setFromVersion: vi.fn(),
+  setToVersion: vi.fn(),
+  whenCondition: "default",
+  setWhenCondition: vi.fn(),
+  availableConditions: ["default"],
+  diffResult: null,
+  loading: false,
+  error: null,
+  fromNotFound: false,
+  toNotFound: false,
+};
+
+const versions: VersionInfo[] = [
+  { version: "2.0.0", is_latest: true },
+  { version: "1.5.0", is_latest: false },
+  { version: "1.0.0", is_latest: false },
+];
+
+describe("TelemetryComparisonSection — defaultFromVersion", () => {
+  beforeEach(() => {
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue(
+      noopHookReturn
+    );
+  });
+
+  it("uses the next-older version as From when viewing the latest version", () => {
+    render(
+      <TelemetryComparisonSection
+        instrumentationName="jdbc"
+        versions={versions}
+        currentVersion="2.0.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "jdbc",
+      "1.5.0",
+      "2.0.0"
+    );
+  });
+
+  it("uses the next-older version as From when viewing a middle version", () => {
+    render(
+      <TelemetryComparisonSection
+        instrumentationName="jdbc"
+        versions={versions}
+        currentVersion="1.5.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "jdbc",
+      "1.0.0",
+      "1.5.0"
+    );
+  });
+
+  // Regression for issue #727: previously fell back to versions[0] (latest), producing an
+  // inverted From=latest / To=oldest comparison.
+  it("uses currentVersion as From when viewing the oldest version (no older version exists)", () => {
+    render(
+      <TelemetryComparisonSection
+        instrumentationName="jdbc"
+        versions={versions}
+        currentVersion="1.0.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "jdbc",
+      "1.0.0", // From = oldest (same as To) — triggers same-version warning, not inverted diff
+      "1.0.0"
+    );
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
@@ -34,7 +34,8 @@ export function TelemetryComparisonSection({
   currentVersion,
 }: TelemetryComparisonSectionProps) {
   const { t } = useTranslation("java-agent");
-  // "To" defaults to the version being viewed; "From" defaults to the previous release.
+  // "To" defaults to the version being viewed. "From" defaults to the previous release,
+  // or falls back to currentVersion (triggering a same-version warning) if viewing the oldest version.
   const currentIndex = versions.findIndex((v) => v.version === currentVersion);
   const defaultFromVersion =
     currentIndex < versions.length - 1

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
@@ -38,9 +38,7 @@ export function TelemetryComparisonSection({
   // or falls back to currentVersion (triggering a same-version warning) if viewing the oldest version.
   const currentIndex = versions.findIndex((v) => v.version === currentVersion);
   const defaultFromVersion =
-    currentIndex < versions.length - 1
-      ? versions[currentIndex + 1].version
-      : currentVersion;
+    currentIndex < versions.length - 1 ? versions[currentIndex + 1].version : currentVersion;
 
   const {
     fromVersion,

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/telemetry-comparison-section.tsx
@@ -39,7 +39,7 @@ export function TelemetryComparisonSection({
   const defaultFromVersion =
     currentIndex < versions.length - 1
       ? versions[currentIndex + 1].version
-      : versions[0]?.version || currentVersion;
+      : currentVersion;
 
   const {
     fromVersion,


### PR DESCRIPTION
## Summary

Fixes #727

When the currently selected instrumentation version is the oldest available version, the telemetry comparison view initialized with a reversed comparison range!

This caused telemetry additions and removals to appear with inverted semantics!

## Changes

- Corrected the fallback `defaultFromVersion` selection for the oldest-version case
- Reused the existing same-version warning flow when no older comparison target exists
- Added regression test coverage for the oldest-version scenario

## Validation

- Added regression tests
- All tests passing
- Typecheck passing
- Lint passing
- Manually verified through the UI