### PR TITLE
fix(java-agent): collapse cross-condition telemetry moves into a single changed entry

### DIFF
--- a/ecosystem-explorer/public/locales/en/java-agent.json
+++ b/ecosystem-explorer/public/locales/en/java-agent.json
@@ -291,6 +291,9 @@
     "metricRemoved": "This metric is no longer emitted in the comparison version.",
     "spanRemoved": "This span is no longer emitted in the comparison version.",
     "spanAdded": "This span is newly emitted in the comparison version.",
+    "whenChanged": {
+      "label": "Now only emitted when"
+    },
     "moduleAddedTooltip": "This module was added in the new version",
     "moduleRemovedTooltip": "This module was removed in the new version",
     "moduleChangedTooltip": "This module has telemetry or configuration changes",

--- a/ecosystem-explorer/public/locales/es/java-agent.json
+++ b/ecosystem-explorer/public/locales/es/java-agent.json
@@ -292,7 +292,7 @@
     "spanRemoved": "Este span ya no se emite en la versión de comparación.",
     "spanAdded": "Este span se emite por primera vez en la versión de comparación.",
     "whenChanged": {
-      "label": "Now only emitted when"
+      "label": "Ahora solo se emite cuando"
     },
     "moduleAddedTooltip": "Este módulo se agregó en la nueva versión",
     "moduleRemovedTooltip": "Este módulo se eliminó en la nueva versión",

--- a/ecosystem-explorer/public/locales/es/java-agent.json
+++ b/ecosystem-explorer/public/locales/es/java-agent.json
@@ -291,6 +291,9 @@
     "metricRemoved": "Esta métrica ya no se emite en la versión de comparación.",
     "spanRemoved": "Este span ya no se emite en la versión de comparación.",
     "spanAdded": "Este span se emite por primera vez en la versión de comparación.",
+    "whenChanged": {
+      "label": "Now only emitted when"
+    },
     "moduleAddedTooltip": "Este módulo se agregó en la nueva versión",
     "moduleRemovedTooltip": "Este módulo se eliminó en la nueva versión",
     "moduleChangedTooltip": "Este módulo tiene cambios en telemetría o configuración",

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/metric-diff-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/metric-diff-card.tsx
@@ -25,7 +25,7 @@ interface MetricDiffCardProps {
 
 export function MetricDiffCard({ diff }: MetricDiffCardProps) {
   const { t } = useTranslation("java-agent");
-  const { status, metric, changes } = diff;
+  const { status, metric, changes, whenCondition } = diff;
 
   const statusVariant = status === "added" ? "success" : "warning";
 
@@ -110,6 +110,16 @@ export function MetricDiffCard({ diff }: MetricDiffCardProps) {
                 <span className="text-muted-foreground text-xs">)</span>
               </div>
             )}
+          </div>
+        )}
+
+        {/* When-condition change indicator */}
+        {status === "changed" && !changes && whenCondition && (
+          <div className="space-y-1 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4">
+            <p className="text-sm font-medium text-amber-400">
+              {t("diffCard.whenChanged.label")}
+            </p>
+            <code className="break-all font-mono text-sm text-amber-400">{whenCondition}</code>
           </div>
         )}
 

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/metric-diff-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/metric-diff-card.tsx
@@ -116,10 +116,8 @@ export function MetricDiffCard({ diff }: MetricDiffCardProps) {
         {/* When-condition change indicator */}
         {status === "changed" && !changes && whenCondition && (
           <div className="space-y-1 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4">
-            <p className="text-sm font-medium text-amber-400">
-              {t("diffCard.whenChanged.label")}
-            </p>
-            <code className="break-all font-mono text-sm text-amber-400">{whenCondition}</code>
+            <p className="text-sm font-medium text-amber-400">{t("diffCard.whenChanged.label")}</p>
+            <code className="font-mono text-sm break-all text-amber-400">{whenCondition}</code>
           </div>
         )}
 

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/span-diff-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/span-diff-card.tsx
@@ -25,7 +25,7 @@ interface SpanDiffCardProps {
 
 export function SpanDiffCard({ diff }: SpanDiffCardProps) {
   const { t } = useTranslation("java-agent");
-  const { status, span, changes } = diff;
+  const { status, span, changes, whenCondition } = diff;
 
   const statusVariant = status === "added" ? "success" : "warning";
 
@@ -51,6 +51,16 @@ export function SpanDiffCard({ diff }: SpanDiffCardProps) {
             </GlowBadge>
           </div>
         </div>
+
+        {/* When-condition change indicator */}
+        {status === "changed" && !changes && whenCondition && (
+          <div className="space-y-1 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4">
+            <p className="text-sm font-medium text-amber-400">
+              {t("diffCard.whenChanged.label")}
+            </p>
+            <code className="break-all font-mono text-sm text-amber-400">{whenCondition}</code>
+          </div>
+        )}
 
         {/* Attributes section */}
         {status === "changed" && changes?.attributes && (

--- a/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/span-diff-card.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/telemetry-comparison/span-diff-card.tsx
@@ -55,10 +55,8 @@ export function SpanDiffCard({ diff }: SpanDiffCardProps) {
         {/* When-condition change indicator */}
         {status === "changed" && !changes && whenCondition && (
           <div className="space-y-1 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4">
-            <p className="text-sm font-medium text-amber-400">
-              {t("diffCard.whenChanged.label")}
-            </p>
-            <code className="break-all font-mono text-sm text-amber-400">{whenCondition}</code>
+            <p className="text-sm font-medium text-amber-400">{t("diffCard.whenChanged.label")}</p>
+            <code className="font-mono text-sm break-all text-amber-400">{whenCondition}</code>
           </div>
         )}
 

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
@@ -252,3 +252,220 @@ describe("release-diff utility", () => {
     expect(instr2?.configDiff?.added).toContain("config2");
   });
 });
+
+// Regression tests for issue #732: span moved between when-conditions should not
+// appear as both removed and added.
+describe("cross-condition span/metric deduplication", () => {
+  it("collapses a span moved between when-conditions into changed (jaxrs-1.0 pattern)", () => {
+    const fromData: InstrumentationData[] = [
+      {
+        name: "jaxrs-1.0",
+        display_name: "JAX-RS 1.x",
+        scope: { name: "io.opentelemetry.jaxrs-1.0" },
+        telemetry: [
+          {
+            when: "default",
+            spans: [
+              {
+                span_kind: "INTERNAL",
+                attributes: [
+                  { name: "code.function", type: "STRING" },
+                  { name: "code.namespace", type: "STRING" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const toData: InstrumentationData[] = [
+      {
+        name: "jaxrs-1.0",
+        display_name: "JAX-RS 1.x",
+        scope: { name: "io.opentelemetry.jaxrs-1.0" },
+        telemetry: [
+          {
+            when: "otel.instrumentation.common.experimental.controller-telemetry.enabled=true",
+            spans: [
+              {
+                span_kind: "INTERNAL",
+                attributes: [
+                  { name: "code.function", type: "STRING" },
+                  { name: "code.namespace", type: "STRING" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const diff = compareReleases("2.27.0", "2.28.1", fromData, toData);
+
+    const instr = diff.instrumentations.find((i) => i.id === "jaxrs-1.0");
+    // The span content is identical; only the when-condition label changed.
+    // It must NOT appear as both removed and added — it must be a single "changed" entry
+    // with the new whenCondition populated.
+    expect(instr?.status).toBe("changed");
+    expect(instr?.telemetryDiff.spans).toHaveLength(1);
+    expect(instr?.telemetryDiff.spans[0].status).toBe("changed");
+    expect(instr?.telemetryDiff.spans[0].whenCondition).toBe(
+      "otel.instrumentation.common.experimental.controller-telemetry.enabled=true"
+    );
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "removed")).toBe(false);
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "added")).toBe(false);
+  });
+
+  it("does not collapse when the span content changed across conditions", () => {
+    // Same span_kind but extra attribute in the new version — NOT a pure condition rename.
+    const fromData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "default",
+            spans: [{ span_kind: "INTERNAL", attributes: [{ name: "code.function", type: "STRING" }] }],
+          },
+        ],
+      },
+    ];
+
+    const toData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "some-flag=true",
+            spans: [
+              {
+                span_kind: "INTERNAL",
+                attributes: [
+                  { name: "code.function", type: "STRING" },
+                  { name: "code.namespace", type: "STRING" }, // extra attribute
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const diff = compareReleases("1.0.0", "1.1.0", fromData, toData);
+    const instr = diff.instrumentations.find((i) => i.id === "instr1");
+    // Content differs — must not be silently collapsed.
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "removed")).toBe(true);
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "added")).toBe(true);
+  });
+
+  it("preserves a genuinely removed span (no matching add in any condition)", () => {
+    const fromData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "default",
+            spans: [{ span_kind: "CLIENT", attributes: [{ name: "http.url", type: "STRING" }] }],
+          },
+        ],
+      },
+    ];
+    const toData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [{ when: "default", spans: [] }],
+      },
+    ];
+
+    const diff = compareReleases("1.0.0", "1.1.0", fromData, toData);
+    const instr = diff.instrumentations.find((i) => i.id === "instr1");
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "removed")).toBe(true);
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "added")).toBe(false);
+  });
+
+  it("preserves a genuinely added span (no matching remove in any condition)", () => {
+    const fromData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [{ when: "default", spans: [] }],
+      },
+    ];
+    const toData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "default",
+            spans: [{ span_kind: "CLIENT", attributes: [{ name: "http.url", type: "STRING" }] }],
+          },
+        ],
+      },
+    ];
+
+    const diff = compareReleases("1.0.0", "1.1.0", fromData, toData);
+    const instr = diff.instrumentations.find((i) => i.id === "instr1");
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "added")).toBe(true);
+    expect(instr?.telemetryDiff.spans.some((s) => s.status === "removed")).toBe(false);
+  });
+
+  it("collapses a metric moved between when-conditions into changed", () => {
+    const fromData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "default",
+            metrics: [
+              {
+                name: "jvm.memory.used",
+                description: "Memory used",
+                instrument: "updowncounter",
+                data_type: "LONG_SUM",
+                unit: "By",
+                attributes: [{ name: "pool", type: "STRING" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const toData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "some-flag=true",
+            metrics: [
+              {
+                name: "jvm.memory.used",
+                description: "Memory used",
+                instrument: "updowncounter",
+                data_type: "LONG_SUM",
+                unit: "By",
+                attributes: [{ name: "pool", type: "STRING" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const diff = compareReleases("1.0.0", "1.1.0", fromData, toData);
+    const instr = diff.instrumentations.find((i) => i.id === "instr1");
+    expect(instr?.status).toBe("changed");
+    expect(instr?.telemetryDiff.metrics).toHaveLength(1);
+    expect(instr?.telemetryDiff.metrics[0].status).toBe("changed");
+    expect(instr?.telemetryDiff.metrics[0].whenCondition).toBe("some-flag=true");
+    expect(instr?.telemetryDiff.metrics.some((m) => m.status === "removed")).toBe(false);
+    expect(instr?.telemetryDiff.metrics.some((m) => m.status === "added")).toBe(false);
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
@@ -326,7 +326,9 @@ describe("cross-condition span/metric deduplication", () => {
         telemetry: [
           {
             when: "default",
-            spans: [{ span_kind: "INTERNAL", attributes: [{ name: "code.function", type: "STRING" }] }],
+            spans: [
+              { span_kind: "INTERNAL", attributes: [{ name: "code.function", type: "STRING" }] },
+            ],
           },
         ],
       },

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
@@ -19,8 +19,95 @@ import type {
   TelemetryDiffResult,
   MetricDiff,
   SpanDiff,
+  Span,
+  Metric,
+  Attribute,
 } from "@/types/javaagent";
 import { compareTelemetry, getAvailableWhenConditions } from "./telemetry-diff";
+
+function attrsKey(attrs: Attribute[] | undefined): string {
+  if (!attrs || attrs.length === 0) return "";
+  return [...attrs]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((a) => `${a.name}:${a.type}`)
+    .join("|");
+}
+
+function spansIdentical(a: Span, b: Span): boolean {
+  return a.span_kind === b.span_kind && attrsKey(a.attributes) === attrsKey(b.attributes);
+}
+
+function metricsIdentical(a: Metric, b: Metric): boolean {
+  return (
+    a.name === b.name &&
+    a.description === b.description &&
+    a.data_type === b.data_type &&
+    a.unit === b.unit &&
+    a.instrument === b.instrument &&
+    attrsKey(a.attributes) === attrsKey(b.attributes)
+  );
+}
+
+/**
+ * Collapses (removed, added) pairs that are structurally identical across
+ * different when-conditions into a single "changed" entry. This prevents a span
+ * or metric that was merely re-labelled to a different when-condition from
+ * appearing as both removed and added in the comparison UI. The collapsed entry
+ * carries the new whenCondition so the UI can display the change context.
+ */
+function deduplicateSpanDiffs(spans: SpanDiff[]): SpanDiff[] {
+  const passThrough = spans.filter((s) => s.status !== "removed" && s.status !== "added");
+  const removed = spans.filter((s) => s.status === "removed");
+  const added = spans.filter((s) => s.status === "added");
+
+  const consumed = new Set<number>();
+  const result: SpanDiff[] = [];
+
+  for (const removedEntry of removed) {
+    const matchIdx = added.findIndex((a, i) => !consumed.has(i) && spansIdentical(removedEntry.span, a.span));
+    if (matchIdx !== -1) {
+      consumed.add(matchIdx);
+      result.push({ status: "changed", span: removedEntry.span, whenCondition: added[matchIdx].whenCondition });
+    } else {
+      result.push(removedEntry);
+    }
+  }
+
+  for (let i = 0; i < added.length; i++) {
+    if (!consumed.has(i)) {
+      result.push(added[i]);
+    }
+  }
+
+  return [...passThrough, ...result];
+}
+
+function deduplicateMetricDiffs(metrics: MetricDiff[]): MetricDiff[] {
+  const passThrough = metrics.filter((m) => m.status !== "removed" && m.status !== "added");
+  const removed = metrics.filter((m) => m.status === "removed");
+  const added = metrics.filter((m) => m.status === "added");
+
+  const consumed = new Set<number>();
+  const result: MetricDiff[] = [];
+
+  for (const removedEntry of removed) {
+    const matchIdx = added.findIndex((a, i) => !consumed.has(i) && metricsIdentical(removedEntry.metric, a.metric));
+    if (matchIdx !== -1) {
+      consumed.add(matchIdx);
+      result.push({ status: "changed", metric: removedEntry.metric, whenCondition: added[matchIdx].whenCondition });
+    } else {
+      result.push(removedEntry);
+    }
+  }
+
+  for (let i = 0; i < added.length; i++) {
+    if (!consumed.has(i)) {
+      result.push(added[i]);
+    }
+  }
+
+  return [...passThrough, ...result];
+}
 
 export interface InstrumentationDiff {
   id: string;
@@ -136,10 +223,13 @@ export function compareReleases(
       const spans: SpanDiff[] = [];
       for (const w of whens) {
         const d = compareTelemetry(fromInstr, toInstr, w);
-        metrics.push(...d.metrics);
-        spans.push(...d.spans);
+        metrics.push(...d.metrics.map((m) => ({ ...m, whenCondition: w })));
+        spans.push(...d.spans.map((s) => ({ ...s, whenCondition: w })));
       }
-      const telemetryDiff = { metrics, spans };
+      const telemetryDiff = {
+        metrics: deduplicateMetricDiffs(metrics),
+        spans: deduplicateSpanDiffs(spans),
+      };
 
       const fromConfigs = new Map((fromInstr.configurations || []).map((c) => [c.name, c]));
       const toConfigs = new Map((toInstr.configurations || []).map((c) => [c.name, c]));

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
@@ -71,7 +71,7 @@ function deduplicateSpanDiffs(spans: SpanDiff[]): SpanDiff[] {
       consumed.add(matchIdx);
       result.push({
         status: "changed",
-        span: removedEntry.span,
+        span: added[matchIdx].span,
         whenCondition: added[matchIdx].whenCondition,
       });
     } else {
@@ -104,7 +104,7 @@ function deduplicateMetricDiffs(metrics: MetricDiff[]): MetricDiff[] {
       consumed.add(matchIdx);
       result.push({
         status: "changed",
-        metric: removedEntry.metric,
+        metric: added[matchIdx].metric,
         whenCondition: added[matchIdx].whenCondition,
       });
     } else {

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
@@ -64,10 +64,16 @@ function deduplicateSpanDiffs(spans: SpanDiff[]): SpanDiff[] {
   const result: SpanDiff[] = [];
 
   for (const removedEntry of removed) {
-    const matchIdx = added.findIndex((a, i) => !consumed.has(i) && spansIdentical(removedEntry.span, a.span));
+    const matchIdx = added.findIndex(
+      (a, i) => !consumed.has(i) && spansIdentical(removedEntry.span, a.span)
+    );
     if (matchIdx !== -1) {
       consumed.add(matchIdx);
-      result.push({ status: "changed", span: removedEntry.span, whenCondition: added[matchIdx].whenCondition });
+      result.push({
+        status: "changed",
+        span: removedEntry.span,
+        whenCondition: added[matchIdx].whenCondition,
+      });
     } else {
       result.push(removedEntry);
     }
@@ -91,10 +97,16 @@ function deduplicateMetricDiffs(metrics: MetricDiff[]): MetricDiff[] {
   const result: MetricDiff[] = [];
 
   for (const removedEntry of removed) {
-    const matchIdx = added.findIndex((a, i) => !consumed.has(i) && metricsIdentical(removedEntry.metric, a.metric));
+    const matchIdx = added.findIndex(
+      (a, i) => !consumed.has(i) && metricsIdentical(removedEntry.metric, a.metric)
+    );
     if (matchIdx !== -1) {
       consumed.add(matchIdx);
-      result.push({ status: "changed", metric: removedEntry.metric, whenCondition: added[matchIdx].whenCondition });
+      result.push({
+        status: "changed",
+        metric: removedEntry.metric,
+        whenCondition: added[matchIdx].whenCondition,
+      });
     } else {
       result.push(removedEntry);
     }

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -286,7 +286,7 @@ export interface MetricDiff {
   status: DiffStatus;
   metric: Metric;
   changes?: MetricChanges;
-  /** Populated only when the metric moved between when-conditions without content changes. */
+  /** When-condition associated with this diff entry. For condition-only moves collapsed into a single `changed` entry, this is the destination when-condition. */
   whenCondition?: string;
 }
 
@@ -294,7 +294,7 @@ export interface SpanDiff {
   status: DiffStatus;
   span: Span;
   changes?: SpanChanges;
-  /** Populated only when the span moved between when-conditions without content changes. */
+  /** When-condition associated with this diff entry. For condition-only moves collapsed into a single `changed` entry, this is the destination when-condition. */
   whenCondition?: string;
 }
 

--- a/ecosystem-explorer/src/types/javaagent.ts
+++ b/ecosystem-explorer/src/types/javaagent.ts
@@ -286,12 +286,16 @@ export interface MetricDiff {
   status: DiffStatus;
   metric: Metric;
   changes?: MetricChanges;
+  /** Populated only when the metric moved between when-conditions without content changes. */
+  whenCondition?: string;
 }
 
 export interface SpanDiff {
   status: DiffStatus;
   span: Span;
   changes?: SpanChanges;
+  /** Populated only when the span moved between when-conditions without content changes. */
+  whenCondition?: string;
 }
 
 export interface TelemetryDiffResult {


### PR DESCRIPTION
## Summary

Fixes #732

This PR fixes an issue in the Java Agent release comparison where telemetry that only moved between `when` conditions was rendered as two separate entries (Removed + Added) instead of a single Changed entry.

For example, the JAX-RS 1.x INTERNAL span moved from:

- `default` (v2.27.0)
- `otel.instrumentation.common.experimental.controller-telemetry.enabled=true` (v2.28.1)

Previously this appeared as two separate cards even though the span itself was unchanged.

## What changed

- Added cross-condition span and metric deduplication during release comparison.
- Detect structurally identical Added/Removed pairs and collapse them into a single `changed` entry.
- Preserve the destination `when` condition so it can be surfaced in the UI.
- Added a contextual "Now only emitted when ..." message for condition-only changes.
- Left genuine additions, removals, and content changes unchanged.
- Added regression tests covering:
  - cross-condition span moves
  - cross-condition metric moves
  - genuine additions
  - genuine removals
  - real content changes

## Result

Before:

- Removed
- Added

After:

- Changed
- "Now only emitted when `<condition>`"

This better represents telemetry that has moved between conditions without implying that it was removed and re-added.