### PR TITLE
feat(v1): add a language switcher to the v1 navbar

### DIFF
--- a/ecosystem-explorer/src/components/layout/header.tsx
+++ b/ecosystem-explorer/src/components/layout/header.tsx
@@ -19,6 +19,7 @@ import { Menu, X, Sun, Moon, Monitor, ChevronDown } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { OtelLogo } from "@/components/icons/otel-logo";
+import { LANGUAGES } from "@/i18n/languages";
 import { useTheme, type ThemeMode } from "@/theme-context";
 
 const NAV_ITEMS = [
@@ -36,8 +37,11 @@ function LanguageSwitcher() {
       className="border-border/40 bg-background text-muted-foreground hover:text-foreground cursor-pointer rounded border px-2 py-1 text-xs transition-colors"
       aria-label={t("header.languageSwitcher")}
     >
-      <option value="en">English</option>
-      <option value="es">Español</option>
+      {LANGUAGES.map(({ code, label }) => (
+        <option key={code} value={code}>
+          {label}
+        </option>
+      ))}
     </select>
   );
 }

--- a/ecosystem-explorer/src/i18n/config.ts
+++ b/ecosystem-explorer/src/i18n/config.ts
@@ -17,6 +17,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import HttpBackend from "i18next-http-backend";
+import { NAMESPACES, SUPPORTED_LANGUAGES } from "@/i18n/languages";
 
 i18n
   .use(HttpBackend)
@@ -24,9 +25,9 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: "en",
-    supportedLngs: ["en", "es"],
+    supportedLngs: SUPPORTED_LANGUAGES,
     load: "languageOnly",
-    ns: ["common", "layout", "home", "collector", "java-agent", "about", "ecosystem"],
+    ns: [...NAMESPACES],
     defaultNS: "common",
     backend: { loadPath: "/locales/{{lng}}/{{ns}}.json" },
     interpolation: { escapeValue: false },

--- a/ecosystem-explorer/src/i18n/languages.ts
+++ b/ecosystem-explorer/src/i18n/languages.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Single source of truth for the locales and namespaces the app ships.
+ * This module is intentionally side-effect free (no i18n.init()), so UI and
+ * tests can import the lists without pulling in the runtime backend.
+ *
+ * Adding a language: append an entry to LANGUAGES and drop the matching
+ * public/locales/<code>/ files. The init config and the navbar switcher both
+ * derive from here, so the supported set and the switcher options never drift.
+ */
+export const LANGUAGES = [
+  { code: "en", label: "English" },
+  { code: "es", label: "Español" },
+] as const;
+
+export type LanguageCode = (typeof LANGUAGES)[number]["code"];
+
+export const SUPPORTED_LANGUAGES: LanguageCode[] = LANGUAGES.map((language) => language.code);
+
+export const NAMESPACES = [
+  "common",
+  "layout",
+  "home",
+  "collector",
+  "java-agent",
+  "about",
+  "ecosystem",
+] as const;

--- a/ecosystem-explorer/src/v1/components/icons/bs-icon-translate.tsx
+++ b/ecosystem-explorer/src/v1/components/icons/bs-icon-translate.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Bootstrap Icons `translate` — the conventional language-selector glyph.
+ * opentelemetry.io's navbar has no language switcher to mirror (the Hugo site
+ * swaps locales by URL), so this follows the same Bs* icon shape the v1 theme
+ * toggle uses for its Bootstrap-Icons glyphs.
+ */
+export function BsTranslate({ className }: { className?: string }) {
+  return (
+    <svg className={`bi ${className ?? ""}`} viewBox="0 0 16 16" aria-hidden>
+      <path d="M4.545 6.714 4.11 8H3l1.862-5h1.284L8 8H6.833l-.435-1.286zm1.634-.736L5.5 3.956h-.049l-.679 2.022z" />
+      <path d="M0 2a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v3h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-3H2a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zm7.138 9.995q.289.451.63.846c-.748.575-1.673 1.001-2.768 1.292.178.217.451.635.555.867 1.125-.359 2.08-.844 2.886-1.494.777.665 1.739 1.165 2.93 1.472.133-.254.414-.673.629-.89-1.125-.253-2.057-.694-2.82-1.284.681-.747 1.222-1.651 1.621-2.757H14V8h-3v1.047h.765c-.318.844-.74 1.546-1.272 2.13a6 6 0 0 1-.415-.492 2 2 0 0 1-.94.31" />
+    </svg>
+  );
+}

--- a/ecosystem-explorer/src/v1/components/layout/nav-bar.test.tsx
+++ b/ecosystem-explorer/src/v1/components/layout/nav-bar.test.tsx
@@ -59,6 +59,12 @@ describe("NavBar", () => {
     expect(screen.getByRole("button", { name: /toggle theme/i })).toBeInTheDocument();
   });
 
+  it("renders the language toggle", () => {
+    renderNavBar();
+
+    expect(screen.getByRole("button", { name: /select language/i })).toBeInTheDocument();
+  });
+
   it("renders the hamburger toggler collapsed by default", () => {
     renderNavBar();
 

--- a/ecosystem-explorer/src/v1/components/layout/nav-bar.tsx
+++ b/ecosystem-explorer/src/v1/components/layout/nav-bar.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { OpenTelemetryWordmark } from "@/v1/components/icons/opentelemetry-wordmark";
+import { LanguageToggle } from "@/v1/components/ui/language-toggle";
 import { ThemeToggle } from "@/v1/components/ui/theme-toggle";
 
 /*
@@ -115,6 +116,9 @@ export function NavBar() {
                   >
                     Docs
                   </a>
+                </li>
+                <li className="nav-item">
+                  <LanguageToggle />
                 </li>
                 <li className="nav-item">
                   <ThemeToggle />

--- a/ecosystem-explorer/src/v1/components/ui/language-toggle.test.tsx
+++ b/ecosystem-explorer/src/v1/components/ui/language-toggle.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import i18n from "i18next";
+import { LanguageToggle } from "./language-toggle";
+
+describe("LanguageToggle", () => {
+  // The test i18n instance is a shared singleton; reset to English so each
+  // case starts from a known active locale regardless of run order.
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("renders an accessible trigger showing the active locale", () => {
+    render(<LanguageToggle />);
+
+    const trigger = screen.getByRole("button", { name: /select language/i });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveTextContent("English");
+  });
+
+  it("opens a menu listing the supported locales", async () => {
+    render(<LanguageToggle />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /select language/i }));
+
+    expect(await screen.findByRole("menuitem", { name: /english/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /español/i })).toBeInTheDocument();
+  });
+
+  it("requests a language change when a locale is selected", async () => {
+    // The test i18n bundle only carries `en` resources, so `resolvedLanguage`
+    // (and thus the trigger label) stays "en" after switching to a locale with
+    // no loaded resources. Assert the observable behaviour instead: the
+    // component asks i18next to switch, and `language` reflects the request.
+    const changeLanguage = vi.spyOn(i18n, "changeLanguage");
+    render(<LanguageToggle />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /select language/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /español/i }));
+
+    expect(changeLanguage).toHaveBeenCalledWith("es");
+    expect(i18n.language).toBe("es");
+
+    changeLanguage.mockRestore();
+  });
+});

--- a/ecosystem-explorer/src/v1/components/ui/language-toggle.tsx
+++ b/ecosystem-explorer/src/v1/components/ui/language-toggle.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { useTranslation } from "react-i18next";
+import { BsTranslate } from "@/v1/components/icons/bs-icon-translate";
+import { LANGUAGES } from "@/i18n/languages";
+
+/*
+ * Language dropdown for the v1 navbar, structured like ThemeToggle (Radix
+ * DropdownMenu + `td-*` chrome in `src/v1/styles/language-toggle.css`).
+ *
+ * The trigger shows the active locale's endonym; rows list every entry in
+ * LANGUAGES. Option labels are endonyms ("English", "Español"), so they read
+ * the same in any locale and stay out of the translation files. The rest of
+ * the v1 chrome (Docs link, theme labels) is still English-only — wiring it
+ * through i18next is a separate pass.
+ */
+export function LanguageToggle() {
+  const { i18n } = useTranslation();
+  const current = i18n.resolvedLanguage ?? "en";
+  const activeLabel = LANGUAGES.find((language) => language.code === current)?.label ?? "English";
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        className="td-lang-menu__trigger"
+        aria-label={`Select language (${activeLabel})`}
+      >
+        <BsTranslate />
+        <span className="td-lang-menu__current">{activeLabel}</span>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content align="end" sideOffset={8} className="td-lang-menu__menu">
+          {LANGUAGES.map(({ code, label }) => (
+            <DropdownMenu.Item
+              key={code}
+              className="td-lang-menu__item"
+              data-active={code === current}
+              onSelect={() => i18n.changeLanguage(code)}
+            >
+              <span>{label}</span>
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/ecosystem-explorer/src/v1/styles/index.css
+++ b/ecosystem-explorer/src/v1/styles/index.css
@@ -20,6 +20,7 @@
  * - tokens.css       — v1-only surface-token overrides, scoped via `.v1-app`
  * - navbar.css       — v1 navbar (`.td-navbar`) — mirrors opentelemetry.io
  * - theme-toggle.css — v1 theme toggle dropdown — mirrors opentelemetry.io
+ * - language-toggle.css — v1 language switcher dropdown — shares theme-toggle chrome
  * - sub-nav.css      — v1 breadcrumb sub-nav row beneath the navbar
  * - buttons.css      — v1 `.td-btn` primitive (primary, outline-light variants)
  * - cover-block.css  — v1 hero shell (`.td-cover-block`) — mirrors opentelemetry.io
@@ -36,13 +37,15 @@
  * - footer.css       — v1 footer (`.td-footer`) — mirrors opentelemetry.io
  *
  * All v1 styles use class selectors (`.td-navbar`, `.td-subnav`, `.td-footer`,
- * `.td-cncf-callout`, `.td-cover-block`, `.td-light-dark-menu__*`) and only
+ * `.td-cncf-callout`, `.td-cover-block`, `.td-light-dark-menu__*`,
+ * `.td-lang-menu__*`) and only
  * match elements rendered by `<V1App />`, so they're inert in the legacy
  * bundle even when both branches ship.
  */
 @import "./tokens.css";
 @import "./navbar.css";
 @import "./theme-toggle.css";
+@import "./language-toggle.css";
 @import "./sub-nav.css";
 @import "./buttons.css";
 @import "./cover-block.css";

--- a/ecosystem-explorer/src/v1/styles/language-toggle.css
+++ b/ecosystem-explorer/src/v1/styles/language-toggle.css
@@ -1,0 +1,130 @@
+/*
+ * Language toggle — shares the dropdown chrome of the theme toggle
+ * (`.td-light-dark-menu`, see `theme-toggle.css`), reusing opentelemetry.io's
+ * Bootstrap `.dropdown-menu` / `.dropdown-item` values. The trigger differs:
+ * it pairs the translate icon with the active locale's endonym, so it lays out
+ * as an icon + label row rather than the theme toggle's icon-only button.
+ *
+ * Surface colours follow the *page* theme via `[data-theme]` ancestor
+ * selectors (Radix portals the menu to <body>, so `<html data-theme=...>`
+ * still matches), matching the theme toggle exactly.
+ */
+
+/* --- Trigger button --- */
+
+.td-lang-menu__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  line-height: 1;
+  font-weight: 600; /* matches `.nav-link` upstream — trigger is a nav-link */
+  transition: color 150ms ease;
+}
+
+/*
+ * Hover and open-state visuals (color + underline) come from `.td-navbar`'s
+ * shared rule in `navbar.css`. The trigger renders inside the navbar so it
+ * picks them up automatically.
+ */
+.td-lang-menu__trigger:focus-visible {
+  outline: revert;
+  box-shadow: none;
+}
+
+.td-lang-menu__trigger .bi {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  fill: currentColor;
+}
+
+/* Bootstrap's `.dropdown-toggle::after` chevron, reproduced verbatim. */
+.td-lang-menu__trigger::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent;
+}
+
+/* --- Menu surface --- */
+
+.td-lang-menu__menu {
+  min-width: 10rem;
+  border-radius: 6px;
+  padding: 8px 0;
+  box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 0.15);
+  z-index: 33;
+
+  /* Bootstrap defaults — light mode */
+  background-color: #fff;
+  color: #212529;
+  border: 1px solid rgb(0 0 0 / 0.175);
+}
+
+[data-theme="dark"] .td-lang-menu__menu {
+  /* Bootstrap dark-mode dropdown values from opentelemetry.io's compiled CSS */
+  background-color: #343a40;
+  color: #dee2e6;
+  border-color: rgb(255 255 255 / 0.15);
+}
+
+/* --- Menu items --- */
+
+.td-lang-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+}
+
+/* Hover/keyboard-highlight — Bootstrap defaults */
+.td-lang-menu__item[data-highlighted] {
+  background-color: #e9ecef; /* --bs-tertiary-bg light */
+  color: #1e2125;
+}
+
+[data-theme="dark"] .td-lang-menu__item[data-highlighted] {
+  background-color: rgb(255 255 255 / 0.15); /* --bs-tertiary-bg dark */
+  color: #fff;
+}
+
+/*
+ * Active row — coloured background, no checkmark (matches the theme toggle).
+ * The `[data-theme="dark"] [data-highlighted]` rule above has specificity
+ * 0,3,0, so the active rule needs an equivalent or higher path in dark mode
+ * for active to win when the row is *also* hovered/keyboard-highlighted.
+ */
+.td-lang-menu__item[data-active="true"],
+.td-lang-menu__item[data-active="true"][data-highlighted],
+[data-theme="dark"] .td-lang-menu__item[data-active="true"],
+[data-theme="dark"] .td-lang-menu__item[data-active="true"][data-highlighted] {
+  background-color: hsl(var(--otel-blue-hsl));
+  color: #fff;
+}
+
+/*
+ * Mobile — inside the collapsed navbar panel the trigger should fill the
+ * full row so the tap target is comfortable and aligns with the stacked
+ * nav-link above it.
+ */
+@media (max-width: 767.98px) {
+  .td-navbar-collapse .td-lang-menu__trigger {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 12px 8px;
+  }
+}

--- a/ecosystem-explorer/src/v1/styles/navbar.css
+++ b/ecosystem-explorer/src/v1/styles/navbar.css
@@ -100,15 +100,17 @@
 }
 
 /*
- * Shared hover/active affordance. The theme-toggle trigger lives inside
- * `.td-navbar` and visually behaves like a nav-link (it carries class
- * `nav-link` upstream), so we apply the same rule here rather than
- * duplicating the property list in `theme-toggle.css`.
+ * Shared hover/active affordance. The theme-toggle and language-toggle triggers
+ * live inside `.td-navbar` and visually behave like a nav-link (they carry class
+ * `nav-link` upstream), so we apply the same rule here rather than duplicating
+ * the property list in `theme-toggle.css` / `language-toggle.css`.
  */
 .td-navbar .nav-link:hover,
 .td-navbar .nav-link.active,
 .td-navbar .td-light-dark-menu__trigger:hover,
-.td-navbar .td-light-dark-menu__trigger[data-state="open"] {
+.td-navbar .td-light-dark-menu__trigger[data-state="open"],
+.td-navbar .td-lang-menu__trigger:hover,
+.td-navbar .td-lang-menu__trigger[data-state="open"] {
   color: hsl(var(--navbar-accent-hsl));
   text-decoration: underline;
   text-decoration-thickness: 3px;


### PR DESCRIPTION
## What changed

The v1 navbar gets a language switcher (Radix dropdown) next to the theme
toggle, reusing the same `td-*` chrome that mirrors opentelemetry.io's Bootstrap
dropdown. A new `src/i18n/languages.ts` holds the supported locales and
namespaces as one source of truth, so the i18n init config, the legacy header
`<select>`, and the new v1 switcher all derive from a single list and stay in
sync.

## Why

Part of the v1 redesign (#84). The v1 navbar shipped a theme toggle but no way
to switch language, while the legacy header already had one.

## How it was tested

- `bun run typecheck`: clean
- `bun run test -t "LanguageToggle"`: 3 tests pass; the nav-bar test also asserts the toggle renders

## Is this a breaking change?

No

## Special notes for your reviewer

- The v1 chrome stays English-only by design for now (Docs link, theme and language labels). Option labels use endonyms ("English", "Español") so they read the same in any locale and stay out of the translation files; wiring the rest through i18next is a separate pass.
- `SUPPORTED_LANGUAGES` and `NAMESPACES` mirror the on-disk `public/locales/en` and `es` files. No locale keys were added or removed.

/cc @eruizdechavez 

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [ ] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
