### PR TITLE
feat(about): add ecosystem coverage statistics

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -22,7 +22,7 @@ from semantic_version import Version
 
 from explorer_db_builder.collector_database_writer import CollectorDatabaseWriter
 from explorer_db_builder.collector_transformer import make_index_component, transform_collector_components
-from explorer_db_builder.ecosystem_stats import count_unique_component_ids
+from explorer_db_builder.ecosystem_stats import count_unique_collector_component_ids
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +154,7 @@ def run_collector_builder(
         db_writer.write_ecosystem_stats(
             {
                 "version_count": len(processed_versions),
-                "component_count": count_unique_component_ids(components_by_version),
+                "component_count": count_unique_collector_component_ids(components_by_version),
             }
         )
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -22,6 +22,7 @@ from semantic_version import Version
 
 from explorer_db_builder.collector_database_writer import CollectorDatabaseWriter
 from explorer_db_builder.collector_transformer import make_index_component, transform_collector_components
+from explorer_db_builder.ecosystem_stats import count_unique_component_ids
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ def run_collector_builder(
 
         processed_versions: list[Version] = []
         latest_components: list[dict] = []
+        components_by_version: list[list[dict]] = []
         bundle_hashes: dict[Version, str] = {}
 
         for version in versions:
@@ -139,6 +141,7 @@ def run_collector_builder(
 
             processed_versions.append(version)
             bundle_hashes[version] = bundle_hash
+            components_by_version.append(components)
             if not latest_components:
                 latest_components = components
 
@@ -147,6 +150,13 @@ def run_collector_builder(
 
         db_writer.write_version_list(processed_versions, bundle_hashes)
         db_writer.write_index(latest_components)
+
+        db_writer.write_ecosystem_stats(
+            {
+                "version_count": len(processed_versions),
+                "component_count": count_unique_component_ids(components_by_version),
+            }
+        )
 
         stats = db_writer.get_stats()
         total_mb = stats["total_bytes"] / (1024 * 1024)

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
@@ -250,6 +250,25 @@ class CollectorDatabaseWriter:
             logger.error("Failed to write index.json: %s", e)
             raise
 
+    def write_ecosystem_stats(self, stats: dict[str, Any]) -> None:
+        """Write the collector ecosystem-stats.json summary file.
+
+        Args:
+            stats: Dict with "version_count" and "component_count".
+
+        Raises:
+            OSError: If file writing fails.
+        """
+        self.database_dir.mkdir(parents=True, exist_ok=True)
+
+        output_file = self.database_dir / "ecosystem-stats.json"
+        try:
+            self._write_json(output_file, stats)
+            logger.info("Wrote collector ecosystem stats: %s", stats)
+        except OSError as e:
+            logger.error("Failed to write ecosystem stats: %s", e)
+            raise
+
     def get_stats(self) -> dict[str, Any]:
         return {"files_written": self.files_written, "total_bytes": self.total_bytes}
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
@@ -295,6 +295,30 @@ class DatabaseWriter:
             logger.error(f"Failed to write global configurations: {e}")
             raise
 
+    def write_ecosystem_stats(self, stats: dict[str, Any]) -> None:
+        """Write the javaagent ecosystem-stats.json summary file.
+
+        Args:
+            stats: Dict with "version_count" and "library_count".
+
+        Raises:
+            OSError: If file writing fails.
+        """
+        self.database_dir.mkdir(parents=True, exist_ok=True)
+
+        output_file = self.database_dir / "ecosystem-stats.json"
+        try:
+            content = json.dumps(stats, indent=2, sort_keys=True)
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(content)
+            file_size = len(content.encode("utf-8"))
+            self.files_written += 1
+            self.total_bytes += file_size
+            logger.info(f"Wrote javaagent ecosystem stats: {stats}")
+        except OSError as e:
+            logger.error(f"Failed to write ecosystem stats: {e}")
+            raise
+
     def write_markdown(self, library_name: str, markdown_hash: str, content: str) -> None:
         """Write markdown file to the database.
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/ecosystem_stats.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/ecosystem_stats.py
@@ -22,7 +22,7 @@ reflects the latest version, so these unions must run over every loaded version 
 from typing import Any
 
 
-def count_unique_library_names(inventories: list[dict[str, Any]]) -> int:
+def count_unique_java_library_names(inventories: list[dict[str, Any]]) -> int:
     """Count unique instrumentation names across all versions.
 
     Libraries and custom instrumentations are counted together, matching how every other
@@ -45,7 +45,7 @@ def count_unique_library_names(inventories: list[dict[str, Any]]) -> int:
     return len(names)
 
 
-def count_unique_component_ids(components_by_version: list[list[dict[str, Any]]]) -> int:
+def count_unique_collector_component_ids(components_by_version: list[list[dict[str, Any]]]) -> int:
     """Count unique collector component ids across all versions.
 
     Args:

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/ecosystem_stats.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/ecosystem_stats.py
@@ -1,0 +1,64 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Aggregate cross-version counts for the About page's ecosystem-stats.json.
+
+Produces the counts written to ecosystem-stats.json during the javaagent and collector
+builds. Pure (no I/O); the respective DatabaseWriter writes the file. index.json only
+reflects the latest version, so these unions must run over every loaded version instead.
+"""
+
+from typing import Any
+
+
+def count_unique_library_names(inventories: list[dict[str, Any]]) -> int:
+    """Count unique instrumentation names across all versions.
+
+    Libraries and custom instrumentations are counted together, matching how every other
+    javaagent artifact (index.json, version bundles) already treats the two lists as one
+    combined instrumentation set.
+
+    Args:
+        inventories: Per-version inventories, each with "libraries" and/or "custom" lists.
+
+    Returns:
+        The number of distinct instrumentation names across all inventories.
+    """
+    names: set[str] = set()
+    for inventory in inventories:
+        for key in ("libraries", "custom"):
+            for item in inventory.get(key) or []:
+                name = item.get("name")
+                if name:
+                    names.add(name)
+    return len(names)
+
+
+def count_unique_component_ids(components_by_version: list[list[dict[str, Any]]]) -> int:
+    """Count unique collector component ids across all versions.
+
+    Args:
+        components_by_version: One list of canonical component dicts (each with an "id"
+            field) per processed version.
+
+    Returns:
+        The number of distinct component ids across all versions.
+    """
+    ids: set[str] = set()
+    for components in components_by_version:
+        for component in components:
+            component_id = component.get("id")
+            if component_id:
+                ids.add(component_id)
+    return len(ids)

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -27,7 +27,7 @@ from explorer_db_builder.configuration_aggregator import build_global_configurat
 from explorer_db_builder.configuration_builder import run_configuration_builder
 from explorer_db_builder.database_writer import DatabaseWriter
 from explorer_db_builder.declarative_name_corrections import apply_declarative_name_corrections
-from explorer_db_builder.ecosystem_stats import count_unique_library_names
+from explorer_db_builder.ecosystem_stats import count_unique_java_library_names
 from explorer_db_builder.instrumentation_transformer import (
     make_list_instrumentation,
     transform_instrumentation_format,
@@ -239,7 +239,7 @@ def run_javaagent_builder(
         db_writer.write_ecosystem_stats(
             {
                 "version_count": len(versions),
-                "library_count": count_unique_library_names([backfilled_inventories[v] for v in versions]),
+                "library_count": count_unique_java_library_names([backfilled_inventories[v] for v in versions]),
             }
         )
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -27,6 +27,7 @@ from explorer_db_builder.configuration_aggregator import build_global_configurat
 from explorer_db_builder.configuration_builder import run_configuration_builder
 from explorer_db_builder.database_writer import DatabaseWriter
 from explorer_db_builder.declarative_name_corrections import apply_declarative_name_corrections
+from explorer_db_builder.ecosystem_stats import count_unique_library_names
 from explorer_db_builder.instrumentation_transformer import (
     make_list_instrumentation,
     transform_instrumentation_format,
@@ -234,6 +235,13 @@ def run_javaagent_builder(
 
         global_configurations = build_global_configurations([backfilled_inventories[v] for v in versions])
         db_writer.write_global_configurations(global_configurations)
+
+        db_writer.write_ecosystem_stats(
+            {
+                "version_count": len(versions),
+                "library_count": count_unique_library_names([backfilled_inventories[v] for v in versions]),
+            }
+        )
 
         stats = db_writer.get_stats()
         total_mb = stats["total_bytes"] / (1024 * 1024)

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
@@ -300,6 +300,52 @@ class TestRunCollectorBuilder:
         assert versions_listed == ["0.151.0"]
         assert not (tmp_path / "collector" / "versions" / "0.150.0-index.json").exists()
 
+    def test_writes_ecosystem_stats(self, tmp_path):
+        manager = _make_mock_inventory_manager()
+        db_writer = CollectorDatabaseWriter(database_dir=str(tmp_path / "collector"))
+
+        result = run_collector_builder(inventory_manager=manager, db_writer=db_writer)
+
+        assert result == 0
+        with open(tmp_path / "collector" / "ecosystem-stats.json") as f:
+            data = json.load(f)
+
+        assert data["version_count"] == 2
+        # Both mocked versions carry the same 3 components (core: 1 receiver, contrib: 2
+        # receivers), so the union across versions is still 3, not 6.
+        assert data["component_count"] == 3
+
+    def test_ecosystem_stats_counts_components_removed_in_newer_versions(self, tmp_path):
+        """A component present only in an older version still contributes to the total."""
+        inventories = {
+            ("core", Version("0.151.0")): _make_core_inventory("0.151.0"),
+            ("contrib", Version("0.151.0")): {
+                "distribution": "contrib",
+                "version": "0.151.0",
+                "repository": "opentelemetry-collector-contrib",
+                "components": {
+                    "receiver": [],
+                    "processor": [],
+                    "exporter": [],
+                    "connector": [],
+                    "extension": [],
+                },
+            },
+            ("core", Version("0.150.0")): _make_core_inventory("0.150.0"),
+            ("contrib", Version("0.150.0")): _make_contrib_inventory("0.150.0"),
+        }
+        manager = _make_mock_inventory_manager(inventories=inventories)
+        db_writer = CollectorDatabaseWriter(database_dir=str(tmp_path / "collector"))
+
+        result = run_collector_builder(inventory_manager=manager, db_writer=db_writer)
+
+        assert result == 0
+        with open(tmp_path / "collector" / "ecosystem-stats.json") as f:
+            data = json.load(f)
+
+        # 0.151.0 has only core's 1 receiver; 0.150.0 additionally has contrib's 2 receivers.
+        assert data["component_count"] == 3
+
     def test_returns_1_when_all_versions_empty(self, tmp_path):
         inventories = {
             ("core", Version("0.151.0")): {

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
@@ -255,6 +255,33 @@ class TestWriteIndex:
         assert "attributes" not in otlp
 
 
+class TestWriteEcosystemStats:
+    def test_writes_deterministic_file(self, db_writer, temp_db_dir):
+        """Serialization is exactly json.dumps(indent=2, sort_keys=True) with no trailing newline."""
+        stats = {"version_count": 7, "component_count": 312}
+
+        db_writer.write_ecosystem_stats(stats)
+
+        raw = (temp_db_dir / "ecosystem-stats.json").read_text(encoding="utf-8")
+        assert raw == json.dumps(stats, indent=2, sort_keys=True)
+        assert not raw.endswith("\n")
+
+    def test_writes_expected_shape(self, db_writer, temp_db_dir):
+        db_writer.write_ecosystem_stats({"version_count": 7, "component_count": 312})
+
+        with open(temp_db_dir / "ecosystem-stats.json") as f:
+            data = json.load(f)
+        assert data == {"version_count": 7, "component_count": 312}
+
+    def test_counts_bytes_in_stats(self, db_writer):
+        """The write increments files_written and total_bytes."""
+        db_writer.write_ecosystem_stats({"version_count": 1, "component_count": 1})
+
+        stats = db_writer.get_stats()
+        assert stats["files_written"] == 1
+        assert stats["total_bytes"] > 0
+
+
 class TestGetStats:
     def test_initial_stats(self, db_writer):
         stats = db_writer.get_stats()

--- a/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
@@ -721,3 +721,29 @@ class TestWriteGlobalConfigurations:
         db_writer.write_global_configurations([])
 
         assert json.loads((temp_db_dir / "global-configurations.json").read_text(encoding="utf-8")) == []
+
+
+class TestWriteEcosystemStats:
+    def test_writes_deterministic_file(self, db_writer, temp_db_dir):
+        """Serialization is exactly json.dumps(indent=2, sort_keys=True) with no trailing newline."""
+        stats = {"version_count": 5, "library_count": 253}
+
+        db_writer.write_ecosystem_stats(stats)
+
+        raw = (temp_db_dir / "ecosystem-stats.json").read_text(encoding="utf-8")
+        assert raw == json.dumps(stats, indent=2, sort_keys=True)
+        assert not raw.endswith("\n")
+
+    def test_writes_expected_shape(self, db_writer, temp_db_dir):
+        db_writer.write_ecosystem_stats({"version_count": 5, "library_count": 253})
+
+        data = json.loads((temp_db_dir / "ecosystem-stats.json").read_text(encoding="utf-8"))
+        assert data == {"version_count": 5, "library_count": 253}
+
+    def test_counts_bytes_in_stats(self, db_writer):
+        """The write increments files_written and total_bytes."""
+        db_writer.write_ecosystem_stats({"version_count": 1, "library_count": 1})
+
+        stats = db_writer.get_stats()
+        assert stats["files_written"] == 1
+        assert stats["total_bytes"] > 0

--- a/ecosystem-automation/explorer-db-builder/tests/test_ecosystem_stats.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_ecosystem_stats.py
@@ -1,0 +1,106 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the ecosystem stats aggregator."""
+
+from explorer_db_builder.ecosystem_stats import (
+    count_unique_component_ids,
+    count_unique_library_names,
+)
+
+
+def _inventory(libraries=None, custom=None):
+    inv = {}
+    if libraries is not None:
+        inv["libraries"] = libraries
+    if custom is not None:
+        inv["custom"] = custom
+    return inv
+
+
+class TestCountUniqueLibraryNames:
+    def test_counts_libraries_across_a_single_version(self):
+        inventories = [_inventory(libraries=[{"name": "jdbc"}, {"name": "servlet-5.0"}])]
+
+        assert count_unique_library_names(inventories) == 2
+
+    def test_dedups_names_repeated_across_versions(self):
+        inventories = [
+            _inventory(libraries=[{"name": "jdbc"}]),
+            _inventory(libraries=[{"name": "jdbc"}]),
+        ]
+
+        assert count_unique_library_names(inventories) == 1
+
+    def test_counts_a_name_added_in_an_older_version_only(self):
+        """A library present only in an older version still contributes to the total."""
+        inventories = [
+            _inventory(libraries=[{"name": "jdbc"}]),
+            _inventory(libraries=[{"name": "jdbc"}, {"name": "removed-lib"}]),
+        ]
+
+        assert count_unique_library_names(inventories) == 2
+
+    def test_combines_libraries_and_custom(self):
+        inventories = [_inventory(libraries=[{"name": "jdbc"}], custom=[{"name": "custom-a"}])]
+
+        assert count_unique_library_names(inventories) == 2
+
+    def test_same_name_in_libraries_and_custom_counts_once(self):
+        inventories = [_inventory(libraries=[{"name": "shared"}], custom=[{"name": "shared"}])]
+
+        assert count_unique_library_names(inventories) == 1
+
+    def test_item_missing_name_is_skipped(self):
+        inventories = [_inventory(libraries=[{"version": "1.0"}, {"name": "kept"}])]
+
+        assert count_unique_library_names(inventories) == 1
+
+    def test_empty_inventories_returns_zero(self):
+        assert count_unique_library_names([]) == 0
+
+    def test_inventory_with_no_libraries_or_custom_key_contributes_nothing(self):
+        assert count_unique_library_names([_inventory()]) == 0
+
+
+class TestCountUniqueComponentIds:
+    def test_counts_ids_across_a_single_version(self):
+        components_by_version = [[{"id": "core-nopreceiver"}, {"id": "contrib-otlpreceiver"}]]
+
+        assert count_unique_component_ids(components_by_version) == 2
+
+    def test_dedups_ids_repeated_across_versions(self):
+        components_by_version = [
+            [{"id": "core-nopreceiver"}],
+            [{"id": "core-nopreceiver"}],
+        ]
+
+        assert count_unique_component_ids(components_by_version) == 1
+
+    def test_counts_an_id_removed_in_a_newer_version(self):
+        """A component present only in an older version still contributes to the total."""
+        components_by_version = [
+            [{"id": "core-nopreceiver"}],
+            [{"id": "core-nopreceiver"}, {"id": "core-removedreceiver"}],
+        ]
+
+        assert count_unique_component_ids(components_by_version) == 2
+
+    def test_component_missing_id_is_skipped(self):
+        components_by_version = [[{"name": "no-id"}, {"id": "kept"}]]
+
+        assert count_unique_component_ids(components_by_version) == 1
+
+    def test_empty_input_returns_zero(self):
+        assert count_unique_component_ids([]) == 0

--- a/ecosystem-automation/explorer-db-builder/tests/test_ecosystem_stats.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_ecosystem_stats.py
@@ -15,8 +15,8 @@
 """Tests for the ecosystem stats aggregator."""
 
 from explorer_db_builder.ecosystem_stats import (
-    count_unique_component_ids,
-    count_unique_library_names,
+    count_unique_collector_component_ids,
+    count_unique_java_library_names,
 )
 
 
@@ -33,7 +33,7 @@ class TestCountUniqueLibraryNames:
     def test_counts_libraries_across_a_single_version(self):
         inventories = [_inventory(libraries=[{"name": "jdbc"}, {"name": "servlet-5.0"}])]
 
-        assert count_unique_library_names(inventories) == 2
+        assert count_unique_java_library_names(inventories) == 2
 
     def test_dedups_names_repeated_across_versions(self):
         inventories = [
@@ -41,7 +41,7 @@ class TestCountUniqueLibraryNames:
             _inventory(libraries=[{"name": "jdbc"}]),
         ]
 
-        assert count_unique_library_names(inventories) == 1
+        assert count_unique_java_library_names(inventories) == 1
 
     def test_counts_a_name_added_in_an_older_version_only(self):
         """A library present only in an older version still contributes to the total."""
@@ -50,35 +50,35 @@ class TestCountUniqueLibraryNames:
             _inventory(libraries=[{"name": "jdbc"}, {"name": "removed-lib"}]),
         ]
 
-        assert count_unique_library_names(inventories) == 2
+        assert count_unique_java_library_names(inventories) == 2
 
     def test_combines_libraries_and_custom(self):
         inventories = [_inventory(libraries=[{"name": "jdbc"}], custom=[{"name": "custom-a"}])]
 
-        assert count_unique_library_names(inventories) == 2
+        assert count_unique_java_library_names(inventories) == 2
 
     def test_same_name_in_libraries_and_custom_counts_once(self):
         inventories = [_inventory(libraries=[{"name": "shared"}], custom=[{"name": "shared"}])]
 
-        assert count_unique_library_names(inventories) == 1
+        assert count_unique_java_library_names(inventories) == 1
 
     def test_item_missing_name_is_skipped(self):
         inventories = [_inventory(libraries=[{"version": "1.0"}, {"name": "kept"}])]
 
-        assert count_unique_library_names(inventories) == 1
+        assert count_unique_java_library_names(inventories) == 1
 
     def test_empty_inventories_returns_zero(self):
-        assert count_unique_library_names([]) == 0
+        assert count_unique_java_library_names([]) == 0
 
     def test_inventory_with_no_libraries_or_custom_key_contributes_nothing(self):
-        assert count_unique_library_names([_inventory()]) == 0
+        assert count_unique_java_library_names([_inventory()]) == 0
 
 
 class TestCountUniqueComponentIds:
     def test_counts_ids_across_a_single_version(self):
         components_by_version = [[{"id": "core-nopreceiver"}, {"id": "contrib-otlpreceiver"}]]
 
-        assert count_unique_component_ids(components_by_version) == 2
+        assert count_unique_collector_component_ids(components_by_version) == 2
 
     def test_dedups_ids_repeated_across_versions(self):
         components_by_version = [
@@ -86,7 +86,7 @@ class TestCountUniqueComponentIds:
             [{"id": "core-nopreceiver"}],
         ]
 
-        assert count_unique_component_ids(components_by_version) == 1
+        assert count_unique_collector_component_ids(components_by_version) == 1
 
     def test_counts_an_id_removed_in_a_newer_version(self):
         """A component present only in an older version still contributes to the total."""
@@ -95,12 +95,12 @@ class TestCountUniqueComponentIds:
             [{"id": "core-nopreceiver"}, {"id": "core-removedreceiver"}],
         ]
 
-        assert count_unique_component_ids(components_by_version) == 2
+        assert count_unique_collector_component_ids(components_by_version) == 2
 
     def test_component_missing_id_is_skipped(self):
         components_by_version = [[{"name": "no-id"}, {"id": "kept"}]]
 
-        assert count_unique_component_ids(components_by_version) == 1
+        assert count_unique_collector_component_ids(components_by_version) == 1
 
     def test_empty_input_returns_zero(self):
-        assert count_unique_component_ids([]) == 0
+        assert count_unique_collector_component_ids([]) == 0

--- a/ecosystem-automation/explorer-db-builder/tests/test_main.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_main.py
@@ -426,6 +426,33 @@ class TestRunJavaagentBuilder:
         assert data[0]["type"] == "list"
         assert data[0]["instrumentations"] == ["jdbc"]
 
+    def test_writes_ecosystem_stats(self, tmp_path):
+        """run_javaagent_builder writes ecosystem-stats.json with version and unique library counts."""
+        inventory_manager = MagicMock()
+        inventory_manager.list_versions.return_value = [Version("2.1.0"), Version("2.0.0")]
+        inventory_manager.load_library_readme_map.return_value = {}
+        inventory_manager.load_versioned_inventory.side_effect = lambda v: {
+            Version("2.1.0"): {
+                "file_format": 0.5,
+                "libraries": [{"name": "jdbc"}],
+                "custom": [{"name": "custom-a"}],
+            },
+            Version("2.0.0"): {
+                "file_format": 0.5,
+                "libraries": [{"name": "jdbc"}, {"name": "removed-lib"}],
+            },
+        }[v]
+
+        db_writer = DatabaseWriter(database_dir=str(tmp_path))
+
+        exit_code = run_javaagent_builder(inventory_manager, db_writer)
+
+        assert exit_code == 0
+        data = json.loads((tmp_path / "ecosystem-stats.json").read_text(encoding="utf-8"))
+        assert data["version_count"] == 2
+        # jdbc, custom-a, removed-lib: unioned across versions and across libraries/custom.
+        assert data["library_count"] == 3
+
 
 class TestMain:
     @patch("explorer_db_builder.main.run_builder")

--- a/ecosystem-explorer/public/data/collector/ecosystem-stats.json
+++ b/ecosystem-explorer/public/data/collector/ecosystem-stats.json
@@ -1,0 +1,4 @@
+{
+  "component_count": 271,
+  "version_count": 7
+}

--- a/ecosystem-explorer/public/data/javaagent/ecosystem-stats.json
+++ b/ecosystem-explorer/public/data/javaagent/ecosystem-stats.json
@@ -1,0 +1,4 @@
+{
+  "library_count": 263,
+  "version_count": 5
+}

--- a/ecosystem-explorer/public/locales/en/about.json
+++ b/ecosystem-explorer/public/locales/en/about.json
@@ -8,6 +8,25 @@
     "body1": "The ecosystem is large and growing. Finding what instrumentation exists, what it produces, and how to configure it can be difficult. This project aims to make that information accessible and easy to navigate.",
     "body2": "By building a structured registry and an interactive explorer, we help developers understand what is available, what signals each component emits, and how components relate to OpenTelemetry semantic conventions."
   },
+  "ecosystems": {
+    "heading": "Ecosystems",
+    "loading": "Loading ecosystem stats…",
+    "error": "We couldn't load ecosystem stats right now.",
+    "javaAgent": {
+      "title": "Java Agent",
+      "versions_one": "{{count}} Version",
+      "versions_other": "{{count}} Versions",
+      "libraries_one": "{{count}} instrumentation library",
+      "libraries_other": "{{count}} instrumentation libraries"
+    },
+    "collector": {
+      "title": "Collector",
+      "versions_one": "{{count}} Version",
+      "versions_other": "{{count}} Versions",
+      "components_one": "{{count}} Component",
+      "components_other": "{{count}} Components"
+    }
+  },
   "getInvolved": {
     "heading": "Get Involved",
     "sourceCode": {

--- a/ecosystem-explorer/public/locales/es/about.json
+++ b/ecosystem-explorer/public/locales/es/about.json
@@ -8,6 +8,25 @@
     "body1": "El ecosistema es grande y está en crecimiento. Encontrar qué instrumentación existe, qué produce y cómo configurarla puede ser difícil. Este proyecto busca hacer esa información accesible y fácil de navegar.",
     "body2": "Al construir un registro estructurado y un explorador interactivo, ayudamos a los desarrolladores a entender qué está disponible, qué señales emite cada componente y cómo se relacionan con las convenciones semánticas de OpenTelemetry."
   },
+  "ecosystems": {
+    "heading": "Ecosistemas",
+    "loading": "Cargando estadísticas del ecosistema…",
+    "error": "No pudimos cargar las estadísticas del ecosistema en este momento.",
+    "javaAgent": {
+      "title": "Java Agent",
+      "versions_one": "{{count}} versión",
+      "versions_other": "{{count}} versiones",
+      "libraries_one": "{{count}} biblioteca de instrumentación",
+      "libraries_other": "{{count}} bibliotecas de instrumentación"
+    },
+    "collector": {
+      "title": "Collector",
+      "versions_one": "{{count}} versión",
+      "versions_other": "{{count}} versiones",
+      "components_one": "{{count}} componente",
+      "components_other": "{{count}} componentes"
+    }
+  },
   "getInvolved": {
     "heading": "Participa",
     "sourceCode": {

--- a/ecosystem-explorer/src/features/about/about-page.test.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.test.tsx
@@ -15,7 +15,7 @@
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AboutPage } from "./about-page";
 
 const SAMPLE_JAVA_AGENT_STATS = { version_count: 5, library_count: 263 };
@@ -37,37 +37,41 @@ function stubFetch(byUrl: Record<string, { ok: boolean; status?: number; body?: 
 }
 
 describe("AboutPage", () => {
+  beforeEach(() => {
+    stubFetch({
+      "/data/javaagent/ecosystem-stats.json": { ok: true, body: SAMPLE_JAVA_AGENT_STATS },
+      "/data/collector/ecosystem-stats.json": { ok: true, body: SAMPLE_COLLECTOR_STATS },
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
-  it("renders the page heading", () => {
+  async function renderAboutPage() {
     render(
       <MemoryRouter>
         <AboutPage />
       </MemoryRouter>
     );
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+  }
+
+  it("renders the page heading", async () => {
+    await renderAboutPage();
 
     expect(screen.getByRole("heading", { name: "About", level: 1 })).toBeInTheDocument();
   });
 
-  it("renders the Goals section", () => {
-    render(
-      <MemoryRouter>
-        <AboutPage />
-      </MemoryRouter>
-    );
+  it("renders the Goals section", async () => {
+    await renderAboutPage();
 
     expect(screen.getByRole("heading", { name: "Goals" })).toBeInTheDocument();
   });
 
-  it("renders the Get Involved section with links", () => {
-    render(
-      <MemoryRouter>
-        <AboutPage />
-      </MemoryRouter>
-    );
+  it("renders the Get Involved section with links", async () => {
+    await renderAboutPage();
 
     expect(screen.getByRole("heading", { name: "Get Involved" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /source code/i })).toBeInTheDocument();
@@ -75,23 +79,15 @@ describe("AboutPage", () => {
     expect(screen.getByRole("link", { name: /request a feature/i })).toBeInTheDocument();
   });
 
-  it("renders the Contributing section", () => {
-    render(
-      <MemoryRouter>
-        <AboutPage />
-      </MemoryRouter>
-    );
+  it("renders the Contributing section", async () => {
+    await renderAboutPage();
 
     expect(screen.getByRole("heading", { name: "Contributing" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /contributing guide/i })).toBeInTheDocument();
   });
 
-  it("source code link points to the GitHub repo", () => {
-    render(
-      <MemoryRouter>
-        <AboutPage />
-      </MemoryRouter>
-    );
+  it("source code link points to the GitHub repo", async () => {
+    await renderAboutPage();
 
     const link = screen.getByRole("link", { name: /source code/i });
     expect(link).toHaveAttribute(

--- a/ecosystem-explorer/src/features/about/about-page.test.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.test.tsx
@@ -13,12 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { AboutPage } from "./about-page";
 
+const SAMPLE_JAVA_AGENT_STATS = { version_count: 5, library_count: 263 };
+const SAMPLE_COLLECTOR_STATS = { version_count: 7, component_count: 271 };
+
+function stubFetch(byUrl: Record<string, { ok: boolean; status?: number; body?: unknown }>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      const response = byUrl[url];
+      if (!response) throw new Error(`Unexpected fetch to ${url}`);
+      return Promise.resolve({
+        ok: response.ok,
+        status: response.status ?? 200,
+        json: async () => response.body,
+      });
+    })
+  );
+}
+
 describe("AboutPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("renders the page heading", () => {
     render(
       <MemoryRouter>
@@ -75,5 +98,58 @@ describe("AboutPage", () => {
       "href",
       "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer"
     );
+  });
+
+  describe("Ecosystems section", () => {
+    it("renders the loading state before data arrives", () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => new Promise(() => {}))
+      );
+
+      render(
+        <MemoryRouter>
+          <AboutPage />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByRole("heading", { name: "Ecosystems" })).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveTextContent("Loading ecosystem stats");
+    });
+
+    it("renders computed Java Agent and Collector stats once loaded", async () => {
+      stubFetch({
+        "/data/javaagent/ecosystem-stats.json": { ok: true, body: SAMPLE_JAVA_AGENT_STATS },
+        "/data/collector/ecosystem-stats.json": { ok: true, body: SAMPLE_COLLECTOR_STATS },
+      });
+
+      render(
+        <MemoryRouter>
+          <AboutPage />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => expect(screen.getByText("5 Versions")).toBeInTheDocument());
+      expect(screen.getByText("263 instrumentation libraries")).toBeInTheDocument();
+      expect(screen.getByText("7 Versions")).toBeInTheDocument();
+      expect(screen.getByText("271 Components")).toBeInTheDocument();
+    });
+
+    it("renders an error state when a stats fetch fails", async () => {
+      stubFetch({
+        "/data/javaagent/ecosystem-stats.json": { ok: true, body: SAMPLE_JAVA_AGENT_STATS },
+        "/data/collector/ecosystem-stats.json": { ok: false, status: 500 },
+      });
+
+      render(
+        <MemoryRouter>
+          <AboutPage />
+        </MemoryRouter>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent("couldn't load ecosystem stats")
+      );
+    });
   });
 });

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -18,11 +18,17 @@ import { BookOpen, Bug, MessageSquare } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import { BackButton } from "@/components/ui/back-button";
 import { PageContainer } from "@/components/layout/page-container";
+import { useEcosystemStats } from "@/hooks/use-ecosystem-stats";
 
 const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
 
 export function AboutPage() {
   const { t } = useTranslation("about");
+  const {
+    data: ecosystemStats,
+    loading: ecosystemStatsLoading,
+    error: ecosystemStatsError,
+  } = useEcosystemStats();
   return (
     <PageContainer>
       <div className="space-y-6">
@@ -54,6 +60,56 @@ export function AboutPage() {
               <p>{t("goals.body1")}</p>
               <p>{t("goals.body2")}</p>
             </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-foreground text-xl font-semibold">{t("ecosystems.heading")}</h2>
+            {ecosystemStatsError ? (
+              <p className="text-muted-foreground text-sm" role="status">
+                {t("ecosystems.error")}
+              </p>
+            ) : ecosystemStatsLoading || !ecosystemStats ? (
+              <p className="text-muted-foreground text-sm" role="status" aria-live="polite">
+                {t("ecosystems.loading")}
+              </p>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="border-border/50 bg-card/50 space-y-2 rounded-lg border p-6">
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("ecosystems.javaAgent.title")}
+                  </h3>
+                  <ul className="text-muted-foreground space-y-1 text-sm">
+                    <li>
+                      {t("ecosystems.javaAgent.versions", {
+                        count: ecosystemStats.javaAgent.version_count,
+                      })}
+                    </li>
+                    <li>
+                      {t("ecosystems.javaAgent.libraries", {
+                        count: ecosystemStats.javaAgent.library_count,
+                      })}
+                    </li>
+                  </ul>
+                </div>
+                <div className="border-border/50 bg-card/50 space-y-2 rounded-lg border p-6">
+                  <h3 className="text-foreground text-sm font-medium">
+                    {t("ecosystems.collector.title")}
+                  </h3>
+                  <ul className="text-muted-foreground space-y-1 text-sm">
+                    <li>
+                      {t("ecosystems.collector.versions", {
+                        count: ecosystemStats.collector.version_count,
+                      })}
+                    </li>
+                    <li>
+                      {t("ecosystems.collector.components", {
+                        count: ecosystemStats.collector.component_count,
+                      })}
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            )}
           </section>
 
           <section className="space-y-4">

--- a/ecosystem-explorer/src/hooks/use-ecosystem-stats.test.ts
+++ b/ecosystem-explorer/src/hooks/use-ecosystem-stats.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useEcosystemStats } from "./use-ecosystem-stats";
+
+const SAMPLE_JAVA_AGENT_STATS = { version_count: 5, library_count: 263 };
+const SAMPLE_COLLECTOR_STATS = { version_count: 7, component_count: 271 };
+
+function stubFetch(byUrl: Record<string, { ok: boolean; status?: number; body?: unknown }>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      const response = byUrl[url];
+      if (!response) throw new Error(`Unexpected fetch to ${url}`);
+      return Promise.resolve({
+        ok: response.ok,
+        status: response.status ?? 200,
+        json: async () => response.body,
+      });
+    })
+  );
+}
+
+describe("useEcosystemStats", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("starts in loading state and transitions to populated", async () => {
+    stubFetch({
+      "/java.json": { ok: true, body: SAMPLE_JAVA_AGENT_STATS },
+      "/collector.json": { ok: true, body: SAMPLE_COLLECTOR_STATS },
+    });
+
+    const { result } = renderHook(() =>
+      useEcosystemStats({ javaAgentStatsUrl: "/java.json", collectorStatsUrl: "/collector.json" })
+    );
+
+    expect(result.current).toEqual({ data: null, loading: true, error: null });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual({
+      javaAgent: SAMPLE_JAVA_AGENT_STATS,
+      collector: SAMPLE_COLLECTOR_STATS,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions to error state when either fetch is unreachable", async () => {
+    stubFetch({
+      "/java.json": { ok: true, body: SAMPLE_JAVA_AGENT_STATS },
+      "/collector.json": { ok: false, status: 500 },
+    });
+
+    const { result } = renderHook(() =>
+      useEcosystemStats({ javaAgentStatsUrl: "/java.json", collectorStatsUrl: "/collector.json" })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("clears a prior error when the urls change and the new fetches succeed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => SAMPLE_JAVA_AGENT_STATS })
+      .mockResolvedValueOnce({ ok: true, json: async () => SAMPLE_COLLECTOR_STATS });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({
+        javaAgentStatsUrl,
+        collectorStatsUrl,
+      }: {
+        javaAgentStatsUrl: string;
+        collectorStatsUrl: string;
+      }) => useEcosystemStats({ javaAgentStatsUrl, collectorStatsUrl }),
+      {
+        initialProps: {
+          javaAgentStatsUrl: "/broken-java.json",
+          collectorStatsUrl: "/broken-collector.json",
+        },
+      }
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+
+    rerender({ javaAgentStatsUrl: "/java.json", collectorStatsUrl: "/collector.json" });
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual({
+        javaAgent: SAMPLE_JAVA_AGENT_STATS,
+        collector: SAMPLE_COLLECTOR_STATS,
+      })
+    );
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/ecosystem-explorer/src/hooks/use-ecosystem-stats.ts
+++ b/ecosystem-explorer/src/hooks/use-ecosystem-stats.ts
@@ -15,6 +15,7 @@
  */
 import { useEffect, useState } from "react";
 import type { DataState } from "@/hooks/data-state";
+import { resolveDataPath } from "@/lib/api/fetch-with-cache";
 
 export const JAVA_AGENT_ECOSYSTEM_STATS_URL = "/data/javaagent/ecosystem-stats.json";
 export const COLLECTOR_ECOSYSTEM_STATS_URL = "/data/collector/ecosystem-stats.json";
@@ -40,7 +41,8 @@ export interface UseEcosystemStatsOptions {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  // Intentionally not using cache for this data
+  const res = await fetch(resolveDataPath(url));
   if (!res.ok) throw new Error(`${url} responded with ${res.status}`);
   return (await res.json()) as T;
 }

--- a/ecosystem-explorer/src/hooks/use-ecosystem-stats.ts
+++ b/ecosystem-explorer/src/hooks/use-ecosystem-stats.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from "react";
+import type { DataState } from "@/hooks/data-state";
+
+export const JAVA_AGENT_ECOSYSTEM_STATS_URL = "/data/javaagent/ecosystem-stats.json";
+export const COLLECTOR_ECOSYSTEM_STATS_URL = "/data/collector/ecosystem-stats.json";
+
+interface JavaAgentStatsShape {
+  version_count: number;
+  library_count: number;
+}
+
+interface CollectorStatsShape {
+  version_count: number;
+  component_count: number;
+}
+
+export interface EcosystemStats {
+  javaAgent: JavaAgentStatsShape;
+  collector: CollectorStatsShape;
+}
+
+export interface UseEcosystemStatsOptions {
+  javaAgentStatsUrl?: string;
+  collectorStatsUrl?: string;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} responded with ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export function useEcosystemStats({
+  javaAgentStatsUrl = JAVA_AGENT_ECOSYSTEM_STATS_URL,
+  collectorStatsUrl = COLLECTOR_ECOSYSTEM_STATS_URL,
+}: UseEcosystemStatsOptions = {}): DataState<EcosystemStats> {
+  const [state, setState] = useState<DataState<EcosystemStats>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setState({ data: null, loading: true, error: null });
+      try {
+        const [javaAgent, collector] = await Promise.all([
+          fetchJson<JavaAgentStatsShape>(javaAgentStatsUrl),
+          fetchJson<CollectorStatsShape>(collectorStatsUrl),
+        ]);
+        if (cancelled) return;
+        setState({ data: { javaAgent, collector }, loading: false, error: null });
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [javaAgentStatsUrl, collectorStatsUrl]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

This PR adds ecosystem coverage statistics to the About page by generating build-time metadata for each ecosystem and rendering it in a new **"Ecosystems"** section.

The statistics are computed during the existing explorer-db-builder pipeline, written as a new `ecosystem-stats.json` artifact, and consumed by the frontend instead of using hardcoded values.

Fixes #754!

---

## What changed

### Builder

- Added generation of a new `ecosystem-stats.json` artifact for each ecosystem.
- Compute:
  - Number of supported versions.
  - Number of unique Java instrumentation libraries.
  - Number of unique Collector components.
- Integrated artifact generation into the existing Java Agent and Collector build pipelines.
- Added unit and integration tests covering the new builder logic.

### Frontend

- Added a new **Ecosystems** section to the About page.
- Fetch ecosystem statistics from the generated build artifacts.
- Display:
  - Java Agent
    - Version count
    - Instrumentation library count
  - Collector
    - Version count
    - Component count
- Added loading/error handling following existing data-fetching patterns.
- Added i18n entries and frontend tests for the new section.

---

## Result

The About page now displays live build-generated ecosystem coverage information instead of hardcoded values.

Example:

- **Java Agent**
  - 5 Versions
  - 263 Instrumentation Libraries

- **Collector**
  - 7 Versions
  - 271 Components

(The exact numbers depend on the current registry contents.)

---

## Testing

- Added builder unit tests.
- Added frontend tests.
- Verified generated `ecosystem-stats.json` artifacts.
- Verified the About page renders the generated statistics correctly.
- Verified translations render correctly.
- Ran the existing project test suite successfully.

---

## Screenshots

### About page – Ecosystems section

The About page now includes a new **Ecosystems** section displaying build-generated coverage statistics for the Java Agent and Collector.

<img width="1200" alt="About page with Ecosystems section" src="https://github.com/user-attachments/assets/b1e5346b-d900-48ec-a449-5b08b3bce438" />