### PR TITLE
test: add LegacyApp/V1App route parity test

### DIFF
--- a/ecosystem-explorer/src/route-parity.test.ts
+++ b/ecosystem-explorer/src/route-parity.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const legacyAppPath = resolve(__dirname, "LegacyApp.tsx");
+const v1AppPath = resolve(__dirname, "v1/V1App.tsx");
+
+function extractRoutePaths(filePath: string): string[] {
+  const content = readFileSync(filePath, "utf-8");
+  return [...content.matchAll(/path="([^"]+)"/g)].map((match) => match[1]);
+}
+
+const legacyPaths = Array.from(new Set(extractRoutePaths(legacyAppPath)));
+const v1Paths = extractRoutePaths(v1AppPath);
+const v1PathSet = new Set(v1Paths);
+
+describe("route table sync between LegacyApp and V1App", () => {
+  it("extracted route paths from both LegacyApp.tsx and V1App.tsx", () => {
+    expect(legacyPaths.length).toBeGreaterThan(0);
+    expect(v1Paths.length).toBeGreaterThan(0);
+  });
+
+  for (const path of legacyPaths) {
+    it(`LegacyApp route "${path}" also exists in V1App`, () => {
+      expect(v1PathSet.has(path)).toBe(true);
+    });
+  }
+});

--- a/ecosystem-explorer/src/route-parity.test.ts
+++ b/ecosystem-explorer/src/route-parity.test.ts
@@ -24,14 +24,42 @@ const v1AppPath = resolve(__dirname, "v1/V1App.tsx");
 
 function extractRoutePaths(filePath: string): string[] {
   const content = readFileSync(filePath, "utf-8");
-  return [...content.matchAll(/path="([^"]+)"/g)].map((match) => match[1]);
+  const routeCount = (content.match(/<Route\b/g) ?? []).length;
+  const paths = [...content.matchAll(/path="([^"]+)"/g)].map((match) => match[1]);
+
+  if (paths.length !== routeCount) {
+    throw new Error(
+      `route-parity.test.ts expected one literal path="..." per <Route> in ` +
+        `${filePath}, but found ${routeCount} <Route> elements and only ` +
+        `${paths.length} literal paths. Update the extractor to handle the new route shape.`
+    );
+  }
+
+  return paths;
 }
 
-const legacyPaths = Array.from(new Set(extractRoutePaths(legacyAppPath)));
-const v1Paths = extractRoutePaths(v1AppPath);
+let legacyPaths: string[] = [];
+let v1Paths: string[] = [];
+let setupError: unknown = null;
+
+try {
+  legacyPaths = Array.from(new Set(extractRoutePaths(legacyAppPath)));
+  v1Paths = extractRoutePaths(v1AppPath);
+} catch (error) {
+  setupError = error;
+}
+
 const v1PathSet = new Set(v1Paths);
 
-describe("route table sync between LegacyApp and V1App", () => {
+describe("LegacyApp routes are present in V1App", () => {
+  it("read LegacyApp.tsx and V1App.tsx and extracted route paths without error", () => {
+    if (setupError) throw setupError;
+  });
+
+  if (setupError) {
+    return;
+  }
+
   it("extracted route paths from both LegacyApp.tsx and V1App.tsx", () => {
     expect(legacyPaths.length).toBeGreaterThan(0);
     expect(v1Paths.length).toBeGreaterThan(0);

--- a/ecosystem-explorer/src/route-parity.test.ts
+++ b/ecosystem-explorer/src/route-parity.test.ts
@@ -22,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const legacyAppPath = resolve(__dirname, "LegacyApp.tsx");
 const v1AppPath = resolve(__dirname, "v1/V1App.tsx");
 
+// TODO: This test file to be removed when we retire the Legacy theme
 function extractRoutePaths(filePath: string): string[] {
   const content = readFileSync(filePath, "utf-8");
   const routeCount = (content.match(/<Route\b/g) ?? []).length;


### PR DESCRIPTION
## What changed

added a test that checks every route in LegacyApp.tsx also shows up in V1App.tsx. it's one-directional on purpose, not a strict match both ways, V1App is allowed to have extra routes Legacy doesn't have, since it's actively getting new pages added as part of the redesign and those don't need a legacy equivalent. but anything that's in Legacy has to also exist in V1App or it 404s on preview deploys.

## Why

Fixes #750 
both files already have comments saying the route tables need to stay in sync, but nothing actually enforces it, it's just a comment. if someone adds or removes a route from one file and forgets the other, nothing catches it until someone actually hits a 404.

## How it was tested

ran ```bun run test src/route-parity.test.ts```, 16 tests pass (one sanity check that paths were actually extracted, plus one per route in Legacy). also tested that it actually catches drift on purpose: deleted a route from V1App.tsx that's still in Legacy, reran, got one clean failure naming exactly that route, other 15 still passed. after putting it back, confirmed clean again. then tested the other direction too, added a brand new route to V1App that has zero Legacy equivalent, reran, and confirmed it still passes like it's supposed to. ran the full suite after as well.

## Is this a breaking change?

No

## Special notes for your reviewer

just a new test file, no app code touched. one thing worth flagging: I made the check one-directional (Legacy routes must exist in V1, not the other way around), but the existing comments in both LegacyApp.tsx and V1App.tsx are phrased like it should be symmetric ("any new route added here must also be added there"). went with one-directional anyway since V1 is expected to grow v1-only pages during the redesign and a strict two-way check would start failing on stuff that isn't actually a bug.

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
