### PR TITLE
fix(javaagent): prevent false "No README found" flash on initial render

### DIFF
--- a/ecosystem-explorer/src/hooks/use-javaagent-data.test.ts
+++ b/ecosystem-explorer/src/hooks/use-javaagent-data.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLibraryReadme } from "./use-javaagent-data";
+
+vi.mock("@/lib/api/javaagent-data", () => ({
+  loadLibraryReadme: vi.fn(),
+}));
+
+import * as javaagentData from "@/lib/api/javaagent-data";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("useLibraryReadme", () => {
+  it("should start in loading state so callers don't render an empty/error state first", () => {
+    (javaagentData.loadLibraryReadme as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise(() => {})
+    );
+
+    const { result } = renderHook(() => useLibraryReadme("some-library", "abc123"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should load the readme successfully", async () => {
+    (javaagentData.loadLibraryReadme as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "# Readme content"
+    );
+
+    const { result } = renderHook(() => useLibraryReadme("some-library", "abc123"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toBe("# Readme content");
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/ecosystem-explorer/src/hooks/use-javaagent-data.ts
+++ b/ecosystem-explorer/src/hooks/use-javaagent-data.ts
@@ -109,7 +109,7 @@ export function useLibraryReadme(
 ): DataState<string> {
   const [state, setState] = useState<DataState<string>>({
     data: null,
-    loading: false,
+    loading: true,
     error: null,
   });
 


### PR DESCRIPTION
## What changed

This PR initializes `useLibraryReadme` with `loading: true` instead of `loading: false`.

It also adds a regression test covering the hook's initial loading state and the normal successful loading path.

## Why

The `StandaloneLibraryTab` checks the hook's loading state before rendering the markdown content.

Because `useLibraryReadme` previously initialized with `loading: false`, the first render could briefly enter the "No README found" state before the effect started the fetch and switched the hook into the loading state.

Initializing the hook in the loading state keeps its lifecycle consistent with the other data-fetching hooks in the same file and avoids the transient incorrect UI.

Fixes #764!

## How it was tested

- Added regression tests for `useLibraryReadme`
  - verifies the hook starts in the loading state
  - verifies the normal successful loading path still works
- Ran the new tests successfully.

## Is this a breaking change?

No.

## Notes for reviewers

This intentionally keeps the change minimal:
- one-line initialization change
- regression tests only
- no behavior changes beyond preventing the transient incorrect render