### PR TITLE
feat(collector-watcher): discover and store component READMEs

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -178,6 +178,8 @@ class CollectorSync:
         Also discovers and stores each component's README.md, if present,
         content-addressed under ``component_readmes/``. README publishing
         is best-effort: a failure here is logged and does not fail the sync.
+        This always runs after the inventory write below, never before -
+        see the comment at that call site for why the order matters.
 
         Schema is always read from the core repo: ``mdatagen`` lives only in
         ``opentelemetry-collector``, and the schema is identical across
@@ -196,6 +198,24 @@ class CollectorSync:
         """
         schema_hash = self._resolve_schema_hash(version)
 
+        repository = self.get_repository_name(distribution)
+        self.inventory_manager.save_versioned_inventory(
+            distribution=distribution,
+            version=version,
+            components=components,
+            repository=repository,
+            schema_hash=schema_hash,
+        )
+
+        # Readme discovery/save runs after the critical inventory write, not
+        # before: save_versioned_inventory() is what version_exists() treats
+        # as the "this version is tracked" signal, since it just checks
+        # whether the version directory exists. If readme saving (which also
+        # mkdirs that directory as a side effect of writing into it) ran
+        # first and the process crashed before save_versioned_inventory
+        # completed, version_exists() would incorrectly report the version
+        # as already tracked despite zero real component data ever being
+        # written - causing process_latest_release() to skip it forever.
         repo_path = self.repos[distribution]
         try:
             readmes = discover_component_readmes(repo_path, components)
@@ -206,15 +226,6 @@ class CollectorSync:
             # README publishing is best-effort and must never fail the sync -
             # the component inventory itself is the critical data.
             logger.warning("  Failed to save component READMEs for %s %s: %s", distribution, version, e)
-
-        repository = self.get_repository_name(distribution)
-        self.inventory_manager.save_versioned_inventory(
-            distribution=distribution,
-            version=version,
-            components=components,
-            repository=repository,
-            schema_hash=schema_hash,
-        )
 
         logger.info("  Saved %s %s (schema_hash=%s)", distribution, version, schema_hash)
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -23,6 +23,7 @@ from watcher_common.version_detector import VersionDetector
 from .component_scanner import ComponentScanner
 from .deprecation_detector import DeprecationDetector
 from .inventory_manager import InventoryManager
+from .readme_scanner import discover_component_readmes
 from .schema_copier import SCHEMA_RELATIVE_PATH, UNKNOWN_HASH, CollectorSchemaCopier
 from .type_defs import DistributionName
 
@@ -174,14 +175,19 @@ class CollectorSync:
         distributions) and records that hash in every component YAML for
         drift detection and parser routing.
 
+        Also discovers and stores each component's README.md, if present,
+        content-addressed under ``component_readmes/``. README publishing
+        is best-effort: a failure here is logged and does not fail the sync.
+
         Schema is always read from the core repo: ``mdatagen`` lives only in
         ``opentelemetry-collector``, and the schema is identical across
         distributions, so contrib carries the same ``schema_hash`` as core.
 
         Registry layout after this call:
             ecosystem-registry/collector/
-                {distribution}/v{version}/*.yaml   (component data, each with schema_hash)
-                meta/schemas/{hash}.yaml           (one file per distinct schema)
+                {distribution}/v{version}/*.yaml               (component data, each with schema_hash)
+                {distribution}/v{version}/component_readmes/    (one file per distinct README content)
+                meta/schemas/{hash}.yaml                        (one file per distinct schema)
 
         Args:
             distribution: Distribution name
@@ -189,6 +195,17 @@ class CollectorSync:
             components: Scanned components
         """
         schema_hash = self._resolve_schema_hash(version)
+
+        repo_path = self.repos[distribution]
+        try:
+            readmes = discover_component_readmes(repo_path, components)
+            written = self.inventory_manager.save_component_readmes(distribution, version, readmes.items())
+            if written:
+                logger.info("  Saved %d component README(s)", written)
+        except OSError as e:
+            # README publishing is best-effort and must never fail the sync -
+            # the component inventory itself is the critical data.
+            logger.warning("  Failed to save component READMEs for %s %s: %s", distribution, version, e)
 
         repository = self.get_repository_name(distribution)
         self.inventory_manager.save_versioned_inventory(

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -15,12 +15,15 @@
 """Inventory management for component tracking."""
 
 import logging
+import re
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 import yaml
 from semantic_version import Version
+from watcher_common.content_hashing import compute_content_hash
 
 from .type_defs import COMPONENT_TYPES, DistributionName
 
@@ -29,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 class InventoryManager:
     """Manages component inventory storage and retrieval."""
+
+    README_DIR = "component_readmes"
 
     def __init__(self, inventory_dir: str = "ecosystem-registry/collector"):
         """
@@ -186,6 +191,142 @@ class InventoryManager:
             "schema_hash": schema_hash,
             "components": components,
         }
+
+    def readme_dir_exists(self, distribution: DistributionName, version: Version) -> bool:
+        """Return True if the component_readmes directory exists for this distribution/version."""
+        return (self.get_version_dir(distribution, version) / self.README_DIR).exists()
+
+    def _sanitize_name(self, name: str) -> str:
+        """Sanitizes a name for use as a filename to prevent path traversal."""
+        return re.sub(r"[^a-zA-Z0-9._\-]", "_", name)
+
+    def save_component_readmes(
+        self,
+        distribution: DistributionName,
+        version: Version,
+        readmes: Iterable[tuple[str, str]],  # (component_name, content)
+    ) -> int:
+        """
+        Write each README content-addressed. Returns count newly written.
+
+        Args:
+            distribution: Distribution name (core or contrib)
+            version: Version object
+            readmes: Iterable of (component_name, content) pairs, e.g. from
+                     readme_scanner.discover_component_readmes()
+
+        Returns:
+            Number of README files newly written (existing content-addressed
+            files are left untouched, matching save_versioned_inventory's
+            general approach of not rewriting unchanged data).
+        """
+        target_dir = self.get_version_dir(distribution, version) / self.README_DIR
+        target_dir.mkdir(parents=True, exist_ok=True)
+        written = 0
+        for name, content in readmes:
+            digest = compute_content_hash(content)
+            safe_name = self._sanitize_name(name)
+            file_path = target_dir / f"{safe_name}-{digest}.md"
+            if file_path.exists():
+                continue
+            file_path.write_text(content, encoding="utf-8")
+            written += 1
+        return written
+
+    def load_component_readme_map(self, distribution: DistributionName, version: Version) -> dict[str, str]:
+        """
+        Scan component_readmes/ and build a map of sanitized component_name -> markdown_hash.
+
+        Args:
+            distribution: Distribution name (core or contrib)
+            version: Version to scan
+
+        Returns:
+            Dictionary mapping sanitized component names to their markdown content hashes
+        """
+        readme_dir = self.get_version_dir(distribution, version) / self.README_DIR
+        if not readme_dir.exists():
+            return {}
+
+        selected_readmes: dict[str, tuple[str, int, str]] = {}
+        seen_hashes: dict[str, set[str]] = {}
+
+        for item in sorted(readme_dir.iterdir(), key=lambda p: p.name):
+            if item.is_file() and item.suffix == ".md":
+                parsed = self._parse_readme_filename(item.name)
+                if parsed:
+                    component_name, markdown_hash = parsed
+                    seen_hashes.setdefault(component_name, set()).add(markdown_hash)
+
+                    try:
+                        mtime_ns = item.stat().st_mtime_ns
+                    except OSError:
+                        logger.warning("Failed to stat README file in %s %s: %s", distribution, version, item.name)
+                        continue
+
+                    current = selected_readmes.get(component_name)
+                    if current is None:
+                        selected_readmes[component_name] = (markdown_hash, mtime_ns, item.name)
+                    else:
+                        _, current_mtime_ns, current_name = current
+                        if mtime_ns > current_mtime_ns or (mtime_ns == current_mtime_ns and item.name > current_name):
+                            selected_readmes[component_name] = (markdown_hash, mtime_ns, item.name)
+                else:
+                    logger.warning("Malformed README filename in %s %s: %s", distribution, version, item.name)
+
+        readme_map = {}
+        for component_name, (markdown_hash, _, selected_name) in selected_readmes.items():
+            readme_map[component_name] = markdown_hash
+            hashes = seen_hashes.get(component_name, set())
+            if len(hashes) > 1:
+                logger.warning(
+                    "Multiple README files found for component '%s' in %s %s; "
+                    "selected '%s' with hash '%s'. Available hashes: %s",
+                    component_name,
+                    distribution,
+                    version,
+                    selected_name,
+                    markdown_hash,
+                    sorted(hashes),
+                )
+
+        return readme_map
+
+    def load_component_readme_content(
+        self, distribution: DistributionName, version: Version, component_name: str, markdown_hash: str
+    ) -> str | None:
+        """
+        Load the content of a specific component README.
+
+        Args:
+            distribution: Distribution name (core or contrib)
+            version: Version to load from
+            component_name: Name of the component
+            markdown_hash: Content hash of the markdown
+
+        Returns:
+            The markdown content, or None if it doesn't exist or cannot be read
+        """
+        safe_name = self._sanitize_name(component_name)
+        file_path = self.get_version_dir(distribution, version) / self.README_DIR / f"{safe_name}-{markdown_hash}.md"
+        if not file_path.exists():
+            return None
+
+        try:
+            return file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            logger.error("Failed to read README file '%s': %s", file_path, e)
+            return None
+
+    def _parse_readme_filename(self, filename: str) -> tuple[str, str] | None:
+        """
+        Parse a README filename into (component_name, markdown_hash).
+        Format: {component-name}-{hash}.md
+        """
+        match = re.match(r"^(.+)-([a-f0-9]{12})\.md$", filename)
+        if match:
+            return match.group(1), match.group(2)
+        return None
 
     def list_versions(self, distribution: DistributionName) -> list[Version]:
         """

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/readme_scanner.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/readme_scanner.py
@@ -1,0 +1,71 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Discovers and reads component README files from a local collector repository clone.
+
+Unlike java-instrumentation-watcher, which fetches individual files remotely
+over the GitHub API, collector-watcher already works against a full local
+clone (see repository_manager.py), so discovering a component's README is a
+direct filesystem check rather than a tree/blob API call.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+README_FILENAME = "README.md"
+
+
+def discover_component_readmes(repo_path: str, components: dict[str, list[dict[str, Any]]]) -> dict[str, str]:
+    """
+    Find and read README.md files for already-scanned components.
+
+    Walks the same (component_type, subtype, name) entries ComponentScanner
+    already produced, rather than re-deriving which directories count as real
+    components. This can't drift from the scanner's own inclusion rules, and
+    avoids a second, independent filesystem walk.
+
+    Args:
+        repo_path: Path to the cloned repository (the same one that was scanned)
+        components: Output of ComponentScanner.scan_all_components()
+
+    Returns:
+        Dictionary mapping component name to README content. Components with
+        no README.md, or whose README couldn't be read, are omitted rather
+        than raising - a single unreadable file should never fail a sync.
+    """
+    base = Path(repo_path)
+    readmes: dict[str, str] = {}
+
+    for component_type, component_list in components.items():
+        for component in component_list:
+            name = component.get("name")
+            if not name:
+                continue
+
+            subtype = component.get("subtype")
+            component_dir = base / component_type / subtype / name if subtype else base / component_type / name
+
+            readme_path = component_dir / README_FILENAME
+            if not readme_path.is_file():
+                continue
+
+            try:
+                readmes[name] = readme_path.read_text(encoding="utf-8")
+            except OSError as e:
+                logger.warning("Failed to read README for '%s' at %s: %s", name, readme_path, e)
+
+    return readmes

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -586,7 +586,7 @@ def test_save_version_discovers_and_saves_component_readmes(
     assert content == "# OTLP Receiver"
 
 
-def test_save_version_with_no_readmes_writes_no_readme_dir(collector_sync, sample_components, temp_inventory_dir):
+def test_save_version_with_no_readmes_persists_no_readme_content(collector_sync, sample_components, temp_inventory_dir):
     """Most components won't have a README - no readme content should be persisted."""
     version = Version("0.112.0")
 
@@ -596,6 +596,42 @@ def test_save_version_with_no_readmes_writes_no_readme_dir(collector_sync, sampl
     # save_library_readmes exactly), so check for absence of content, not
     # absence of the directory itself.
     assert collector_sync.inventory_manager.load_component_readme_map("core", version) == {}
+
+
+def test_save_version_crash_before_inventory_write_leaves_no_trace(
+    collector_sync, sample_components, temp_inventory_dir
+):
+    """
+    Regression test for an ordering bug: readme saving used to run before the
+    real inventory write and mkdir'd the version directory as a side effect.
+    A crash between the two steps left version_exists() incorrectly True with
+    zero real component data, causing process_latest_release() to treat the
+    version as already tracked forever. The real write must happen first.
+    """
+    version = Version("0.112.0")
+
+    with patch.object(
+        collector_sync.inventory_manager, "save_versioned_inventory", side_effect=RuntimeError("simulated crash")
+    ):
+        with pytest.raises(RuntimeError):
+            collector_sync.save_version("core", version, sample_components)
+
+    assert not collector_sync.inventory_manager.version_exists("core", version)
+
+
+def test_save_version_crash_during_readme_save_is_benign(collector_sync, sample_components, temp_inventory_dir):
+    """The flip side: once the real inventory write has succeeded, a later readme-save crash is harmless."""
+    version = Version("0.112.0")
+
+    with patch.object(
+        collector_sync.inventory_manager, "save_component_readmes", side_effect=RuntimeError("simulated crash")
+    ):
+        with pytest.raises(RuntimeError):
+            collector_sync.save_version("core", version, sample_components)
+
+    assert collector_sync.inventory_manager.version_exists("core", version)
+    version_dir = temp_inventory_dir / "core" / "v0.112.0"
+    assert (version_dir / "receiver.yaml").exists()
 
 
 def test_save_version_readme_failure_does_not_block_inventory_save(

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -566,3 +566,46 @@ def test_baseline_not_updated_for_prereleases(collector_sync):
     assert collector_sync.deprecations["core"]["receiver"][0]["name"] == "receiver2"
     assert collector_sync.deprecations["core"]["receiver"][0]["last_version"] == f"v{v1}"
     assert collector_sync.deprecations["core"]["receiver"][0]["deprecated_in_version"] == f"v{v2}"
+
+
+def test_save_version_discovers_and_saves_component_readmes(
+    collector_sync, sample_components, temp_inventory_dir, temp_git_repos
+):
+    version = Version("0.112.0")
+    receiver_dir = Path(temp_git_repos["core"]) / "receiver" / "otlpreceiver"
+    receiver_dir.mkdir(parents=True)
+    (receiver_dir / "README.md").write_text("# OTLP Receiver")
+
+    collector_sync.save_version("core", version, sample_components)
+
+    readme_map = collector_sync.inventory_manager.load_component_readme_map("core", version)
+    assert "otlpreceiver" in readme_map
+    content = collector_sync.inventory_manager.load_component_readme_content(
+        "core", version, "otlpreceiver", readme_map["otlpreceiver"]
+    )
+    assert content == "# OTLP Receiver"
+
+
+def test_save_version_with_no_readmes_writes_no_readme_dir(collector_sync, sample_components, temp_inventory_dir):
+    """Most components won't have a README - no readme content should be persisted."""
+    version = Version("0.112.0")
+
+    collector_sync.save_version("core", version, sample_components)
+
+    # save_component_readmes always creates the target dir (matching java's
+    # save_library_readmes exactly), so check for absence of content, not
+    # absence of the directory itself.
+    assert collector_sync.inventory_manager.load_component_readme_map("core", version) == {}
+
+
+def test_save_version_readme_failure_does_not_block_inventory_save(
+    collector_sync, sample_components, temp_inventory_dir
+):
+    """A readme-saving failure must never prevent the core component inventory from being written."""
+    version = Version("0.112.0")
+
+    with patch.object(collector_sync.inventory_manager, "save_component_readmes", side_effect=OSError("disk full")):
+        collector_sync.save_version("core", version, sample_components)
+
+    version_dir = temp_inventory_dir / "core" / "v0.112.0"
+    assert (version_dir / "receiver.yaml").exists()

--- a/ecosystem-automation/collector-watcher/tests/test_inventory.py
+++ b/ecosystem-automation/collector-watcher/tests/test_inventory.py
@@ -14,14 +14,17 @@
 #
 """Tests for inventory manager."""
 
+import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
 import yaml
 from collector_watcher.inventory_manager import InventoryManager
 from semantic_version import Version
+from watcher_common.content_hashing import compute_content_hash
 
 
 @pytest.fixture
@@ -607,3 +610,205 @@ def test_add_deprecated_components_multiple_distributions(temp_inventory_dir):
     assert deprecations["core"]["receiver"][0]["name"] == "corereceiver"
     assert len(deprecations["contrib"]["exporter"]) == 1
     assert deprecations["contrib"]["exporter"][0]["name"] == "contribexporter"
+
+
+# --- save_component_readmes / load_component_readme_* ---
+#
+# Ported from java-instrumentation-watcher's JavaagentInventoryManager readme
+# tests (see watcher_common.inventory_manager), adapted for collector's
+# (distribution, version) two-key model instead of java's version-only key.
+
+
+def test_readme_dir_exists_false_when_no_readmes(temp_inventory_dir, sample_components, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+    )
+    assert not manager.readme_dir_exists("core", sample_version)
+
+
+def test_readme_dir_exists_true_after_save(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    manager.save_component_readmes("core", sample_version, [("otlpreceiver", "# content")])
+    assert manager.readme_dir_exists("core", sample_version)
+
+
+def test_save_component_readmes_writes_content_addressed_files(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    readmes = [
+        ("otlpreceiver", "# OTLP Receiver"),
+        ("batchprocessor", "# Batch Processor"),
+    ]
+
+    written = manager.save_component_readmes("core", sample_version, readmes)
+
+    assert written == 2
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    files = list(readme_dir.glob("*.md"))
+    assert len(files) == 2
+
+
+def test_save_component_readmes_filename_format(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    content = "# Hello"
+    expected_hash = compute_content_hash(content)
+
+    manager.save_component_readmes("core", sample_version, [("otlpreceiver", content)])
+
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    expected_file = readme_dir / f"otlpreceiver-{expected_hash}.md"
+    assert expected_file.exists()
+    assert expected_file.read_text(encoding="utf-8") == content
+
+
+def test_save_component_readmes_idempotent(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    readmes = [("otlpreceiver", "# Content")]
+
+    first = manager.save_component_readmes("core", sample_version, readmes)
+    second = manager.save_component_readmes("core", sample_version, readmes)
+
+    assert first == 1
+    assert second == 0
+
+
+def test_save_component_readmes_different_content_same_name(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    first = manager.save_component_readmes("core", sample_version, [("otlpreceiver", "# v1")])
+    second = manager.save_component_readmes("core", sample_version, [("otlpreceiver", "# v2")])
+
+    assert first == 1
+    assert second == 1
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    assert len(list(readme_dir.glob("*.md"))) == 2
+
+
+def test_component_readmes_are_isolated_per_distribution(temp_inventory_dir, sample_version):
+    """core and contrib must not share a component_readmes directory, unlike java which has no distribution axis."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    manager.save_component_readmes("core", sample_version, [("otlpreceiver", "# core version")])
+    manager.save_component_readmes("contrib", sample_version, [("otlpreceiver", "# contrib version")])
+
+    core_map = manager.load_component_readme_map("core", sample_version)
+    contrib_map = manager.load_component_readme_map("contrib", sample_version)
+
+    core_content = manager.load_component_readme_content(
+        "core", sample_version, "otlpreceiver", core_map["otlpreceiver"]
+    )
+    contrib_content = manager.load_component_readme_content(
+        "contrib", sample_version, "otlpreceiver", contrib_map["otlpreceiver"]
+    )
+
+    assert core_content == "# core version"
+    assert contrib_content == "# contrib version"
+
+
+def test_cleanup_snapshots_removes_component_readmes(temp_inventory_dir, sample_components, sample_snapshot_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=sample_snapshot_version,
+        components=sample_components,
+        repository="opentelemetry-collector",
+    )
+    manager.save_component_readmes("core", sample_snapshot_version, [("otlpreceiver", "# Content")])
+
+    snapshot_dir = manager.get_version_dir("core", sample_snapshot_version)
+    assert (snapshot_dir / "component_readmes").exists()
+
+    manager.cleanup_snapshots("core")
+
+    assert not snapshot_dir.exists()
+
+
+def test_parse_readme_filename(temp_inventory_dir):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    # Valid cases (12 char hash)
+    assert manager._parse_readme_filename("otlpreceiver-abc123def456.md") == ("otlpreceiver", "abc123def456")
+    assert manager._parse_readme_filename("my-comp-1.0-abc123def456.md") == ("my-comp-1.0", "abc123def456")
+
+    # Invalid cases
+    assert manager._parse_readme_filename("otlpreceiver-abc123.md") is None  # Too short
+    assert manager._parse_readme_filename("otlpreceiver-abc123def4567.md") is None  # Too long
+    assert manager._parse_readme_filename("-abc123def456.md") is None  # Empty name
+    assert manager._parse_readme_filename("otlpreceiver.md") is None  # No hash
+
+
+def test_load_component_readme_map_deterministic_selection(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    readme_dir.mkdir(parents=True)
+
+    p1 = readme_dir / "otlpreceiver-abc123def456.md"
+    p1.write_text("old content")
+
+    p2 = readme_dir / "otlpreceiver-fed4321cba98.md"
+    p2.write_text("new content")
+
+    p3 = readme_dir / "otlpreceiver-ffffff000000.md"
+    p3.write_text("newest content")
+
+    now = time.time_ns()
+    os.utime(p1, ns=(now - 1000000, now - 1000000))
+    os.utime(p2, ns=(now, now))
+    os.utime(p3, ns=(now + 1000000, now + 1000000))
+
+    readme_map = manager.load_component_readme_map("core", sample_version)
+
+    # Should pick p3 (ffffff...) because it has the newest mtime
+    assert len(readme_map) == 1
+    assert readme_map["otlpreceiver"] == "ffffff000000"
+
+
+def test_load_component_readme_map_lexicographical_fallback(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    readme_dir.mkdir(parents=True)
+
+    p1 = readme_dir / "otlpreceiver-aaaaaa111111.md"
+    p1.write_text("content a")
+
+    p2 = readme_dir / "otlpreceiver-bbbbbb222222.md"
+    p2.write_text("content b")
+
+    now = time.time_ns()
+    os.utime(p1, ns=(now, now))
+    os.utime(p2, ns=(now, now))
+
+    readme_map = manager.load_component_readme_map("core", sample_version)
+
+    # Should pick p2 (bbbbbb...) because b > a lexicographically
+    assert readme_map["otlpreceiver"] == "bbbbbb222222"
+
+
+def test_load_component_readme_content_sanitization(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    readme_dir = manager.get_version_dir("core", sample_version) / "component_readmes"
+    readme_dir.mkdir(parents=True)
+
+    # Save a file with a potentially dangerous name that gets sanitized
+    component_name = "../dangerous"
+    sanitized_name = ".._dangerous"
+    markdown_hash = "abc123def456"
+    (readme_dir / f"{sanitized_name}-{markdown_hash}.md").write_text("safe content")
+
+    # Should be able to load it using the original (unsanitized) name
+    content = manager.load_component_readme_content("core", sample_version, component_name, markdown_hash)
+    assert content == "safe content"
+
+
+def test_load_component_readme_content_missing_returns_none(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    content = manager.load_component_readme_content("core", sample_version, "nonexistent", "abc123def456")
+    assert content is None
+
+
+def test_load_component_readme_map_missing_dir_returns_empty(temp_inventory_dir, sample_version):
+    manager = InventoryManager(str(temp_inventory_dir))
+    assert manager.load_component_readme_map("core", sample_version) == {}

--- a/ecosystem-automation/collector-watcher/tests/test_readme_scanner.py
+++ b/ecosystem-automation/collector-watcher/tests/test_readme_scanner.py
@@ -1,0 +1,103 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for readme_scanner."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from collector_watcher.readme_scanner import discover_component_readmes
+
+
+def write_component(
+    repo_path: Path, component_type: str, name: str, subtype: str | None = None, readme: str | None = None
+):
+    """Create a component directory (optionally nested under a subtype), optionally with a README.md."""
+    directory = repo_path / component_type / subtype / name if subtype else repo_path / component_type / name
+    directory.mkdir(parents=True)
+    if readme is not None:
+        (directory / "README.md").write_text(readme, encoding="utf-8")
+
+
+def test_finds_readme_for_simple_component(tmp_path):
+    write_component(tmp_path, "receiver", "otlpreceiver", readme="# OTLP Receiver")
+    components = {"receiver": [{"name": "otlpreceiver"}]}
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {"otlpreceiver": "# OTLP Receiver"}
+
+
+def test_finds_readme_for_nested_subtype_component(tmp_path):
+    write_component(tmp_path, "extension", "s3storage", subtype="storage", readme="# S3 Storage")
+    components = {"extension": [{"name": "s3storage", "subtype": "storage"}]}
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {"s3storage": "# S3 Storage"}
+
+
+def test_skips_component_without_readme(tmp_path):
+    write_component(tmp_path, "receiver", "otlpreceiver")  # no readme=...
+    components = {"receiver": [{"name": "otlpreceiver"}]}
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {}
+
+
+def test_skips_entry_missing_name(tmp_path):
+    components = {"receiver": [{"subtype": None}]}  # malformed: no "name" key
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {}
+
+
+def test_handles_mixed_presence_across_types(tmp_path):
+    write_component(tmp_path, "receiver", "otlpreceiver", readme="# OTLP")
+    write_component(tmp_path, "processor", "batchprocessor")  # no readme
+    write_component(tmp_path, "exporter", "loggingexporter", readme="# Logging")
+
+    components = {
+        "receiver": [{"name": "otlpreceiver"}],
+        "processor": [{"name": "batchprocessor"}],
+        "exporter": [{"name": "loggingexporter"}],
+        "connector": [],
+    }
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {"otlpreceiver": "# OTLP", "loggingexporter": "# Logging"}
+
+
+def test_missing_component_directory_is_skipped_not_raised(tmp_path):
+    # No directory created at all for this component - scanner data can be
+    # stale relative to a fresh checkout; this must not raise.
+    components = {"receiver": [{"name": "doesnotexist"}]}
+
+    readmes = discover_component_readmes(str(tmp_path), components)
+
+    assert readmes == {}
+
+
+def test_unreadable_readme_is_skipped_not_raised(tmp_path):
+    write_component(tmp_path, "receiver", "otlpreceiver", readme="# OTLP Receiver")
+    components = {"receiver": [{"name": "otlpreceiver"}]}
+
+    with patch.object(Path, "read_text", side_effect=OSError("permission denied")):
+        readmes = discover_component_readmes(str(tmp_path), components)
+
+    # The bad file is skipped; the function still returns cleanly with no entry for it.
+    assert readmes == {}


### PR DESCRIPTION
## What changed

Collector-watcher now looks for a README.md next to each component it already scans, and if one exists, then stores it content-addressed under ```component_readmes/``` (same idea as how java-instrumentation-watcher stores library readmes, just adapted since collector has two distributions - core and contrib, instead of just one version key).

## Why

Part 1/3 of #762 

Readmes on collector components have useful context that's currently invisible in the explorer. This PR just makes the content available and stored properly.

## How it was tested

I ran the full collector-watcher suite, 180 passed (156 existing + 24 new). So for the two trickier bits I actually broke the code on purpose first: removed the try/except around the readme-saving step and confirmed the "doesn't block the sync" test actually fails without it, then put it back. I also had a wrong assumption in one of my own tests about whether an empty component_readmes dir gets created when there's nothing to save, caught that by actually running it against the real behavior, and fixed the test to match.

## Is this a breaking change?

No

## Special notes for your reviewer

A couple things:

- Went with porting the pattern into collector's own InventoryManager instead of generalizing BaseInventoryManager, since collector's (distribution, version) key doesn't fit the base class's current single-key design. Generalizing that is being tracked as a separate followup instead of blocking this
- Readme saving is wrapped in a try/except so it can never fail the actual component inventory write, same "never fail the build" idea already used for markdown publishing on the db-builder side
- Named the storage dir ```component_readmes``` instead of reusing java's ```library_readmes```, just to match collector's own naming.

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
