### PR TITLE
fix(collector): prevent infinite loading on Collector detail page

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CollectorDetailPage } from "./collector-detail-page";
+
+vi.mock("@/hooks/use-collector-data", () => ({
+  useCollectorVersions: vi.fn(),
+  useCollectorComponent: vi.fn(),
+}));
+
+import { useCollectorVersions, useCollectorComponent } from "@/hooks/use-collector-data";
+import type { CollectorComponent } from "@/types/collector";
+
+const mockComponent: CollectorComponent = {
+  id: "core-otlpreceiver",
+  name: "otlpreceiver",
+  ecosystem: "collector",
+  type: "receiver",
+  distribution: "core",
+  display_name: "OTLP Receiver",
+  description: "Receives data via OTLP.",
+  repository: "opentelemetry-collector",
+  status: {
+    class: "receiver",
+    stability: { stable: ["traces", "metrics", "logs"] },
+    distributions: ["core"],
+  },
+};
+
+function renderAtRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/collector/components/:distribution/:name" element={<CollectorDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("CollectorDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an error state instead of an infinite loading spinner when the versions fetch fails and no ?version= is present", () => {
+    // Regression guard for the versions-fetch-failure deadlock: with no
+    // ?version= in the URL, `version` can only ever be resolved from
+    // useCollectorVersions()'s data. If that fetch fails, the page must
+    // fall through to the error UI instead of spinning forever.
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error("Failed to load collector-versions-index: 500 Internal Server Error"),
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.getByRole("heading", { name: "Error loading component" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to load collector-versions-index: 500 Internal Server Error")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Loading component...")).not.toBeInTheDocument();
+    // The error state must still offer a way out.
+    expect(screen.getByRole("button", { name: /go back/i })).toBeInTheDocument();
+  });
+
+  it("still shows the loading state while versions are genuinely in flight (no error yet)", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.getByText("Loading component...")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Error loading component" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the component when the version resolves and the component loads successfully", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponent,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.getByText("OTLP Receiver")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Error loading component" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves the existing error UI when the component fetch itself fails with a valid version", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error('Collector component "core-otlpreceiver" not found in version 0.150.0'),
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver?version=0.150.0");
+
+    expect(screen.getByRole("heading", { name: "Error loading component" })).toBeInTheDocument();
+    expect(
+      screen.getByText('Collector component "core-otlpreceiver" not found in version 0.150.0')
+    ).toBeInTheDocument();
+  });
+
+  it("resolves the version from the URL immediately when ?version= is present, independent of the versions fetch", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponent,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver?version=0.150.0");
+
+    expect(useCollectorComponent).toHaveBeenCalledWith("core", "otlpreceiver", "0.150.0");
+    expect(screen.getByText("OTLP Receiver")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
@@ -147,8 +147,8 @@ describe("CollectorDetailPage", () => {
   it("resolves the version from the URL immediately when ?version= is present, independent of the versions fetch", () => {
     vi.mocked(useCollectorVersions).mockReturnValue({
       data: null,
-      loading: true,
-      error: null,
+      loading: false,
+      error: new Error("Failed to load collector-versions-index"),
     });
     vi.mocked(useCollectorComponent).mockReturnValue({
       data: mockComponent,

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -114,7 +114,7 @@ export function CollectorDetailPage() {
     );
   }
 
-  if (error || versionsError || !component) {
+  if (error || (!version && versionsError) || !component) {
     return (
       <PageContainer>
         <BackButton />

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -49,12 +49,15 @@ export function CollectorDetailPage() {
 
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { data: versionData } = useCollectorVersions();
+  const { data: versionData, error: versionsError } = useCollectorVersions();
 
   const version =
     searchParams.get("version") || versionData?.versions.find((v) => v.is_latest)?.version || "";
 
-  const versionLoading = !version;
+  // Once the versions fetch has settled with an error, stop waiting for a
+  // version to resolve — `version` will never become non-empty otherwise,
+  // which would leave this stuck on the loading state forever.
+  const versionLoading = !version && !versionsError;
   const {
     data: component,
     loading,
@@ -111,7 +114,7 @@ export function CollectorDetailPage() {
     );
   }
 
-  if (error || !component) {
+  if (error || versionsError || !component) {
     return (
       <PageContainer>
         <BackButton />
@@ -127,7 +130,7 @@ export function CollectorDetailPage() {
                   {t("detail.error.title")}
                 </h3>
                 <p className="text-sm text-red-600/90 dark:text-red-400/90">
-                  {error?.message || t("detail.error.fallback")}
+                  {(error ?? versionsError)?.message || t("detail.error.fallback")}
                 </p>
                 <button
                   onClick={() => navigate(-1)}


### PR DESCRIPTION
## What changed

This PR fixes the Collector detail page getting stuck in an infinite loading state when the versions fetch fails and the URL does not contain a `?version=` query parameter.

Specifically, it:

- reads the existing `versionsError` returned by `useCollectorVersions()`
- stops waiting for a version once the versions request has failed
- routes the page into the existing error UI instead of remaining in the loading state
- adds regression tests covering this scenario while preserving the existing success and loading paths

Fixes #774

---

## Why

The Collector detail page previously ignored the `error` returned from `useCollectorVersions()`.

When the versions request failed and there was no explicit `?version=` in the URL, the page could never resolve a version, causing it to remain on the loading spinner indefinitely without any recovery UI.

Other Collector pages and the equivalent Java Agent page already surface this failure correctly. This change aligns the Collector detail page with the existing error-handling behavior used elsewhere.

---

## How it was tested

- Added regression tests covering versions-fetch failures
- Verified existing loading behavior remains unchanged
- Verified successful version resolution still works
- Verified existing component-fetch error handling is preserved
- Ran targeted Collector tests
- Ran `tsc --noEmit`
- Ran ESLint

---

## Breaking change?

No

---

## Notes for reviewers

This change is intentionally scoped to the Collector detail page.

No hook or API changes were required because `useCollectorVersions()` already exposed the required error state. The page simply wasn't consuming it..!

The implementation reuses the existing error rendering path, keeping behavior consistent with other Collector pages while adding regression coverage for the previously untested scenario!