### PR TITLE
Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.repo_check.outputs.is_primary == 'true'
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write # Create / edit / reopen the automated PR

--- a/.github/workflows/nightly-registry-update.yml
+++ b/.github/workflows/nightly-registry-update.yml
@@ -54,7 +54,7 @@ jobs:
         if: steps.repo_check.outputs.is_primary == 'true'
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write # Create / edit / reopen the automated PR

--- a/.github/workflows/regenerate-collector-registry.yml
+++ b/.github/workflows/regenerate-collector-registry.yml
@@ -52,7 +52,7 @@ jobs:
         if: steps.repo_check.outputs.is_primary == 'true'
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write # Create / edit / reopen the backfill PR

--- a/.github/workflows/screenshots-commit.yml
+++ b/.github/workflows/screenshots-commit.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The app-id input for `actions/create-github-app-token` is deprecated in favor of client-id. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id / *_APP_ID` to `client-id / *_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744