### PR TITLE
Add User Interview Discussion Guide

### DIFF
--- a/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
+++ b/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
@@ -1,0 +1,98 @@
+# User Interview Discussion Guide
+
+## Introduction
+
+Thank you so much for taking the time to chat with me today.
+
+My name is Karimot, and I'm conducting UX research for the OpenTelemetry Ecosystem Explorer—a platform that helps developers discover and understand OpenTelemetry components.
+
+This session will take about **20–30 minutes**. There are no right or wrong answers. I'm here to learn from your real experiences, so please feel free to share openly.
+
+---
+
+## Background
+
+1. Could you briefly introduce yourself and tell me about your current role?
+2. How long have you been working with OpenTelemetry, and in what context do you mainly use it?
+3. How would you describe your familiarity with OpenTelemetry?
+   - Are you still finding your way around it?
+   - Using it confidently day to day?
+   - Or would you consider yourself deeply experienced?
+4. Have you used other observability tools? If so, what was your experience finding and using their documentation?
+
+---
+
+## Recent Experience
+
+Think about the last time you needed information about an OpenTelemetry component or instrumentation.
+
+Can you walk me through what you were trying to accomplish?
+
+Follow-up prompts:
+
+- What was the task or problem you were solving?
+- What component or library were you looking at?
+
+---
+
+## Information Discovery
+
+1. Where did you look for information, and why did you choose those sources?
+2. Which source ended up being the most helpful, and what made it useful?
+3. Was there anything you couldn't find or had to piece together from multiple places?
+4. How important is version-specific information (such as changelogs or compatibility notes), and how do you currently track it?
+
+---
+
+## Decision Making
+
+1. How do you decide whether a component is the right fit for your situation?
+
+   Follow-up:
+
+   - What information tells you, "Yes, this is what I need"?
+
+2. Can you think of a time when you couldn't get enough information to feel confident moving forward?
+
+   - What did you do?
+
+---
+
+## Pain Points
+
+1. What are the biggest frustrations you run into when researching OpenTelemetry components?
+2. If you could improve one thing about how OpenTelemetry information is presented today, what would it be?
+
+**Moderator note:** Encourage specific examples. For example, "clearer documentation" is difficult to act on, whereas "show what telemetry signals I'll get before I install" is much more actionable.
+
+---
+
+## AI Tools
+
+1. Do you use AI tools (such as ChatGPT, Claude, Gemini, GitHub Copilot, Claude Code, Codex, or Cursor) when working with OpenTelemetry?
+
+2. If yes:
+
+   - When do you prefer AI over the official documentation?
+   - What has your experience been like? (Accurate, frustrating, hit-or-miss?)
+   - Has an AI tool ever given you incorrect information about OpenTelemetry? What happened?
+
+---
+
+## If Time Permits
+
+### Ecosystem Explorer Feedback
+
+Use any remaining time to gather feedback on the OpenTelemetry Ecosystem Explorer prototype, concepts, or documentation experience.
+
+---
+
+## Wrap-up
+
+1. Is there anything about how you find or use OpenTelemetry information that we haven't covered but you think is important?
+
+Thank you very much for your time today.
+
+If anything comes to mind after our conversation, please feel free to reach out.
+
+If you know anyone else who uses OpenTelemetry who might be willing to participate in a research interview, I'd greatly appreciate an introduction (if additional participants are needed).

--- a/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
+++ b/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
@@ -4,36 +4,31 @@
 
 Thank you so much for taking the time to chat with me today.
 
-My name is Karimot, and I'm conducting UX research for the
-OpenTelemetry Ecosystem Explorer—a platform that helps
-developers discover and understand OpenTelemetry components.
+My name is Karimot, and I'm conducting UX research for the OpenTelemetry Ecosystem Explorer—a
+platform that helps developers discover and understand OpenTelemetry components.
 
-This session will take about **20–30 minutes**. There are no
-right or wrong answers. I'm here to learn from your real
-experiences, so please feel free to share openly.
+This session will take about **20–30 minutes**. There are no right or wrong answers. I'm here to
+learn from your real experiences, so please feel free to share openly.
 
 ---
 
 ## Background
 
-1. Could you briefly introduce yourself and tell me
-about your current role?
-2. How long have you been working with OpenTelemetry,
-and in what context do you mainly use it?
-3. How would you describe your familiarity
-with OpenTelemetry?
+1. Could you briefly introduce yourself and tell me about your current role?
+2. How long have you been working with OpenTelemetry, and in what context do you mainly use it?
+3. How would you describe your familiarity with OpenTelemetry?
    - Are you still finding your way around it?
    - Using it confidently day to day?
    - Or would you consider yourself deeply experienced?
-4. Have you used other observability tools? If so, what was
-your experience finding and using their documentation?
+4. Have you used other observability tools? If so, what was your experience finding and using their
+   documentation?
 
 ---
 
 ## Recent Experience
 
-Think about the last time you needed information about an
-OpenTelemetry component or instrumentation.
+Think about the last time you needed information about an OpenTelemetry component or
+instrumentation.
 
 Can you walk me through what you were trying to accomplish?
 
@@ -46,29 +41,24 @@ Follow-up prompts:
 
 ## Information Discovery
 
-1. Where did you look for information, and why did you
-choose those sources?
-2. Which source ended up being the most helpful, and
-what made it useful?
-3. Was there anything you couldn't find or had to piece
-together from multiple places?
-4. How important is version-specific information
-(such as changelogs or compatibility notes), and how
-do you currently track it?
+1. Where did you look for information, and why did you choose those sources?
+2. Which source ended up being the most helpful, and what made it useful?
+3. Was there anything you couldn't find or had to piece together from multiple places?
+4. How important is version-specific information (such as changelogs or compatibility notes), and
+   how do you currently track it?
 
 ---
 
 ## Decision Making
 
-1. How do you decide whether a component is the right
-fit for your situation?
+1. How do you decide whether a component is the right fit for your situation?
 
    Follow-up:
 
    - What information tells you, "Yes, this is what I need"?
 
-2. Can you think of a time when you couldn't get enough
-information to feel confident moving forward?
+2. Can you think of a time when you couldn't get enough information to feel confident moving
+   forward?
 
    - What did you do?
 
@@ -76,31 +66,25 @@ information to feel confident moving forward?
 
 ## Pain Points
 
-1. What are the biggest frustrations you run into when
-researching OpenTelemetry components?
-2. If you could improve one thing about how
-OpenTelemetry information is presented today, what would it be?
+1. What are the biggest frustrations you run into when researching OpenTelemetry components?
+2. If you could improve one thing about how OpenTelemetry information is presented today, what would
+   it be?
 
-**Moderator note:** Encourage specific examples. For example,
-"clearer documentation" is difficult to act on, whereas
-"show what telemetry signals I'll get before I install"
-is much more actionable.
+**Moderator note:** Encourage specific examples. For example, "clearer documentation" is difficult
+to act on, whereas "show what telemetry signals I'll get before I install" is much more actionable.
 
 ---
 
 ## AI Tools
 
-1. Do you use AI tools (such as ChatGPT, Claude, Gemini,
-GitHub Copilot, Claude Code, Codex, or Cursor) when working
-with OpenTelemetry?
+1. Do you use AI tools (such as ChatGPT, Claude, Gemini, GitHub Copilot, Claude Code, Codex, or
+   Cursor) when working with OpenTelemetry?
 
 2. If yes:
 
    - When do you prefer AI over the official documentation?
-   - What has your experience been like?
-   (Accurate, frustrating, hit-or-miss?)
-   - Has an AI tool ever given you incorrect information
-   about OpenTelemetry? What happened?
+   - What has your experience been like? (Accurate, frustrating, hit-or-miss?)
+   - Has an AI tool ever given you incorrect information about OpenTelemetry? What happened?
 
 ---
 
@@ -108,21 +92,19 @@ with OpenTelemetry?
 
 ### Ecosystem Explorer Feedback
 
-Use any remaining time to gather feedback on the OpenTelemetry
-Ecosystem Explorer prototype, concepts, or documentation experience.
+Use any remaining time to gather feedback on the OpenTelemetry Ecosystem Explorer prototype,
+concepts, or documentation experience.
 
 ---
 
 ## Wrap-up
 
-1. Is there anything about how you find or use OpenTelemetry
-information that we haven't covered but you think is important?
+1. Is there anything about how you find or use OpenTelemetry information that we haven't covered but
+   you think is important?
 
 Thank you very much for your time today.
 
-If anything comes to mind after our conversation,
-please feel free to reach out.
+If anything comes to mind after our conversation, please feel free to reach out.
 
-If you know anyone else who uses OpenTelemetry who might be willing to
-participate in a research interview, I'd greatly appreciate an
-introduction (if additional participants are needed).
+If you know anyone else who uses OpenTelemetry who might be willing to participate in a research
+interview, I'd greatly appreciate an introduction (if additional participants are needed).

--- a/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
+++ b/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
@@ -4,27 +4,36 @@
 
 Thank you so much for taking the time to chat with me today.
 
-My name is Karimot, and I'm conducting UX research for the OpenTelemetry Ecosystem Explorer—a platform that helps developers discover and understand OpenTelemetry components.
+My name is Karimot, and I'm conducting UX research for the
+OpenTelemetry Ecosystem Explorer—a platform that helps
+developers discover and understand OpenTelemetry components.
 
-This session will take about **20–30 minutes**. There are no right or wrong answers. I'm here to learn from your real experiences, so please feel free to share openly.
+This session will take about **20–30 minutes**. There are no
+right or wrong answers. I'm here to learn from your real
+experiences, so please feel free to share openly.
 
 ---
 
 ## Background
 
-1. Could you briefly introduce yourself and tell me about your current role?
-2. How long have you been working with OpenTelemetry, and in what context do you mainly use it?
-3. How would you describe your familiarity with OpenTelemetry?
+1. Could you briefly introduce yourself and tell me
+about your current role?
+2. How long have you been working with OpenTelemetry,
+and in what context do you mainly use it?
+3. How would you describe your familiarity
+with OpenTelemetry?
    - Are you still finding your way around it?
    - Using it confidently day to day?
    - Or would you consider yourself deeply experienced?
-4. Have you used other observability tools? If so, what was your experience finding and using their documentation?
+4. Have you used other observability tools? If so, what was
+your experience finding and using their documentation?
 
 ---
 
 ## Recent Experience
 
-Think about the last time you needed information about an OpenTelemetry component or instrumentation.
+Think about the last time you needed information about an
+OpenTelemetry component or instrumentation.
 
 Can you walk me through what you were trying to accomplish?
 
@@ -37,22 +46,29 @@ Follow-up prompts:
 
 ## Information Discovery
 
-1. Where did you look for information, and why did you choose those sources?
-2. Which source ended up being the most helpful, and what made it useful?
-3. Was there anything you couldn't find or had to piece together from multiple places?
-4. How important is version-specific information (such as changelogs or compatibility notes), and how do you currently track it?
+1. Where did you look for information, and why did you
+choose those sources?
+2. Which source ended up being the most helpful, and
+what made it useful?
+3. Was there anything you couldn't find or had to piece
+together from multiple places?
+4. How important is version-specific information
+(such as changelogs or compatibility notes), and how
+do you currently track it?
 
 ---
 
 ## Decision Making
 
-1. How do you decide whether a component is the right fit for your situation?
+1. How do you decide whether a component is the right
+fit for your situation?
 
    Follow-up:
 
    - What information tells you, "Yes, this is what I need"?
 
-2. Can you think of a time when you couldn't get enough information to feel confident moving forward?
+2. Can you think of a time when you couldn't get enough
+information to feel confident moving forward?
 
    - What did you do?
 
@@ -60,22 +76,31 @@ Follow-up prompts:
 
 ## Pain Points
 
-1. What are the biggest frustrations you run into when researching OpenTelemetry components?
-2. If you could improve one thing about how OpenTelemetry information is presented today, what would it be?
+1. What are the biggest frustrations you run into when
+researching OpenTelemetry components?
+2. If you could improve one thing about how
+OpenTelemetry information is presented today, what would it be?
 
-**Moderator note:** Encourage specific examples. For example, "clearer documentation" is difficult to act on, whereas "show what telemetry signals I'll get before I install" is much more actionable.
+**Moderator note:** Encourage specific examples. For example,
+"clearer documentation" is difficult to act on, whereas
+"show what telemetry signals I'll get before I install"
+is much more actionable.
 
 ---
 
 ## AI Tools
 
-1. Do you use AI tools (such as ChatGPT, Claude, Gemini, GitHub Copilot, Claude Code, Codex, or Cursor) when working with OpenTelemetry?
+1. Do you use AI tools (such as ChatGPT, Claude, Gemini,
+GitHub Copilot, Claude Code, Codex, or Cursor) when working
+with OpenTelemetry?
 
 2. If yes:
 
    - When do you prefer AI over the official documentation?
-   - What has your experience been like? (Accurate, frustrating, hit-or-miss?)
-   - Has an AI tool ever given you incorrect information about OpenTelemetry? What happened?
+   - What has your experience been like?
+   (Accurate, frustrating, hit-or-miss?)
+   - Has an AI tool ever given you incorrect information
+   about OpenTelemetry? What happened?
 
 ---
 
@@ -83,16 +108,21 @@ Follow-up prompts:
 
 ### Ecosystem Explorer Feedback
 
-Use any remaining time to gather feedback on the OpenTelemetry Ecosystem Explorer prototype, concepts, or documentation experience.
+Use any remaining time to gather feedback on the OpenTelemetry
+Ecosystem Explorer prototype, concepts, or documentation experience.
 
 ---
 
 ## Wrap-up
 
-1. Is there anything about how you find or use OpenTelemetry information that we haven't covered but you think is important?
+1. Is there anything about how you find or use OpenTelemetry
+information that we haven't covered but you think is important?
 
 Thank you very much for your time today.
 
-If anything comes to mind after our conversation, please feel free to reach out.
+If anything comes to mind after our conversation,
+please feel free to reach out.
 
-If you know anyone else who uses OpenTelemetry who might be willing to participate in a research interview, I'd greatly appreciate an introduction (if additional participants are needed).
+If you know anyone else who uses OpenTelemetry who might be willing to
+participate in a research interview, I'd greatly appreciate an
+introduction (if additional participants are needed).


### PR DESCRIPTION
## Summary

This PR adds a User Interview Discussion Guide to support UX research for the OpenTelemetry Ecosystem Explorer.

### Changes
- Added `user-interview-discussion-guide.md`
- Included an interview introduction and moderator guidance
- Added questions covering:
  - Participant background
  - Recent OpenTelemetry experience
  - Information discovery
  - Decision-making
  - Pain points
  - AI tool usage
  - Wrap-up questions

This guide is intended to support consistent user interviews and gather actionable feedback from OpenTelemetry users.
