### PR TITLE
fix(telemetry): prevent stale when condition in comparison results

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/components/agent-explore-landing.test.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/agent-explore-landing.test.tsx
@@ -51,7 +51,7 @@ describe("AgentExploreLanding", () => {
     });
     expect(configRefLink).toHaveAttribute(
       "href",
-      "https://opentelemetry.io/docs/zero-code/java/agent-config/"
+      "https://opentelemetry.io/docs/zero-code/java/agent/configuration/"
     );
 
     const githubLink = screen.getByRole("link", {

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useTelemetryComparison } from "./use-telemetry-comparison";
+import * as javaagentData from "@/lib/api/javaagent-data";
+import { compareTelemetry, getAvailableWhenConditions } from "../utils/telemetry-diff";
+import type { InstrumentationData, TelemetryDiffResult } from "@/types/javaagent";
+
+vi.mock("@/lib/api/javaagent-data", () => ({
+  loadInstrumentation: vi.fn(),
+}));
+
+vi.mock("../utils/telemetry-diff", () => ({
+  compareTelemetry: vi.fn(),
+  getAvailableWhenConditions: vi.fn(),
+}));
+
+const INSTRUMENTATION_NAME = "kafka-clients";
+const STUB_INSTRUMENTATION = { name: INSTRUMENTATION_NAME } as InstrumentationData;
+
+describe("useTelemetryComparison hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAvailableWhenConditions).mockReturnValue(["default", "experimental"]);
+    // Echo the `when` condition compareTelemetry was called with into the (real)
+    // optional SpanDiff.whenCondition field, so tests can assert which condition
+    // a given diffResult was actually computed for.
+    vi.mocked(compareTelemetry).mockImplementation(
+      (_from, _to, when = "default"): TelemetryDiffResult => ({
+        metrics: [],
+        spans: [{ status: "added", span: { span_kind: "CONSUMER" }, whenCondition: when }],
+      })
+    );
+  });
+
+  it("uses the whenCondition selected while a version fetch was in flight, not the one active when the fetch started (#795 regression)", async () => {
+    let resolveToVersion: (value: InstrumentationData) => void;
+
+    vi.mocked(javaagentData.loadInstrumentation).mockImplementation(async (_id, version) => {
+      if (version === "2.0.0") {
+        return new Promise<InstrumentationData>((resolve) => {
+          resolveToVersion = resolve;
+        });
+      }
+      return STUB_INSTRUMENTATION;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ toVersion }: { toVersion: string }) =>
+        useTelemetryComparison(INSTRUMENTATION_NAME, "1.0.0", toVersion),
+      { initialProps: { toVersion: "1.5.0" } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.diffResult?.spans[0]?.whenCondition).toBe("default");
+
+    // 1. A new version comparison request starts...
+    rerender({ toVersion: "2.0.0" });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // 2. ...request is intentionally left pending (resolveToVersion not yet called)
+    //    while the user changes the when-condition.
+    act(() => {
+      result.current.setWhenCondition("experimental");
+    });
+
+    // 3. The delayed request now resolves.
+    resolveToVersion!(STUB_INSTRUMENTATION);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The diff must be computed using the latest whenCondition ("experimental"),
+    // not "default" (the value active when the version fetch started).
+    expect(result.current.whenCondition).toBe("experimental");
+    expect(result.current.diffResult?.spans[0]?.whenCondition).toBe("experimental");
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.ts
@@ -52,16 +52,14 @@ export function useTelemetryComparison(
   const [toNotFound, setToNotFound] = useState(false);
   const fromInstrRef = useRef<InstrumentationData | null>(null);
   const toInstrRef = useRef<InstrumentationData | null>(null);
-  // Lets the in-flight loadComparison() closure below read the latest whenCondition
+  // Allows the in-flight loadComparison() closure below to read the latest whenCondition
   // instead of the value captured when the effect was created (see #795).
   const whenConditionRef = useRef(whenCondition);
+  // eslint-disable-next-line react-hooks/refs
+  whenConditionRef.current = whenCondition;
 
   const fromVersion = customFromVersion ?? initialFromVersion;
   const toVersion = customToVersion ?? initialToVersion;
-
-  useEffect(() => {
-    whenConditionRef.current = whenCondition;
-  }, [whenCondition]);
 
   useEffect(() => {
     let cancelled = false;

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-telemetry-comparison.ts
@@ -52,9 +52,16 @@ export function useTelemetryComparison(
   const [toNotFound, setToNotFound] = useState(false);
   const fromInstrRef = useRef<InstrumentationData | null>(null);
   const toInstrRef = useRef<InstrumentationData | null>(null);
+  // Lets the in-flight loadComparison() closure below read the latest whenCondition
+  // instead of the value captured when the effect was created (see #795).
+  const whenConditionRef = useRef(whenCondition);
 
   const fromVersion = customFromVersion ?? initialFromVersion;
   const toVersion = customToVersion ?? initialToVersion;
+
+  useEffect(() => {
+    whenConditionRef.current = whenCondition;
+  }, [whenCondition]);
 
   useEffect(() => {
     let cancelled = false;
@@ -121,11 +128,12 @@ export function useTelemetryComparison(
         const conditions = getAvailableWhenConditions(fromInstrumentation, toInstrumentation);
         setAvailableConditions(conditions);
 
+        const currentWhenCondition = whenConditionRef.current;
         const fallbackCondition = conditions.includes("default") ? "default" : conditions[0];
-        const activeCondition = conditions.includes(whenCondition)
-          ? whenCondition
+        const activeCondition = conditions.includes(currentWhenCondition)
+          ? currentWhenCondition
           : fallbackCondition;
-        if (activeCondition !== whenCondition) {
+        if (activeCondition !== currentWhenCondition) {
           setWhenCondition(activeCondition);
         }
 
@@ -147,7 +155,7 @@ export function useTelemetryComparison(
     return () => {
       cancelled = true;
     };
-  }, [instrumentationName, fromVersion, toVersion, t]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [instrumentationName, fromVersion, toVersion, t]);
 
   useEffect(() => {
     if (!fromInstrRef.current && !toInstrRef.current) return;


### PR DESCRIPTION
## Summary

This PR fixes a stale state issue in the Java Agent Telemetry Comparison view..!

When a version change is still loading, changing the selected `when` condition could cause the comparison to be computed using the previous condition while the UI displayed the newly selected one. This resulted in inconsistent comparison results until another interaction triggered a recomputation!

The comparison logic now always uses the latest selected `when` condition when the asynchronous comparison resolves!

## Changes

- Use the latest `when` condition during asynchronous comparison resolution
- Keep the fix scoped to the comparison hook without changing the API or metadata model
- Add a regression test covering the interaction where the `when` condition changes while a version request is still in flight

## Testing

- Reproduced the issue locally on the latest `main`
- Verified that the comparison now reflects the latest selected `when` condition after the request completes
- Added a regression test for the reported scenario

Fixes #795