### PR TITLE
SEO Improvements 3 - SEO rendering component per page

### DIFF
--- a/ecosystem-explorer/src/components/seo/seo.test.tsx
+++ b/ecosystem-explorer/src/components/seo/seo.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { Seo } from "./seo";
+import { DEFAULT_TITLE, SITE_ORIGIN } from "@/lib/seo/constants";
+import { STATIC_ROUTE_META } from "@/lib/seo/derive";
+
+const metaContent = (attr: "name" | "property", key: string) =>
+  document.head.querySelector(`meta[${attr}="${key}"]`)?.getAttribute("content");
+
+const renderAt = (path: string, props: Parameters<typeof Seo>[0] = {}) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Seo {...props} />
+    </MemoryRouter>
+  );
+
+afterEach(() => {
+  document.head.innerHTML = "";
+  document.title = "";
+});
+
+describe("Seo", () => {
+  it("resolves title/description from the static route map by pathname", () => {
+    renderAt("/collector");
+    const expected = STATIC_ROUTE_META["/collector"];
+    expect(document.title).toBe(expected.title);
+    expect(metaContent("name", "description")).toBe(expected.description);
+    expect(metaContent("property", "og:title")).toBe(expected.title);
+    expect(metaContent("property", "og:description")).toBe(expected.description);
+  });
+
+  it("prefers explicit props over the static map (detail-page usage)", () => {
+    renderAt("/collector/components/contrib/kafkareceiver", {
+      title: "Kafka Receiver — OpenTelemetry Collector",
+      description: "Receives Kafka data.",
+    });
+    expect(document.title).toBe("Kafka Receiver — OpenTelemetry Collector");
+    expect(metaContent("name", "description")).toBe("Receives Kafka data.");
+  });
+
+  it("sets a query-less canonical URL from the current pathname", () => {
+    renderAt("/java-agent/instrumentation/kafka-clients-0.11?version=2.29.0", {
+      title: "t",
+      description: "d",
+    });
+    expect(document.head.querySelector('link[rel="canonical"]')?.getAttribute("href")).toBe(
+      `${SITE_ORIGIN}/java-agent/instrumentation/kafka-clients-0.11`
+    );
+  });
+
+  it("falls back to site defaults for an unknown route with no props", () => {
+    renderAt("/some/unknown/path");
+    expect(document.title).toBe(DEFAULT_TITLE);
+    expect(metaContent("name", "description")?.length).toBeGreaterThan(0);
+  });
+
+  it("updates the existing static tag in place instead of duplicating it", () => {
+    const staticMeta = document.createElement("meta");
+    staticMeta.setAttribute("name", "description");
+    staticMeta.setAttribute("content", "original");
+    document.head.appendChild(staticMeta);
+
+    renderAt("/collector");
+
+    const all = document.head.querySelectorAll('meta[name="description"]');
+    expect(all.length).toBe(1);
+    expect(all[0].getAttribute("content")).toBe(STATIC_ROUTE_META["/collector"].description);
+  });
+});

--- a/ecosystem-explorer/src/components/seo/seo.tsx
+++ b/ecosystem-explorer/src/components/seo/seo.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_OG_IMAGE,
+  DEFAULT_TITLE,
+  SITE_ORIGIN,
+} from "@/lib/seo/constants";
+import { STATIC_ROUTE_META } from "@/lib/seo/derive";
+
+export interface SeoProps {
+  /** Page title. Falls back to the static route map, then the site default. */
+  title?: string;
+  /** Meta/OG description. Falls back to the static route map, then the site default. */
+  description?: string;
+  /** Absolute social image URL. Defaults to the shared og-default.png. */
+  image?: string;
+  /**
+   * Canonical pathname (without query string). Defaults to the current route's
+   * pathname, which is already query-less.
+   */
+  pathname?: string;
+}
+
+/**
+ * Upserts a single `<meta>` tag identified by `attr`=`key` (e.g. name="description"
+ * or property="og:title"), so we update the static tag from index.html in place
+ * rather than appending a duplicate.
+ */
+function upsertMeta(attr: "name" | "property", key: string, content: string): void {
+  let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+/** Upserts the canonical `<link rel="canonical">`. */
+function upsertCanonical(href: string): void {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
+}
+
+/**
+ * Per-route document metadata. Renders nothing; imperatively syncs the document
+ * title, description, canonical link, and Open Graph / Twitter tags to the
+ * resolved values for the current route.
+ *
+ * This is the client-side layer of SEO metadata (browser tab titles + what a
+ * JS-rendering crawler such as Googlebot sees). Non-JS social scrapers are
+ * served the same values at the edge; both derive from the shared src/lib/seo
+ * helpers so they agree per URL.
+ */
+export function Seo({ title, description, image, pathname }: SeoProps) {
+  const location = useLocation();
+  const path = pathname ?? location.pathname;
+
+  const staticMeta = STATIC_ROUTE_META[path];
+  const resolvedTitle = title ?? staticMeta?.title ?? DEFAULT_TITLE;
+  const resolvedDescription = description ?? staticMeta?.description ?? DEFAULT_DESCRIPTION;
+  const resolvedImage = image ?? DEFAULT_OG_IMAGE;
+  const canonicalUrl = `${SITE_ORIGIN}${path}`;
+
+  useEffect(() => {
+    document.title = resolvedTitle;
+    upsertMeta("name", "description", resolvedDescription);
+    upsertCanonical(canonicalUrl);
+
+    upsertMeta("property", "og:title", resolvedTitle);
+    upsertMeta("property", "og:description", resolvedDescription);
+    upsertMeta("property", "og:url", canonicalUrl);
+    upsertMeta("property", "og:image", resolvedImage);
+
+    upsertMeta("name", "twitter:title", resolvedTitle);
+    upsertMeta("name", "twitter:description", resolvedDescription);
+    upsertMeta("name", "twitter:image", resolvedImage);
+  }, [resolvedTitle, resolvedDescription, resolvedImage, canonicalUrl]);
+
+  return null;
+}

--- a/ecosystem-explorer/src/features/about/about-page.tsx
+++ b/ecosystem-explorer/src/features/about/about-page.tsx
@@ -18,6 +18,7 @@ import { BookOpen, Bug, MessageSquare } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import { BackButton } from "@/components/ui/back-button";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { useEcosystemStats } from "@/hooks/use-ecosystem-stats";
 
 const REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer";
@@ -31,6 +32,7 @@ export function AboutPage() {
   } = useEcosystemStats();
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-6">
         <BackButton />
         <div className="mx-auto max-w-4xl space-y-10 py-12">

--- a/ecosystem-explorer/src/features/collector/collector-components-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { BackButton } from "@/components/ui/back-button";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
@@ -178,6 +179,8 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
 
   return (
     <>
+      {/* Pin canonical to the version-less list so /collector/components/:version variants dedupe. */}
+      <Seo pathname="/collector/components" />
       <div className="border-border/60 bg-surface-card shadow-surface relative overflow-hidden rounded-xl border p-6">
         <div className="bg-gradient-radial from-secondary/5 via-primary/2 absolute inset-0 to-transparent opacity-50" />
 

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -26,6 +26,8 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SectionHeader } from "@/components/ui/section-header";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
+import { deriveCollectorMeta } from "@/lib/seo/derive";
 import { useCollectorComponent, useCollectorVersions } from "@/hooks/use-collector-data";
 import { CollectorTelemetryTab } from "./components/collector-telemetry-tab";
 
@@ -165,8 +167,18 @@ export function CollectorDetailPage() {
 
   const typeDesc = t(`detail.typeDescriptions.${component.type}`, { defaultValue: "" });
 
+  const seo = deriveCollectorMeta({
+    id: `${component.distribution}-${component.name}`,
+    name: component.name,
+    distribution: component.distribution,
+    display_name: component.display_name,
+    description: component.description,
+    type: component.type,
+  });
+
   return (
     <PageContainer>
+      <Seo title={seo.title} description={seo.description} />
       <BackButton />
 
       <div className="mt-3 space-y-6">

--- a/ecosystem-explorer/src/features/collector/collector-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-page.tsx
@@ -16,6 +16,7 @@
 import { useTranslation } from "react-i18next";
 import { PageContainer } from "@/components/layout/page-container";
 import { BackButton } from "@/components/ui/back-button";
+import { Seo } from "@/components/seo/seo";
 import { CollectorExploreLanding } from "@/features/collector/components/collector-explore-landing.tsx";
 
 export function CollectorPage() {
@@ -23,6 +24,7 @@ export function CollectorPage() {
 
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-6">
         <BackButton />
         <div>

--- a/ecosystem-explorer/src/features/home/home-page.tsx
+++ b/ecosystem-explorer/src/features/home/home-page.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Seo } from "@/components/seo/seo";
 import { HeroSection } from "./components/hero-section";
 import { ExploreSection } from "./components/explore-section";
 
 export function HomePage() {
   return (
     <>
+      <Seo />
       <HeroSection />
       <ExploreSection />
     </>

--- a/ecosystem-explorer/src/features/java-agent/components/standalone-library-tab.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/standalone-library-tab.tsx
@@ -89,14 +89,17 @@ export function StandaloneLibraryTab({
         components={{
           a: Anchor,
           code: Code,
+          // Downshift README headings one level: the page already owns the sole
+          // <h1> (the instrumentation name), so the rendered document keeps a
+          // single top-level heading. Styling classes are unchanged.
           h1: ({ children }) => (
-            <h1 className="text-foreground mt-6 mb-3 text-2xl font-bold first:mt-0">{children}</h1>
+            <h2 className="text-foreground mt-6 mb-3 text-2xl font-bold first:mt-0">{children}</h2>
           ),
           h2: ({ children }) => (
-            <h2 className="text-foreground mt-5 mb-2 text-xl font-semibold">{children}</h2>
+            <h3 className="text-foreground mt-5 mb-2 text-xl font-semibold">{children}</h3>
           ),
           h3: ({ children }) => (
-            <h3 className="text-foreground mt-4 mb-2 text-base font-semibold">{children}</h3>
+            <h4 className="text-foreground mt-4 mb-2 text-base font-semibold">{children}</h4>
           ),
           p: ({ children }) => (
             <p className="text-foreground/80 mb-3 text-sm leading-relaxed">{children}</p>

--- a/ecosystem-explorer/src/features/java-agent/components/standalone-library-tab.tsx
+++ b/ecosystem-explorer/src/features/java-agent/components/standalone-library-tab.tsx
@@ -89,7 +89,7 @@ export function StandaloneLibraryTab({
         components={{
           a: Anchor,
           code: Code,
-          // Downshift README headings one level: the page already owns the sole
+          // Downshift README headings h1–h3 one level: the page already owns the sole
           // <h1> (the instrumentation name), so the rendered document keeps a
           // single top-level heading. Styling classes are unchanged.
           h1: ({ children }) => (

--- a/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/configuration/configuration-builder-page.tsx
@@ -20,6 +20,7 @@ import { Loader } from "@/components/ui/loader";
 import { BackButton } from "@/components/ui/back-button";
 import { BetaBadge } from "@/components/ui/beta-badge";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { VersionSelector } from "@/features/java-agent/components/version-selector";
 import {
@@ -399,6 +400,7 @@ export function ConfigurationBuilderPage() {
 
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-6">
         <BackButton />
         <div className="flex flex-wrap items-start justify-between gap-4">

--- a/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/instrumentation-detail-page.tsx
@@ -46,6 +46,8 @@ import { TelemetrySection } from "./components/telemetry-section";
 import { TelemetryComparisonSection } from "./components/telemetry-comparison/telemetry-comparison-section";
 import { VersionSelector } from "./components/version-selector";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
+import { deriveInstrumentationMeta } from "@/lib/seo/derive";
 import { Tooltip } from "@/components/ui/tooltip";
 import { InstrumentationConfigurationTab } from "./components/instrumentation-configuration-tab";
 import { StandaloneLibraryTab } from "./components/standalone-library-tab";
@@ -221,8 +223,11 @@ export function InstrumentationDetailPage() {
   const showRawName =
     instrumentation.display_name && instrumentation.display_name !== instrumentation.name;
 
+  const seo = deriveInstrumentationMeta(instrumentation);
+
   return (
     <PageContainer>
+      <Seo title={seo.title} description={seo.description} />
       <BackButton />
 
       <div className="mt-3 space-y-6">

--- a/ecosystem-explorer/src/features/java-agent/java-agent-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-agent-page.tsx
@@ -16,12 +16,14 @@
 import { AgentExploreLanding } from "@/features/java-agent/components/agent-explore-landing.tsx";
 import { BackButton } from "@/components/ui/back-button";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { useTranslation } from "react-i18next";
 
 export function JavaAgentPage() {
   const { t } = useTranslation("java-agent");
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-6">
         <BackButton />
         <div>

--- a/ecosystem-explorer/src/features/java-agent/java-configuration-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-configuration-list-page.tsx
@@ -18,6 +18,7 @@ import { Search, Settings } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
 import { BackButton } from "@/components/ui/back-button";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { useTranslation } from "react-i18next";
 import { Tabs } from "@/components/ui/tabs";
 import { SegmentedTabList } from "@/components/ui/segmented-tabs";
@@ -78,6 +79,7 @@ export function JavaConfigurationListPage() {
 
   return (
     <PageContainer>
+      <Seo />
       <BackButton />
 
       <div className="mt-3 space-y-6">

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -30,6 +30,7 @@ import { VersionSelector } from "@/features/java-agent/components/version-select
 import { getInstrumentationDisplayName } from "./utils/format";
 import { groupInstrumentationsByDisplayName } from "./utils/group-instrumentations";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 
 export function JavaInstrumentationListPage() {
   const { t } = useTranslation("java-agent");
@@ -300,6 +301,7 @@ export function JavaInstrumentationListPage() {
 
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-4">
         <BackButton />
 

--- a/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
@@ -19,6 +19,7 @@ import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { AlertCircle, Loader2, ArrowRight, ExternalLink, ChevronDown } from "lucide-react";
 import { PageContainer } from "@/components/layout/page-container";
+import { Seo } from "@/components/seo/seo";
 import { BackButton } from "@/components/ui/back-button";
 import { useVersions } from "@/hooks/use-javaagent-data";
 import { useReleaseComparison } from "./hooks/use-release-comparison";
@@ -93,6 +94,7 @@ export function JavaReleaseComparisonPage() {
 
   return (
     <PageContainer>
+      <Seo />
       <div className="space-y-8">
         <BackButton />
 

--- a/ecosystem-explorer/src/v1/features/ecosystem/collector-landing.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/collector-landing.tsx
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Seo } from "@/components/seo/seo";
 import { EcosystemPage } from "./ecosystem-page";
 import { collectorConfig } from "./collector-config";
 
 export function CollectorLandingV1() {
-  return <EcosystemPage config={collectorConfig} />;
+  return (
+    <>
+      <Seo />
+      <EcosystemPage config={collectorConfig} />
+    </>
+  );
 }

--- a/ecosystem-explorer/src/v1/features/ecosystem/java-agent-landing.tsx
+++ b/ecosystem-explorer/src/v1/features/ecosystem/java-agent-landing.tsx
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Seo } from "@/components/seo/seo";
 import { EcosystemPage } from "./ecosystem-page";
 import { javaAgentConfig } from "./java-agent-config";
 
 export function JavaAgentLandingV1() {
-  return <EcosystemPage config={javaAgentConfig} />;
+  return (
+    <>
+      <Seo />
+      <EcosystemPage config={javaAgentConfig} />
+    </>
+  );
 }

--- a/ecosystem-explorer/src/v1/features/home/home-page.tsx
+++ b/ecosystem-explorer/src/v1/features/home/home-page.tsx
@@ -17,6 +17,7 @@
 import { Link } from "react-router-dom";
 
 import { Compass } from "@/components/icons/compass";
+import { Seo } from "@/components/seo/seo";
 import { CoverBlock } from "@/v1/components/home/cover-block";
 import { EcosystemsGrid } from "@/v1/components/home/ecosystems-grid";
 import { GlobalSearch } from "@/v1/components/home/global-search";
@@ -48,6 +49,7 @@ const COVER_CTAS = (
 export function HomeV1() {
   return (
     <div className="td-home">
+      <Seo />
       <CoverBlock
         logo={<Compass />}
         title={


### PR DESCRIPTION
Adds additional SEO metadata per page, generated dynamically

Example:
https://deploy-preview-815--otel-ecosystem-explorer.netlify.app/java-agent/instrumentation/activej-http-6.0

<img width="831" height="452" alt="image" src="https://github.com/user-attachments/assets/a87937ca-54a7-4c8f-a310-66a6c8af2ccc" />


Related to #636