### PR TITLE
Add audit for collector components missing display_name

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -126,11 +126,6 @@ jobs:
           uv run explorer-db-builder --ecosystem "$ECOSYSTEM" --clean --collector-audit-report
           "${RUNNER_TEMP}/collector-missing-display-names.json"
 
-      # Open/update/close a tracking issue for collector components lacking a display_name.
-      # Not gated on has_changes (a component can be missing one on a night with no DB diff)
-      # or on is_primary (issue writes only need GITHUB_TOKEN + `issues: write`, so this works
-      # on forks too, against their own issues); skips when the report is absent
-      # (javaagent/configuration-only runs).
       - name: Sync missing-display_name tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,8 +138,6 @@ jobs:
             exit 0
           fi
 
-          # No backticks in the title: they'd show literally (titles aren't rendered) and
-          # this is also the `in:title` search key below.
           ISSUE_TITLE="Collector components missing display_name"
           LABEL="upstream-metadata"
 

--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: write # Push generated database to the otelbot/automated-explorer-database-update branch
       pull-requests: write # Create or update the automated database-update PR
+      issues: write # Open/update/close the "collector components missing display_name" tracking issue
     runs-on: ubuntu-latest
     steps:
       - name: Detect repository type (if on a fork we use different git config)
@@ -111,13 +112,99 @@ jobs:
         if: ${{ (inputs.build_mode || 'incremental') == 'incremental' }}
         env:
           ECOSYSTEM: ${{ inputs.ecosystem || 'all' }}
-        run: uv run explorer-db-builder --ecosystem "$ECOSYSTEM"
+        # --collector-audit-report writes a build artifact (not committed to the database)
+        # consumed by the "Sync missing-display_name tracking issue" step below.
+        run:
+          uv run explorer-db-builder --ecosystem "$ECOSYSTEM" --collector-audit-report
+          "${RUNNER_TEMP}/collector-missing-display-names.json"
 
       - name: Build explorer database (clean)
         if: inputs.build_mode == 'clean'
         env:
           ECOSYSTEM: ${{ inputs.ecosystem }}
-        run: uv run explorer-db-builder --ecosystem "$ECOSYSTEM" --clean
+        run:
+          uv run explorer-db-builder --ecosystem "$ECOSYSTEM" --clean --collector-audit-report
+          "${RUNNER_TEMP}/collector-missing-display-names.json"
+
+      # Open/update/close a tracking issue for collector components lacking a display_name.
+      # Not gated on has_changes (a component can be missing one on a night with no DB diff);
+      # skips when the report is absent (javaagent/configuration-only runs). Issue writes use
+      # GITHUB_TOKEN + `issues: write`; the otelbot App token only holds `pull-requests: write`.
+      - name: Sync missing-display_name tracking issue
+        if: steps.repo_check.outputs.is_primary == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_FILE: ${{ runner.temp }}/collector-missing-display-names.json
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ ! -f "$REPORT_FILE" ]; then
+            echo "No collector audit report at $REPORT_FILE (collector not built); skipping."
+            exit 0
+          fi
+
+          # No backticks in the title: they'd show literally (titles aren't rendered) and
+          # this is also the `in:title` search key below.
+          ISSUE_TITLE="Collector components missing display_name"
+          LABEL="upstream-metadata"
+
+          # Idempotent: no-op if the label already exists.
+          gh label create "$LABEL" \
+            --description "Metadata that should be fixed in the upstream OpenTelemetry repositories" \
+            --color "d4c5f9" 2>/dev/null || true
+
+          COUNT=$(jq '.missing | length' "$REPORT_FILE")
+          VERSION=$(jq -r '.version' "$REPORT_FILE")
+
+          EXISTING=$(gh issue list \
+            --search "in:title \"$ISSUE_TITLE\"" \
+            --state open \
+            --label "$LABEL" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ "$COUNT" -eq 0 ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" \
+                --comment "All collector components in \`v${VERSION}\` now have a \`display_name\`. Closing."
+              echo "Closed tracking issue #$EXISTING (no components missing display_name)."
+            else
+              echo "No components missing display_name and no open issue; nothing to do."
+            fi
+            exit 0
+          fi
+
+          BODY_FILE="${RUNNER_TEMP}/missing-display-names-body.md"
+          {
+            jq -r '
+              . as $r
+              | "The following components in the latest collector release (`v\($r.version)`) are missing a `display_name` in their upstream `metadata.yaml`. Fixing them upstream (opentelemetry-collector / opentelemetry-collector-contrib) lets them render with a friendly name in the Ecosystem Explorer.\n\n**Total missing: \($r.missing | length)**\n"
+                + ( $r.missing
+                    | group_by(.distribution)
+                    | map(
+                        "\n## \(.[0].distribution)\n"
+                        + ( group_by(.type)
+                            | map( "\n### \(.[0].type)\n" + ( map("- `\(.name)`") | join("\n") ) )
+                            | join("\n") ) )
+                    | join("\n") )
+            ' "$REPORT_FILE"
+            echo ""
+            echo ""
+            echo "---"
+            echo "_This issue is maintained automatically by the [Build Explorer Database](https://github.com/${REPO}/actions/runs/${RUN_ID}) workflow. It is updated nightly and closed automatically once every component has a display_name._"
+          } > "$BODY_FILE"
+
+          if [ -n "$EXISTING" ]; then
+            # Edit the body rather than comment: this runs nightly and comments would be noisy.
+            gh issue edit "$EXISTING" --body-file "$BODY_FILE"
+            echo "Updated tracking issue #$EXISTING ($COUNT components missing display_name)."
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "$LABEL"
+            echo "Created tracking issue ($COUNT components missing display_name)."
+          fi
 
       - name: Check for database changes
         id: check_changes

--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -127,11 +127,11 @@ jobs:
           "${RUNNER_TEMP}/collector-missing-display-names.json"
 
       # Open/update/close a tracking issue for collector components lacking a display_name.
-      # Not gated on has_changes (a component can be missing one on a night with no DB diff);
-      # skips when the report is absent (javaagent/configuration-only runs). Issue writes use
-      # GITHUB_TOKEN + `issues: write`; the otelbot App token only holds `pull-requests: write`.
+      # Not gated on has_changes (a component can be missing one on a night with no DB diff)
+      # or on is_primary (issue writes only need GITHUB_TOKEN + `issues: write`, so this works
+      # on forks too, against their own issues); skips when the report is absent
+      # (javaagent/configuration-only runs).
       - name: Sync missing-display_name tracking issue
-        if: steps.repo_check.outputs.is_primary == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPORT_FILE: ${{ runner.temp }}/collector-missing-display-names.json

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -15,6 +15,7 @@
 """Orchestrates the collector database build pipeline."""
 
 import logging
+from pathlib import Path
 from typing import Optional
 
 from collector_watcher.inventory_manager import InventoryManager
@@ -206,6 +207,13 @@ def run_collector_builder(
         )
 
         if audit_report_path:
+            # Enforce the "outside the database directory" invariant: a report written
+            # inside it would be committed and bump DB_VERSION. Fail fast if so.
+            report_path = Path(audit_report_path).resolve()
+            db_dir = db_writer.database_dir.resolve()
+            if report_path == db_dir or db_dir in report_path.parents:
+                raise ValueError(f"audit report path {report_path} must be outside the database directory {db_dir}")
+
             # Latest release only: that's the version fixable upstream today.
             missing = find_missing_display_names(latest_components)
             write_missing_display_name_report(audit_report_path, str(processed_versions[0]), missing)

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -21,6 +21,10 @@ from collector_watcher.inventory_manager import InventoryManager
 from semantic_version import Version
 
 from explorer_db_builder.collector_database_writer import CollectorDatabaseWriter
+from explorer_db_builder.collector_display_name_audit import (
+    find_missing_display_names,
+    write_missing_display_name_report,
+)
 from explorer_db_builder.collector_transformer import make_index_component, transform_collector_components
 from explorer_db_builder.ecosystem_stats import count_unique_collector_component_ids
 
@@ -147,6 +151,7 @@ def run_collector_builder(
     inventory_manager: Optional[InventoryManager] = None,
     db_writer: Optional[CollectorDatabaseWriter] = None,
     clean: bool = False,
+    audit_report_path: Optional[str] = None,
 ) -> int:
     """Run the collector database builder pipeline.
 
@@ -154,6 +159,9 @@ def run_collector_builder(
         inventory_manager: Optional override for testing.
         db_writer: Optional override for testing.
         clean: If True, wipe the output directory before building.
+        audit_report_path: If set, write a JSON report of latest-release components
+            missing a display_name to this path (a build artifact, not part of the
+            database, so it must live outside the database directory).
 
     Returns:
         Exit code: 0 for success, 1 for failure.
@@ -196,6 +204,12 @@ def run_collector_builder(
                 "component_count": count_unique_collector_component_ids(components_by_version),
             }
         )
+
+        if audit_report_path:
+            # Latest release only: that's the version fixable upstream today.
+            missing = find_missing_display_names(latest_components)
+            write_missing_display_name_report(audit_report_path, str(processed_versions[0]), missing)
+            logger.info("Collector components missing display_name (latest release): %d", len(missing))
 
         stats = db_writer.get_stats()
         total_mb = stats["total_bytes"] / (1024 * 1024)

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_display_name_audit.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_display_name_audit.py
@@ -24,6 +24,19 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Experimental interface placeholders in collector-core (the "x" prefix denotes the
+# experimental component API), not real user-facing components - they legitimately have
+# no display_name, so exclude them from the audit rather than flag them for an upstream fix.
+IGNORED_COMPONENT_IDS = frozenset(
+    {
+        "core-xconnector",
+        "core-xexporter",
+        "core-xextension",
+        "core-xprocessor",
+        "core-xreceiver",
+    }
+)
+
 
 def find_missing_display_names(components: list[dict[str, Any]]) -> list[dict[str, str]]:
     """Return the components whose display_name is missing or blank.
@@ -35,9 +48,12 @@ def find_missing_display_names(components: list[dict[str, Any]]) -> list[dict[st
     Returns:
         Slim dicts {id, distribution, type, name} for every component whose display_name
         is absent, null, or empty/whitespace-only, sorted by id for deterministic output.
+        Components in IGNORED_COMPONENT_IDS are excluded.
     """
     missing: list[dict[str, str]] = []
     for component in components:
+        if component.get("id") in IGNORED_COMPONENT_IDS:
+            continue
         if not (component.get("display_name") or "").strip():
             missing.append(
                 {

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_display_name_audit.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_display_name_audit.py
@@ -1,0 +1,69 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Audit collector components for a missing display_name, for the nightly tracking issue.
+
+The report is a build artifact, deliberately NOT written to the content-addressed database,
+so it stays out of the DB diff, the DB_VERSION bump, and the automated database PR.
+"""
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def find_missing_display_names(components: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Return the components whose display_name is missing or blank.
+
+    Args:
+        components: Flat list of canonical component dicts (the shape produced by
+            transform_collector_components).
+
+    Returns:
+        Slim dicts {id, distribution, type, name} for every component whose display_name
+        is absent, null, or empty/whitespace-only, sorted by id for deterministic output.
+    """
+    missing: list[dict[str, str]] = []
+    for component in components:
+        if not (component.get("display_name") or "").strip():
+            missing.append(
+                {
+                    "id": component["id"],
+                    "distribution": component["distribution"],
+                    "type": component["type"],
+                    "name": component["name"],
+                }
+            )
+    return sorted(missing, key=lambda c: c["id"])
+
+
+def write_missing_display_name_report(path: str, version: str, missing: list[dict[str, str]]) -> None:
+    """Write the missing-display_name audit report as JSON.
+
+    Args:
+        path: Destination file path (a build artifact location, not the database dir).
+        version: The collector release version the report reflects (latest processed).
+        missing: Output of find_missing_display_names.
+    """
+    report = {
+        "ecosystem": "collector",
+        "version": version,
+        "missing": missing,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+        f.write("\n")
+    logger.info("Wrote missing-display_name report to %s", path)

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -268,12 +268,14 @@ def run_javaagent_builder(
         return 1
 
 
-def run_builder(clean: bool = False, ecosystem: str = "all") -> int:
+def run_builder(clean: bool = False, ecosystem: str = "all", collector_audit_report: Optional[str] = None) -> int:
     """Run the selected database builder pipelines.
 
     Args:
         clean: If True, wipe the output directories before building.
         ecosystem: Which pipeline to run: "javaagent", "configuration", "collector", or "all".
+        collector_audit_report: If set, the collector build writes a JSON report of
+            latest-release components missing a display_name to this path.
 
     Returns:
         0 if all selected pipelines succeed, 1 if any fail.
@@ -292,7 +294,7 @@ def run_builder(clean: bool = False, ecosystem: str = "all") -> int:
 
     if ecosystem in ("collector", "all"):
         logger.info("--- Collector ---")
-        results.append(run_collector_builder(clean=clean))
+        results.append(run_collector_builder(clean=clean, audit_report_path=collector_audit_report))
         logger.info("")
 
     return 1 if any(r != 0 for r in results) else 0
@@ -315,6 +317,15 @@ def main() -> None:
         default="all",
         help="Which ecosystem pipeline to run (default: all)",
     )
+    parser.add_argument(
+        "--collector-audit-report",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write a JSON report of latest-release collector components missing a "
+            "display_name to PATH. Only produced when the collector pipeline runs."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -325,7 +336,11 @@ def main() -> None:
     logger.info("=" * 60)
     logger.info("")
 
-    exit_code = run_builder(clean=args.clean, ecosystem=args.ecosystem)
+    exit_code = run_builder(
+        clean=args.clean,
+        ecosystem=args.ecosystem,
+        collector_audit_report=args.collector_audit_report,
+    )
     sys.exit(exit_code)
 
 

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
@@ -387,6 +387,74 @@ class TestRunCollectorBuilder:
         assert result == 1
 
 
+class TestRunCollectorBuilderAuditReport:
+    def test_no_report_written_without_path(self, tmp_path):
+        manager = _make_mock_inventory_manager()
+        db_writer = CollectorDatabaseWriter(database_dir=str(tmp_path / "collector"))
+
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer)
+
+        # No stray report file anywhere when the flag isn't passed.
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_report_lists_only_latest_release_missing_components(self, tmp_path):
+        # Latest (0.151.0): one component without display_name; an older version has none
+        # missing, and must not leak into the latest-only report.
+        core_latest = {
+            "distribution": "core",
+            "version": "0.151.0",
+            "repository": "opentelemetry-collector",
+            "components": {
+                "receiver": [
+                    {"name": "nopreceiver", "metadata": {"display_name": "No-op Receiver"}},
+                    {"name": "mysteryreceiver", "metadata": {}},  # missing display_name
+                ],
+                "processor": [],
+                "exporter": [],
+                "connector": [],
+                "extension": [],
+            },
+        }
+        contrib_latest = {
+            "distribution": "contrib",
+            "version": "0.151.0",
+            "repository": "opentelemetry-collector-contrib",
+            "components": {t: [] for t in ["receiver", "processor", "exporter", "connector", "extension"]},
+        }
+        inventories = {
+            ("core", Version("0.151.0")): core_latest,
+            ("contrib", Version("0.151.0")): contrib_latest,
+            ("core", Version("0.150.0")): _make_core_inventory("0.150.0"),
+            ("contrib", Version("0.150.0")): _make_contrib_inventory("0.150.0"),
+        }
+        manager = _make_mock_inventory_manager(inventories=inventories)
+        db_writer = CollectorDatabaseWriter(database_dir=str(tmp_path / "collector"))
+        report_path = tmp_path / "missing.json"
+
+        result = run_collector_builder(
+            inventory_manager=manager, db_writer=db_writer, audit_report_path=str(report_path)
+        )
+
+        assert result == 0
+        with open(report_path) as f:
+            report = json.load(f)
+
+        assert report["ecosystem"] == "collector"
+        assert report["version"] == "0.151.0"
+        assert [c["name"] for c in report["missing"]] == ["mysteryreceiver"]
+
+    def test_report_empty_when_all_have_display_name(self, tmp_path):
+        manager = _make_mock_inventory_manager()  # default fixtures all carry display_name
+        db_writer = CollectorDatabaseWriter(database_dir=str(tmp_path / "collector"))
+        report_path = tmp_path / "missing.json"
+
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer, audit_report_path=str(report_path))
+
+        with open(report_path) as f:
+            report = json.load(f)
+        assert report["missing"] == []
+
+
 class TestRunCollectorBuilderReadmes:
     """Mirrors test_main.py's test_run_builder_processes_readmes for the javaagent builder."""
 

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
@@ -454,6 +454,20 @@ class TestRunCollectorBuilderAuditReport:
             report = json.load(f)
         assert report["missing"] == []
 
+    def test_report_path_inside_database_dir_fails(self, tmp_path):
+        manager = _make_mock_inventory_manager()
+        db_dir = tmp_path / "collector"
+        db_writer = CollectorDatabaseWriter(database_dir=str(db_dir))
+        # A report written inside the DB dir would get committed / bump DB_VERSION.
+        report_path = db_dir / "audit" / "missing.json"
+
+        result = run_collector_builder(
+            inventory_manager=manager, db_writer=db_writer, audit_report_path=str(report_path)
+        )
+
+        assert result == 1
+        assert not report_path.exists()
+
 
 class TestRunCollectorBuilderReadmes:
     """Mirrors test_main.py's test_run_builder_processes_readmes for the javaagent builder."""

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_display_name_audit.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_display_name_audit.py
@@ -1,0 +1,108 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for collector_display_name_audit module."""
+
+import json
+
+from explorer_db_builder.collector_display_name_audit import (
+    find_missing_display_names,
+    write_missing_display_name_report,
+)
+
+
+def _component(name, display_name="present", distribution="contrib", component_type="receiver"):
+    return {
+        "id": f"{distribution}-{name}",
+        "ecosystem": "collector",
+        "distribution": distribution,
+        "type": component_type,
+        "name": name,
+        "display_name": display_name,
+    }
+
+
+class TestFindMissingDisplayNames:
+    def test_none_display_name_is_missing(self):
+        result = find_missing_display_names([_component("nopreceiver", display_name=None)])
+        assert result == [
+            {"id": "contrib-nopreceiver", "distribution": "contrib", "type": "receiver", "name": "nopreceiver"}
+        ]
+
+    def test_missing_key_is_missing(self):
+        component = _component("nopreceiver")
+        del component["display_name"]
+        result = find_missing_display_names([component])
+        assert [c["name"] for c in result] == ["nopreceiver"]
+
+    def test_empty_string_is_missing(self):
+        result = find_missing_display_names([_component("nopreceiver", display_name="")])
+        assert [c["name"] for c in result] == ["nopreceiver"]
+
+    def test_whitespace_only_is_missing(self):
+        result = find_missing_display_names([_component("nopreceiver", display_name="   ")])
+        assert [c["name"] for c in result] == ["nopreceiver"]
+
+    def test_present_display_name_is_not_missing(self):
+        result = find_missing_display_names([_component("otlpreceiver", display_name="OTLP Receiver")])
+        assert result == []
+
+    def test_only_missing_are_returned(self):
+        components = [
+            _component("otlpreceiver", display_name="OTLP Receiver"),
+            _component("nopreceiver", display_name=None),
+            _component("badexporter", display_name="", component_type="exporter"),
+        ]
+        result = find_missing_display_names(components)
+        assert {c["name"] for c in result} == {"nopreceiver", "badexporter"}
+
+    def test_sorted_by_id(self):
+        components = [
+            _component("zeta", display_name=None, distribution="core"),
+            _component("alpha", display_name=None, distribution="core"),
+            _component("mu", display_name=None, distribution="contrib"),
+        ]
+        result = find_missing_display_names(components)
+        assert [c["id"] for c in result] == ["contrib-mu", "core-alpha", "core-zeta"]
+
+    def test_slim_shape_only(self):
+        result = find_missing_display_names([_component("nopreceiver", display_name=None)])
+        assert set(result[0].keys()) == {"id", "distribution", "type", "name"}
+
+
+class TestWriteMissingDisplayNameReport:
+    def test_round_trips(self, tmp_path):
+        missing = [{"id": "contrib-nopreceiver", "distribution": "contrib", "type": "receiver", "name": "nopreceiver"}]
+        path = tmp_path / "report.json"
+
+        write_missing_display_name_report(str(path), "0.151.0", missing)
+
+        with open(path) as f:
+            data = json.load(f)
+        assert data == {"ecosystem": "collector", "version": "0.151.0", "missing": missing}
+
+    def test_empty_missing_list(self, tmp_path):
+        path = tmp_path / "report.json"
+
+        write_missing_display_name_report(str(path), "0.151.0", [])
+
+        with open(path) as f:
+            data = json.load(f)
+        assert data["missing"] == []
+        assert data["version"] == "0.151.0"
+
+    def test_ends_with_newline(self, tmp_path):
+        path = tmp_path / "report.json"
+        write_missing_display_name_report(str(path), "0.151.0", [])
+        assert path.read_text(encoding="utf-8").endswith("\n")

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_display_name_audit.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_display_name_audit.py
@@ -80,6 +80,18 @@ class TestFindMissingDisplayNames:
         result = find_missing_display_names([_component("nopreceiver", display_name=None)])
         assert set(result[0].keys()) == {"id", "distribution", "type", "name"}
 
+    def test_ignores_experimental_core_placeholders(self):
+        components = [
+            _component("xconnector", display_name=None, distribution="core", component_type="connector"),
+            _component("xexporter", display_name=None, distribution="core", component_type="exporter"),
+            _component("xextension", display_name=None, distribution="core", component_type="extension"),
+            _component("xprocessor", display_name=None, distribution="core", component_type="processor"),
+            _component("xreceiver", display_name=None, distribution="core", component_type="receiver"),
+            _component("realreceiver", display_name=None, distribution="core"),
+        ]
+        result = find_missing_display_names(components)
+        assert [c["name"] for c in result] == ["realreceiver"]
+
 
 class TestWriteMissingDisplayNameReport:
     def test_round_trips(self, tmp_path):

--- a/ecosystem-automation/explorer-db-builder/tests/test_main.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_main.py
@@ -464,12 +464,13 @@ class TestMain:
         mock_args = MagicMock()
         mock_args.clean = False
         mock_args.ecosystem = "all"
+        mock_args.collector_audit_report = None
         mock_parse_args.return_value = mock_args
         mock_run_builder.return_value = 0
 
         main()
 
-        mock_run_builder.assert_called_once_with(clean=False, ecosystem="all")
+        mock_run_builder.assert_called_once_with(clean=False, ecosystem="all", collector_audit_report=None)
         mock_exit.assert_called_once_with(0)
 
     @patch("explorer_db_builder.main.run_builder")
@@ -481,12 +482,13 @@ class TestMain:
         mock_args = MagicMock()
         mock_args.clean = False
         mock_args.ecosystem = "all"
+        mock_args.collector_audit_report = None
         mock_parse_args.return_value = mock_args
         mock_run_builder.return_value = 1
 
         main()
 
-        mock_run_builder.assert_called_once_with(clean=False, ecosystem="all")
+        mock_run_builder.assert_called_once_with(clean=False, ecosystem="all", collector_audit_report=None)
         mock_exit.assert_called_once_with(1)
 
     @patch("explorer_db_builder.main.run_builder")
@@ -498,12 +500,13 @@ class TestMain:
         mock_args = MagicMock()
         mock_args.clean = True
         mock_args.ecosystem = "all"
+        mock_args.collector_audit_report = None
         mock_parse_args.return_value = mock_args
         mock_run_builder.return_value = 0
 
         main()
 
-        mock_run_builder.assert_called_once_with(clean=True, ecosystem="all")
+        mock_run_builder.assert_called_once_with(clean=True, ecosystem="all", collector_audit_report=None)
         mock_exit.assert_called_once_with(0)
 
     @patch("explorer_db_builder.main.run_builder")
@@ -516,12 +519,13 @@ class TestMain:
         mock_args = MagicMock()
         mock_args.clean = False
         mock_args.ecosystem = "collector"
+        mock_args.collector_audit_report = None
         mock_parse_args.return_value = mock_args
         mock_run_builder.return_value = 0
 
         main()
 
-        mock_run_builder.assert_called_once_with(clean=False, ecosystem="collector")
+        mock_run_builder.assert_called_once_with(clean=False, ecosystem="collector", collector_audit_report=None)
         mock_exit.assert_called_once_with(0)
 
 
@@ -592,7 +596,7 @@ class TestRunBuilderOrchestrator:
 
         mock_java.assert_called_once_with(clean=True)
         mock_config.assert_called_once_with(clean=True)
-        mock_collector.assert_called_once_with(clean=True)
+        mock_collector.assert_called_once_with(clean=True, audit_report_path=None)
 
     @patch("explorer_db_builder.main.run_collector_builder")
     @patch("explorer_db_builder.main.run_configuration_builder")
@@ -632,3 +636,13 @@ class TestRunBuilderOrchestrator:
         mock_java.assert_not_called()
         mock_config.assert_not_called()
         mock_collector.assert_called_once()
+
+    @patch("explorer_db_builder.main.run_collector_builder")
+    @patch("explorer_db_builder.main.run_configuration_builder")
+    @patch("explorer_db_builder.main.run_javaagent_builder")
+    def test_collector_audit_report_passed_to_collector(self, mock_java, mock_config, mock_collector):
+        mock_collector.return_value = 0
+
+        run_builder(clean=False, ecosystem="collector", collector_audit_report="audit/report.json")
+
+        mock_collector.assert_called_once_with(clean=False, audit_report_path="audit/report.json")


### PR DESCRIPTION
This will alert us when we need to fix things upstream.

Tested on my fork and generated: https://github.com/jaydeluca/opentelemetry-ecosystem-explorer/issues/44

<img width="947" height="757" alt="image" src="https://github.com/user-attachments/assets/ea51cf75-702d-4d36-8e75-40e1150280c6" />
