### PR TITLE
Add Stability Level and Telemetry Signal filters to the Collector Components page

### DIFF
--- a/ecosystem-explorer/public/locales/en/collector.json
+++ b/ecosystem-explorer/public/locales/en/collector.json
@@ -121,6 +121,19 @@
       "all": "All Distributions",
       "core": "Core",
       "contrib": "Contrib"
+    },
+    "stability": {
+      "label": "Stability",
+      "all": "All",
+      "stable": "Stable",
+      "beta": "Beta",
+      "alpha": "Alpha",
+      "development": "Development",
+      "deprecated": "Deprecated",
+      "unmaintained": "Unmaintained"
+    },
+    "signal": {
+      "label": "Telemetry"
     }
   },
   "results": {

--- a/ecosystem-explorer/public/locales/es/collector.json
+++ b/ecosystem-explorer/public/locales/es/collector.json
@@ -121,6 +121,19 @@
       "all": "Todas las distribuciones",
       "core": "Core",
       "contrib": "Contrib"
+    },
+    "stability": {
+      "label": "Estabilidad",
+      "all": "Todos",
+      "stable": "Estable",
+      "beta": "Beta",
+      "alpha": "Alfa",
+      "development": "En desarrollo",
+      "deprecated": "Obsoleto",
+      "unmaintained": "Sin mantenimiento"
+    },
+    "signal": {
+      "label": "Telemetría"
     }
   },
   "results": {

--- a/ecosystem-explorer/src/features/collector/collector-components-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.test.tsx
@@ -20,40 +20,43 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CollectorComponentsPage } from "./collector-components-page";
 import { useCollectorComponents, useCollectorVersions } from "@/hooks/use-collector-data";
-import type { CollectorComponent } from "@/types/collector";
+import type { IndexComponent } from "@/types/collector";
 
 vi.mock("@/hooks/use-collector-data", () => ({
   useCollectorComponents: vi.fn(),
   useCollectorVersions: vi.fn(),
 }));
 
-const mockComponents: CollectorComponent[] = [
+const mockComponents: IndexComponent[] = [
   {
     id: "core-otlpreceiver",
     name: "otlpreceiver",
-    ecosystem: "collector",
     type: "receiver",
     distribution: "core",
     display_name: "OTLP Receiver",
     description: "Receives OTLP telemetry.",
+    stability: "stable",
+    signals: ["traces"],
   },
   {
     id: "contrib-prometheusreceiver",
     name: "prometheusreceiver",
-    ecosystem: "collector",
     type: "receiver",
     distribution: "contrib",
     display_name: "Prometheus Receiver",
     description: "Receives Prometheus metrics.",
+    stability: "beta",
+    signals: ["metrics"],
   },
   {
     id: "core-batchprocessor",
     name: "batchprocessor",
-    ecosystem: "collector",
     type: "processor",
     distribution: "core",
     display_name: "Batch Processor",
     description: "Batches telemetry.",
+    stability: "alpha",
+    signals: ["logs"],
   },
 ];
 
@@ -139,6 +142,107 @@ describe("CollectorComponentsPage", () => {
     );
   });
 
+  it("applies stability query filter", () => {
+    renderPage("/collector/components?stability=beta");
+
+    expect(screen.getByRole("combobox", { name: "Stability" })).toHaveValue("beta");
+    expect(screen.getByText("Prometheus Receiver")).toBeInTheDocument();
+    expect(screen.queryByText("OTLP Receiver")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batch Processor")).not.toBeInTheDocument();
+  });
+
+  it("applies signal query filter (single signal)", () => {
+    renderPage("/collector/components?signal=metrics");
+
+    expect(screen.getByRole("button", { name: "Metrics" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("Prometheus Receiver")).toBeInTheDocument();
+    expect(screen.queryByText("OTLP Receiver")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batch Processor")).not.toBeInTheDocument();
+  });
+
+  it("applies signal query filter (AND across multiple signals)", () => {
+    // AND semantics, matching Java Agent: only a component supporting ALL selected signals
+    // matches. Local mock so a dual-signal component exists to make this observable.
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: [
+        {
+          id: "core-otlpreceiver",
+          name: "otlpreceiver",
+          type: "receiver",
+          distribution: "core",
+          display_name: "OTLP Receiver",
+          description: "Receives OTLP telemetry.",
+          signals: ["metrics", "traces"],
+        },
+        {
+          id: "contrib-prometheusreceiver",
+          name: "prometheusreceiver",
+          type: "receiver",
+          distribution: "contrib",
+          display_name: "Prometheus Receiver",
+          description: "Receives Prometheus metrics.",
+          signals: ["metrics"],
+        },
+        {
+          id: "core-batchprocessor",
+          name: "batchprocessor",
+          type: "processor",
+          distribution: "core",
+          display_name: "Batch Processor",
+          description: "Batches telemetry.",
+          signals: ["logs"],
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    renderPage("/collector/components?signal=metrics&signal=traces");
+
+    expect(screen.getByText("OTLP Receiver")).toBeInTheDocument();
+    expect(screen.queryByText("Prometheus Receiver")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batch Processor")).not.toBeInTheDocument();
+  });
+
+  it("combines search, type, distribution, stability, and signal filters", () => {
+    renderPage(
+      "/collector/components?search=prometheus&type=receiver&distribution=contrib&stability=beta&signal=metrics"
+    );
+
+    expect(screen.getByText("Prometheus Receiver")).toBeInTheDocument();
+    expect(screen.queryByText("OTLP Receiver")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batch Processor")).not.toBeInTheDocument();
+  });
+
+  it("toggling a signal button updates aria-pressed and the URL", async () => {
+    const user = userEvent.setup();
+    renderPage("/collector/components");
+
+    const metricsButton = screen.getByRole("button", { name: "Metrics" });
+    expect(metricsButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(metricsButton);
+
+    expect(metricsButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/collector/components?signal=metrics"
+    );
+  });
+
+  it("clear all resets stability and signal filters too", async () => {
+    const user = userEvent.setup();
+    renderPage("/collector/components?type=receiver&stability=stable&signal=logs");
+
+    expect(screen.getByText("No components found")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear all filters" }));
+
+    expect(screen.getByTestId("location")).toHaveTextContent("/collector/components");
+    expect(screen.getByText("OTLP Receiver")).toBeInTheDocument();
+    expect(screen.getByText("Prometheus Receiver")).toBeInTheDocument();
+    expect(screen.getByText("Batch Processor")).toBeInTheDocument();
+  });
+
   describe("signal badges", () => {
     it("renders a Metrics badge for a component that only supports metrics", () => {
       vi.mocked(useCollectorComponents).mockReturnValue({
@@ -160,10 +264,12 @@ describe("CollectorComponentsPage", () => {
 
       renderPage();
 
-      expect(screen.getByText("Metrics")).toBeInTheDocument();
-      expect(screen.queryByText("Traces")).not.toBeInTheDocument();
-      expect(screen.queryByText("Logs")).not.toBeInTheDocument();
-      expect(screen.queryByText("Profiles")).not.toBeInTheDocument();
+      // Scoped to the badge <span> — the signal filter row now renders a <button> with the
+      // same label text for every signal, regardless of this component's data.
+      expect(screen.getByText("Metrics", { selector: "span" })).toBeInTheDocument();
+      expect(screen.queryByText("Traces", { selector: "span" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Logs", { selector: "span" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Profiles", { selector: "span" })).not.toBeInTheDocument();
     });
 
     it("renders one badge per signal, in canonical order, for a multi-signal component", () => {
@@ -185,10 +291,10 @@ describe("CollectorComponentsPage", () => {
 
       renderPage();
 
-      expect(screen.getByText("Metrics")).toBeInTheDocument();
-      expect(screen.getByText("Traces")).toBeInTheDocument();
-      expect(screen.getByText("Logs")).toBeInTheDocument();
-      expect(screen.queryByText("Profiles")).not.toBeInTheDocument();
+      expect(screen.getByText("Metrics", { selector: "span" })).toBeInTheDocument();
+      expect(screen.getByText("Traces", { selector: "span" })).toBeInTheDocument();
+      expect(screen.getByText("Logs", { selector: "span" })).toBeInTheDocument();
+      expect(screen.queryByText("Profiles", { selector: "span" })).not.toBeInTheDocument();
     });
 
     it("renders no signal badges when signals is missing or empty", () => {
@@ -209,10 +315,10 @@ describe("CollectorComponentsPage", () => {
 
       renderPage();
 
-      expect(screen.queryByText("Metrics")).not.toBeInTheDocument();
-      expect(screen.queryByText("Traces")).not.toBeInTheDocument();
-      expect(screen.queryByText("Logs")).not.toBeInTheDocument();
-      expect(screen.queryByText("Profiles")).not.toBeInTheDocument();
+      expect(screen.queryByText("Metrics", { selector: "span" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Traces", { selector: "span" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Logs", { selector: "span" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Profiles", { selector: "span" })).not.toBeInTheDocument();
     });
   });
 });

--- a/ecosystem-explorer/src/features/collector/collector-components-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.tsx
@@ -36,8 +36,9 @@ import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SignalBadge } from "@/components/ui/signal-badge";
 import { useCollectorVersions, useCollectorComponents } from "@/hooks/use-collector-data";
-import { getPresentSignals } from "./utils/signal-badge-info";
-import { SIGNAL_STYLES } from "./styles/signal-styles";
+import { getPresentSignals, SIGNAL_ORDER, type CollectorSignal } from "./utils/signal-badge-info";
+import { SIGNAL_STYLES, getSignalFilterClasses } from "./styles/signal-styles";
+import type { Stability } from "@/types/collector";
 
 type ComponentTypeFilter =
   | "all"
@@ -47,6 +48,17 @@ type ComponentTypeFilter =
   | "extension"
   | "connector";
 type DistributionFilter = "all" | "core" | "contrib";
+type StabilityFilter = Stability | "all";
+
+// Ranked most-to-least stable, matching the detail page's stability legend ordering.
+const STABILITY_OPTIONS: Stability[] = [
+  "stable",
+  "beta",
+  "alpha",
+  "development",
+  "deprecated",
+  "unmaintained",
+];
 
 function getTypeFilter(value: string | null): ComponentTypeFilter {
   switch (value) {
@@ -69,6 +81,25 @@ function getDistributionFilter(value: string | null): DistributionFilter {
     default:
       return "all";
   }
+}
+
+function getStabilityFilter(value: string | null): StabilityFilter {
+  switch (value) {
+    case "alpha":
+    case "beta":
+    case "stable":
+    case "deprecated":
+    case "unmaintained":
+    case "development":
+      return value;
+    default:
+      return "all";
+  }
+}
+
+function getSignalFilter(values: string[]): Set<CollectorSignal> {
+  const known: readonly string[] = SIGNAL_ORDER;
+  return new Set(values.filter((v): v is CollectorSignal => known.includes(v)));
 }
 
 const getIcon = (type: string) => {
@@ -94,6 +125,8 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const typeQuery = searchParams.get("type");
   const distributionQuery = searchParams.get("distribution");
+  const stabilityQuery = searchParams.get("stability");
+  const signalsParam = searchParams.getAll("signal").join(",");
   const urlSearch = searchParams.get("search") ?? "";
   const [searchQuery, setSearchQuery] = useState(urlSearch);
 
@@ -108,6 +141,13 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
   const distributionFilter = useMemo(
     () => getDistributionFilter(distributionQuery),
     [distributionQuery]
+  );
+
+  const stabilityFilter = useMemo(() => getStabilityFilter(stabilityQuery), [stabilityQuery]);
+
+  const signalFilter = useMemo(
+    () => getSignalFilter(signalsParam ? signalsParam.split(",") : []),
+    [signalsParam]
   );
 
   const {
@@ -138,9 +178,18 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
       const matchesType = typeFilter === "all" || comp.type === typeFilter;
       const matchesDistribution =
         distributionFilter === "all" || comp.distribution === distributionFilter;
-      return matchesSearch && matchesType && matchesDistribution;
+      const matchesStability = stabilityFilter === "all" || comp.stability === stabilityFilter;
+      // AND semantics, matching the Java Agent telemetry filter: a component matches only if it
+      // supports every currently-selected signal.
+      const presentSignals = getPresentSignals(comp);
+      const matchesSignal =
+        signalFilter.size === 0 ||
+        Array.from(signalFilter).every((s) => presentSignals.includes(s));
+      return (
+        matchesSearch && matchesType && matchesDistribution && matchesStability && matchesSignal
+      );
     });
-  }, [components, distributionFilter, searchQuery, typeFilter]);
+  }, [components, distributionFilter, searchQuery, typeFilter, stabilityFilter, signalFilter]);
 
   const handleVersionChange = (val: string) => {
     const currentSearch = searchParams.toString();
@@ -176,6 +225,33 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
       params.delete("distribution");
     } else {
       params.set("distribution", newDistribution);
+    }
+    setSearchParams(params);
+  };
+
+  const handleStabilityFilterChange = (newStability: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (newStability === "all") {
+      params.delete("stability");
+    } else {
+      params.set("stability", newStability);
+    }
+    setSearchParams(params);
+  };
+
+  const handleSignalFilterToggle = (signal: CollectorSignal) => {
+    const params = new URLSearchParams(searchParams);
+    const current = getSignalFilter(params.getAll("signal"));
+    if (current.has(signal)) {
+      current.delete(signal);
+    } else {
+      current.add(signal);
+    }
+    params.delete("signal");
+    for (const s of SIGNAL_ORDER) {
+      if (current.has(s)) {
+        params.append("signal", s);
+      }
     }
     setSearchParams(params);
   };
@@ -250,6 +326,34 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
             </div>
 
             <div className="space-y-2">
+              <label
+                htmlFor="stability-filter"
+                className="text-muted-foreground text-sm font-medium"
+              >
+                {t("filters.stability.label")}
+              </label>
+              <div className="relative">
+                <select
+                  id="stability-filter"
+                  value={stabilityFilter}
+                  onChange={(e) => handleStabilityFilterChange(e.target.value)}
+                  className="border-border/60 bg-background/80 focus:border-primary/50 focus:ring-primary/20 w-[160px] cursor-pointer appearance-none rounded-lg border py-2.5 pr-10 pl-3 text-sm font-medium backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
+                >
+                  <option value="all">{t("filters.stability.all")}</option>
+                  {STABILITY_OPTIONS.map((level) => (
+                    <option key={level} value={level}>
+                      {t(`filters.stability.${level}`)}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
+                  aria-hidden="true"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
               <label htmlFor="version-select" className="text-muted-foreground text-sm font-medium">
                 {t("filters.version.label")}
               </label>
@@ -298,6 +402,28 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                 />
               </div>
             </div>
+          </div>
+        </div>
+
+        <div className="relative z-10 mt-6 space-y-3">
+          <div className="text-muted-foreground text-sm font-medium">
+            {t("filters.signal.label")}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {SIGNAL_ORDER.map((signal) => (
+              <button
+                key={signal}
+                type="button"
+                onClick={() => handleSignalFilterToggle(signal)}
+                aria-pressed={signalFilter.has(signal)}
+                className={`rounded-lg border-2 px-4 py-2 text-sm font-medium transition-all duration-200 ${getSignalFilterClasses(
+                  signal,
+                  signalFilter.has(signal)
+                )}`}
+              >
+                {t(`card.badges.${signal}.label`)}
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/ecosystem-explorer/src/features/collector/styles/signal-styles.ts
+++ b/ecosystem-explorer/src/features/collector/styles/signal-styles.ts
@@ -49,3 +49,9 @@ export const SIGNAL_STYLES: Record<CollectorSignal, SignalBadgeStyles> = {
       "bg-pink-500/5 border-pink-500/20 text-pink-700 dark:text-pink-400/70 hover:border-pink-500/50 hover:bg-pink-500/10",
   },
 };
+
+/** Mirrors Java Agent's `getTelemetryFilterClasses` for the Collector signal filter buttons. */
+export function getSignalFilterClasses(signal: CollectorSignal, isActive: boolean): string {
+  const styles = SIGNAL_STYLES[signal];
+  return isActive ? styles.active : styles.inactive;
+}

--- a/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
+++ b/projects/ux-research-and-info-arc/user-interview-discussion-guide.md
@@ -54,12 +54,10 @@ Follow-up prompts:
 1. How do you decide whether a component is the right fit for your situation?
 
    Follow-up:
-
    - What information tells you, "Yes, this is what I need"?
 
 2. Can you think of a time when you couldn't get enough information to feel confident moving
    forward?
-
    - What did you do?
 
 ---
@@ -81,7 +79,6 @@ to act on, whereas "show what telemetry signals I'll get before I install" is mu
    Cursor) when working with OpenTelemetry?
 
 2. If yes:
-
    - When do you prefer AI over the official documentation?
    - What has your experience been like? (Accurate, frustrating, hit-or-miss?)
    - Has an AI tool ever given you incorrect information about OpenTelemetry? What happened?


### PR DESCRIPTION
## Summary

This PR enhances the **Collector Components** page by introducing two new filtering capabilities:

- **Stability Level** filtering
- **Telemetry Signal** filtering

These integrate with the existing filtering system (Search, Type, Version, Distribution), support URL synchronization, and are fully covered by tests...

---

## What's Added

### Stability Level Filter

Adds a new **Stability** dropdown allowing users to filter Collector components by their stability level!

Supported values:

- All
- Stable
- Beta
- Alpha
- Development
- Deprecated
- Unmaintained

The filter integrates with the existing URL search parameters and works alongside all other filters!

---

### Telemetry Signal Filter

Adds a new **Telemetry** filter allowing components to be filtered by supported telemetry signals..!

Supported signals:

- Metrics
- Traces
- Logs
- Profiles

Multiple signals can be selected simultaneously..

The filtering behavior matches the Java Agent page by requiring components to support **all selected signals (AND semantics)** when multiple telemetry signals are chosen!

---

## Implementation Details

- Added Stability dropdown to the Collector Components filter bar
- Added Telemetry signal toggle buttons
- Integrated both filters into the existing filtering pipeline
- Added URL synchronization for both filters
- Added validation/parsing helpers for Stability and Signal query parameters
- Reused the existing signal styling to keep the UI consistent
- Updated English and Spanish translations
- Added comprehensive test coverage for:
  - Stability filtering
  - Signal filtering
  - Combined filtering
  - URL synchronization
  - Clear filters behavior

---

## Screenshots

### Collector Components Filters

> Added Stability Level dropdown and Telemetry Signal filters.

<img width="1865" height="1003" alt="Screenshot 2026-07-16 at 1 27 53 PM" src="https://github.com/user-attachments/assets/a82a8902-6441-48b8-b447-15527112e2c6" />

---

Closes #816