### PR TITLE
docs: add Collector upstream metadata contributor guide

### DIFF
--- a/.github/workflows/build-explorer-database.yml
+++ b/.github/workflows/build-explorer-database.yml
@@ -189,13 +189,14 @@ jobs:
 
           if [ -n "$EXISTING" ]; then
             # Edit the body rather than comment: this runs nightly and comments would be noisy.
-            gh issue edit "$EXISTING" --body-file "$BODY_FILE"
+            gh issue edit "$EXISTING" --body-file "$BODY_FILE" --add-label "contribution welcome"
             echo "Updated tracking issue #$EXISTING ($COUNT components missing display_name)."
           else
             gh issue create \
               --title "$ISSUE_TITLE" \
               --body-file "$BODY_FILE" \
-              --label "$LABEL"
+              --label "$LABEL" \
+              --label "contribution welcome"
             echo "Created tracking issue ($COUNT components missing display_name)."
           fi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ additional information.
   crawlers and non-JS AI agents
 - [Agent Readiness](./AGENT_READINESS.md) - `llms.txt`, JSON schemas, and structured metadata for AI
   agents
+- [Upstream Metadata](./upstream-metadata.md) - How component metadata is managed upstream and how to
+  fix `upstream-metadata` issues
 
 **Deployment**: The web app deploys automatically to production when changes merge to `main`.
 Registry updates run nightly via GitHub Actions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,8 @@ additional information.
   crawlers and non-JS AI agents
 - [Agent Readiness](./AGENT_READINESS.md) - `llms.txt`, JSON schemas, and structured metadata for AI
   agents
-- [Upstream Metadata](./upstream-metadata.md) - How component metadata is managed upstream and how to
-  fix `upstream-metadata` issues
+- [Upstream Metadata](./upstream-metadata.md) - How component metadata is managed upstream and how
+  to fix `upstream-metadata` issues
 
 **Deployment**: The web app deploys automatically to production when changes merge to `main`.
 Registry updates run nightly via GitHub Actions.

--- a/docs/upstream-metadata.md
+++ b/docs/upstream-metadata.md
@@ -1,0 +1,62 @@
+# Upstream Metadata
+
+Some of the information the Ecosystem Explorer shows about a component is not stored in this
+repository — it comes from **metadata that lives in the component's own upstream project**. When that
+upstream metadata is missing or incomplete, the Explorer has nothing better to show, so it falls back
+to a less friendly value (for example, a raw component identifier instead of a readable name).
+
+This page explains where that metadata comes from and gives a short runbook for fixing it upstream.
+It is the reference material behind the automatically generated `upstream-metadata` tracking issues.
+
+## Working an `upstream-metadata` issue
+
+The Explorer opens and maintains tracking issues labeled `upstream-metadata` (and
+`contribution welcome`) when it detects metadata gaps. These issues are a good first contribution:
+
+- They are updated automatically every night and **close on their own** once the gap is filled
+  upstream — you do not need to touch this repository.
+- Each issue lists the affected components and points at the upstream repository where the fix
+  belongs.
+
+The fix always happens in the upstream project, not here. Find the relevant ecosystem below and
+follow its runbook.
+
+## Collector
+
+Collector component names and descriptions come from a `metadata.yaml` file that lives next to each
+component's source code, in one of two upstream repositories:
+
+- **Core** components — [`open-telemetry/opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-collector)
+- **Contrib** components — [`open-telemetry/opentelemetry-collector-contrib`](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Each component sits in a directory grouped by type (`receiver/`, `processor/`, `exporter/`,
+`extension/`, `connector/`), and the file you care about is that directory's `metadata.yaml` — for
+example `processor/transformprocessor/metadata.yaml`. The Explorer reads two optional top-level
+fields from it:
+
+- `display_name` — the human-readable name shown as the component's title. When it is absent, the
+  Explorer shows the raw component identifier instead.
+- `description` — a short summary shown on the component. When it is absent, a generic placeholder is
+  shown.
+
+### Runbook: add a missing `display_name` (or `description`)
+
+1. Open the tracking issue and note which component is missing metadata and whether it is a **core**
+   or **contrib** component.
+2. In the matching upstream repository, find the component's directory and open its `metadata.yaml`.
+3. Add the missing field at the top level of the file. For example:
+
+   ```yaml
+   type: transform
+   display_name: Transform Processor
+   description: Modifies telemetry based on configuration using OTTL.
+   ```
+
+4. Check the component's code owners so you know who will review the change — they are listed under
+   `status.codeowners.active` in the same `metadata.yaml`.
+5. Open a pull request against the upstream repository, following that repository's `CONTRIBUTING`
+   guide. Reference the Ecosystem Explorer tracking issue in your PR description so the context is
+   clear.
+6. Once your change is merged upstream, no further action is needed here. The Explorer's nightly
+   build picks up the new metadata, and the tracking issue closes automatically once every listed
+   component has a `display_name`.

--- a/docs/upstream-metadata.md
+++ b/docs/upstream-metadata.md
@@ -1,10 +1,9 @@
 # Upstream Metadata
 
-Some of the information the Ecosystem Explorer shows about a component is not stored in this
-repository — it comes from **metadata that lives in the component's own upstream project**. When
-that upstream metadata is missing or incomplete, the Explorer has nothing better to show, so it
-falls back to a less friendly value (for example, a raw component identifier instead of a readable
-name).
+Most of the data that powers the explorer is sourced from **metadata that lives in the component's
+own upstream project** (pulled in via ecosystem-automation "watchers". When that upstream metadata
+is missing or incomplete, the Explorer has nothing better to show, so it falls back to a less
+friendly value (for example, a raw component identifier instead of a readable name).
 
 This page explains where that metadata comes from and gives a short runbook for fixing it upstream.
 It is the reference material behind the automatically generated `upstream-metadata` tracking issues.
@@ -35,8 +34,9 @@ component's source code, in one of two upstream repositories:
 
 Each component sits in a directory grouped by type (`receiver/`, `processor/`, `exporter/`,
 `extension/`, `connector/`), and the file you care about is that directory's `metadata.yaml` — for
-example `processor/transformprocessor/metadata.yaml`. The Explorer reads two optional top-level
-fields from it:
+example `processor/transformprocessor/metadata.yaml`. There are two fields that are especially
+important for the Explorer, but are not required in the collector metadata tooling, and therefore we
+like to track and make an effort to contribute fixes upstream:
 
 - `display_name` — the human-readable name shown as the component's title. When it is absent, the
   Explorer shows the raw component identifier instead.
@@ -56,11 +56,9 @@ fields from it:
    description: Modifies telemetry based on configuration using OTTL.
    ```
 
-4. Check the component's code owners so you know who will review the change — they are listed under
-   `status.codeowners.active` in the same `metadata.yaml`.
-5. Open a pull request against the upstream repository, following that repository's `CONTRIBUTING`
+4. Open a pull request against the upstream repository, following that repository's `CONTRIBUTING`
    guide. Reference the Ecosystem Explorer tracking issue in your PR description so the context is
    clear.
-6. Once your change is merged upstream, no further action is needed here. The Explorer's nightly
+5. Once your change is merged upstream, no further action is needed here. The Explorer's nightly
    build picks up the new metadata, and the tracking issue closes automatically once every listed
    component has a `display_name`.

--- a/docs/upstream-metadata.md
+++ b/docs/upstream-metadata.md
@@ -1,9 +1,10 @@
 # Upstream Metadata
 
 Some of the information the Ecosystem Explorer shows about a component is not stored in this
-repository — it comes from **metadata that lives in the component's own upstream project**. When that
-upstream metadata is missing or incomplete, the Explorer has nothing better to show, so it falls back
-to a less friendly value (for example, a raw component identifier instead of a readable name).
+repository — it comes from **metadata that lives in the component's own upstream project**. When
+that upstream metadata is missing or incomplete, the Explorer has nothing better to show, so it
+falls back to a less friendly value (for example, a raw component identifier instead of a readable
+name).
 
 This page explains where that metadata comes from and gives a short runbook for fixing it upstream.
 It is the reference material behind the automatically generated `upstream-metadata` tracking issues.
@@ -11,10 +12,11 @@ It is the reference material behind the automatically generated `upstream-metada
 ## Working an `upstream-metadata` issue
 
 The Explorer opens and maintains tracking issues labeled `upstream-metadata` (and
-`contribution welcome`) when it detects metadata gaps. These issues are a good first contribution:
+`contribution welcome`) when it detects upstream metadata gaps (currently: Collector components
+missing a `display_name`). These issues are a good first contribution:
 
-- They are updated automatically every night and **close on their own** once the gap is filled
-  upstream — you do not need to touch this repository.
+- They are updated automatically every night and **close on their own** once the tracked gap is
+  filled upstream — you do not need to touch this repository.
 - Each issue lists the affected components and points at the upstream repository where the fix
   belongs.
 
@@ -26,8 +28,10 @@ follow its runbook.
 Collector component names and descriptions come from a `metadata.yaml` file that lives next to each
 component's source code, in one of two upstream repositories:
 
-- **Core** components — [`open-telemetry/opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-collector)
-- **Contrib** components — [`open-telemetry/opentelemetry-collector-contrib`](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+- **Core** components —
+  [`open-telemetry/opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-collector)
+- **Contrib** components —
+  [`open-telemetry/opentelemetry-collector-contrib`](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Each component sits in a directory grouped by type (`receiver/`, `processor/`, `exporter/`,
 `extension/`, `connector/`), and the file you care about is that directory's `metadata.yaml` — for
@@ -36,8 +40,8 @@ fields from it:
 
 - `display_name` — the human-readable name shown as the component's title. When it is absent, the
   Explorer shows the raw component identifier instead.
-- `description` — a short summary shown on the component. When it is absent, a generic placeholder is
-  shown.
+- `description` — a short summary shown on the component. When it is absent, a generic placeholder
+  is shown.
 
 ### Runbook: add a missing `display_name` (or `description`)
 


### PR DESCRIPTION
## Summary

Closes #825

This PR adds contributor documentation explaining how upstream metadata is managed for Collector components and how contributors can resolve automatically generated `upstream-metadata` tracking issues..!

### Changes

- Add a new contributor guide at `docs/upstream-metadata.md`
  - Explain what upstream metadata is
  - Document the difference between the Collector core and contrib repositories
  - Provide a step-by-step runbook for fixing missing `display_name` and `description` fields
  - Explain how tracking issues are resolved after upstream changes

- Update `docs/README.md`
  - Add the new guide to the documentation index

- Update `.github/workflows/build-explorer-database.yml`
  - Add the existing `contribution welcome` label to automatically generated `upstream-metadata` issues as requested in #825

### Testing

- Verified markdown renders correctly
- Verified documentation links
- Verified the workflow change is limited to adding the additional issue label