### PR TITLE
Update for new java agent file format

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
@@ -254,13 +254,15 @@ def backfill_underdocumented_configs(
 
         # Template = the newest config object per instrumentation that carries this declarative_name.
         template_by_instrumentation: dict[str | None, dict[str, Any]] = {}
-        for _version, inventory in versioned_inventories_newest_first:
+        template_version_by_instrumentation: dict[str | None, Version] = {}
+        for template_version, inventory in versioned_inventories_newest_first:
             for instrumentation_name, config in _iter_configs(inventory):
                 if (
                     config.get("declarative_name") == declarative_name
                     and instrumentation_name not in template_by_instrumentation
                 ):
                     template_by_instrumentation[instrumentation_name] = config
+                    template_version_by_instrumentation[instrumentation_name] = template_version
 
         if not template_by_instrumentation:
             continue
@@ -272,8 +274,12 @@ def backfill_underdocumented_configs(
                 for item in inventory.get(key) or []:
                     if not isinstance(item, dict):
                         continue
-                    template = template_by_instrumentation.get(item.get("name"))
-                    if template is None:
+                    instrumentation_name = item.get("name")
+                    template = template_by_instrumentation.get(instrumentation_name)
+                    template_version = template_version_by_instrumentation.get(instrumentation_name)
+                    if template is None or template_version is None:
+                        continue
+                    if version > template_version:
                         continue
                     configurations = item.get("configurations")
                     if not isinstance(configurations, list):

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Corrects known-bad configuration ``declarative_name`` values from the registry.
+"""Corrects known-bad configuration metadata from the registry.
 
-Also normalizes the structured peer-service-mapping config: it injects the declarative schema and
-forces the system-property ``type`` back to ``map`` (v2.29.0 regressed it to ``structured_list``).
+Three classes of correction live here, all operating on the inline ``configurations`` shape
+(so they must run *after* :func:`instrumentation_transformer.transform_instrumentation_format`
+has resolved catalog/ref formats like 0.6 to inline 0.5):
+
+1. ``declarative_name`` rewrites, plus normalizing the structured peer-service-mapping config
+   (inject the declarative schema, force the system-property ``type`` back to ``map`` —
+   v2.29.0 regressed it to ``structured_list``).
+2. **name fallback** — declarative-only configs (introduced in file_format 0.6) may carry only a
+   ``declarative_name`` and no legacy system-property ``name``. Downstream keys configs on
+   ``name`` (release-comparison diff, global-configurations aggregation, metadata backfill), so a
+   missing ``name`` renders blank / drops the config. We fall back to ``declarative_name``.
+3. **description normalization** — pins a curated set of configs' ``description`` to their newest
+   value across versions, so cosmetic upstream rewordings of shared configs don't surface as
+   spurious per-library changes in the release comparison.
 
 Can be removed after the upstream metadata changes land in a java agent release.
 See:
@@ -23,13 +35,45 @@ See:
 - https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19077
 """
 
+import copy
 import logging
 from typing import Any
+
+from semantic_version import Version
 
 logger = logging.getLogger(__name__)
 
 DECLARATIVE_NAME_CORRECTIONS: dict[str, str] = {
     "java.common.peer_service_mapping": "java.common.service_peer_mapping",
+}
+
+# Configs (keyed by ``declarative_name``) whose ``description`` is normalized to the newest
+# version's value across all versions. These are shared/common configs whose descriptions were
+# reworded upstream (pure prose changes, no semantic change), which otherwise show up as a
+# "changed" config in every library that references them. Pinning to the newest description per
+# (instrumentation, config name) collapses that cross-version noise without picking a single
+# global canonical — a config's description can legitimately differ between libraries.
+DESCRIPTION_NORMALIZATION_DECLARATIVE_NAMES: frozenset[str] = frozenset(
+    {
+        "java.common.http.client.emit_experimental_telemetry/development",
+        "java.common.http.server.emit_experimental_telemetry/development",
+        "java.common.messaging.capture_headers/development",
+        "java.common.db.query_sanitization.enabled",
+    }
+)
+
+# Configs that the agent supported before upstream documented them in the registry metadata.
+# They first appear in a given version but the capability predates it, so the release comparison
+# would otherwise show them as spuriously "added". Back-populate each into earlier versions (of the
+# libraries that carry it in its newest version) so it reads as pre-existing.
+#
+# Keyed by ``declarative_name``; the value is an inclusive version floor (only back-populate down to
+# that version), or ``None`` to treat the config as having always existed. Remove an entry once
+# upstream backfills the config into the historical metadata itself.
+UNDERDOCUMENTED_CONFIG_BACKFILL: dict[str, str | None] = {
+    # url_template_rules was gated behind emit-experimental-telemetry long before it became its own
+    # documented config in 2.29.1.
+    "java.common.http.client.url_template_rules": None,
 }
 
 
@@ -115,4 +159,137 @@ def apply_declarative_name_corrections(inventory: dict[str, Any]) -> dict[str, A
                         },
                     }
 
+                # Name fallback for declarative-only configs (file_format 0.6+): downstream keys
+                # configs on ``name``, so use the declarative_name as the stable identifier when the
+                # legacy system-property name is absent. Done last so it sees the corrected
+                # declarative_name above.
+                if not config.get("name") and current_name:
+                    config["name"] = current_name
+
     return inventory
+
+
+def _iter_configs(inventory: dict[str, Any]):
+    """Yield every configuration dict from an inventory's ``libraries`` and ``custom`` lists,
+    paired with its owning instrumentation name: ``(instrumentation_name, config)``."""
+    for key in ("libraries", "custom"):
+        for item in inventory.get(key) or []:
+            if not isinstance(item, dict):
+                continue
+            instrumentation_name = item.get("name")
+            for config in item.get("configurations") or []:
+                if isinstance(config, dict):
+                    yield instrumentation_name, config
+
+
+def normalize_config_descriptions(inventories_newest_first: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pin whitelisted configs' ``description`` to their newest-version value across all versions.
+
+    For every config whose ``declarative_name`` is in
+    :data:`DESCRIPTION_NORMALIZATION_DECLARATIVE_NAMES`, the description from the newest version in
+    which it appears (with a non-empty description) is applied to that same config
+    ``(instrumentation, name)`` in every version. This removes spurious "changed" entries in the
+    release comparison caused by upstream reworking a shared config's prose.
+
+    Inventories must be newest-first (the same ordering ``build_global_configurations`` expects).
+    The inventory dicts are mutated in place and also returned for convenience.
+
+    Args:
+        inventories_newest_first: Per-version inventories, newest version first.
+
+    Returns:
+        The same list, with normalized config descriptions.
+    """
+    # Pass 1: record the newest non-empty description per (instrumentation, config name).
+    newest_description: dict[tuple[str | None, str | None], str] = {}
+    for inventory in inventories_newest_first:
+        for instrumentation_name, config in _iter_configs(inventory):
+            if config.get("declarative_name") not in DESCRIPTION_NORMALIZATION_DECLARATIVE_NAMES:
+                continue
+            key = (instrumentation_name, config.get("name"))
+            description = config.get("description")
+            if description and key not in newest_description:
+                newest_description[key] = description
+
+    # Pass 2: apply the newest description to every version.
+    for inventory in inventories_newest_first:
+        for instrumentation_name, config in _iter_configs(inventory):
+            if config.get("declarative_name") not in DESCRIPTION_NORMALIZATION_DECLARATIVE_NAMES:
+                continue
+            canonical = newest_description.get((instrumentation_name, config.get("name")))
+            if canonical is not None and config.get("description") != canonical:
+                logger.debug(
+                    "Normalized description for %s/%s to newest-version value",
+                    instrumentation_name,
+                    config.get("name"),
+                )
+                config["description"] = canonical
+
+    return inventories_newest_first
+
+
+def backfill_underdocumented_configs(
+    versioned_inventories_newest_first: list[tuple[Version, dict[str, Any]]],
+) -> list[tuple[Version, dict[str, Any]]]:
+    """Back-populate configs from :data:`UNDERDOCUMENTED_CONFIG_BACKFILL` into earlier versions.
+
+    For each whitelisted ``declarative_name``, the newest occurrence of that config on each
+    instrumentation is used as the template. A deep copy is injected into every earlier version
+    (down to the entry's inclusive floor) of that same instrumentation that does not already carry
+    the config. This keeps a config the agent supported all along from showing as spuriously
+    "added" in the release comparison the moment upstream first documents it.
+
+    The config is only injected into instrumentations that are already present in the older version
+    (never resurrects a library that didn't exist yet). Inventory dicts are mutated in place; the
+    ``(version, inventory)`` list must be newest-version first.
+
+    Args:
+        versioned_inventories_newest_first: ``(version, inventory)`` pairs, newest version first.
+
+    Returns:
+        The same list, with under-documented configs back-populated.
+    """
+    for declarative_name, floor in UNDERDOCUMENTED_CONFIG_BACKFILL.items():
+        floor_version = Version(floor) if floor else None
+
+        # Template = the newest config object per instrumentation that carries this declarative_name.
+        template_by_instrumentation: dict[str | None, dict[str, Any]] = {}
+        for _version, inventory in versioned_inventories_newest_first:
+            for instrumentation_name, config in _iter_configs(inventory):
+                if (
+                    config.get("declarative_name") == declarative_name
+                    and instrumentation_name not in template_by_instrumentation
+                ):
+                    template_by_instrumentation[instrumentation_name] = config
+
+        if not template_by_instrumentation:
+            continue
+
+        for version, inventory in versioned_inventories_newest_first:
+            if floor_version is not None and version < floor_version:
+                continue
+            for key in ("libraries", "custom"):
+                for item in inventory.get(key) or []:
+                    if not isinstance(item, dict):
+                        continue
+                    template = template_by_instrumentation.get(item.get("name"))
+                    if template is None:
+                        continue
+                    configurations = item.get("configurations")
+                    if not isinstance(configurations, list):
+                        configurations = []
+                        item["configurations"] = configurations
+                    already_present = any(
+                        isinstance(c, dict) and c.get("declarative_name") == declarative_name for c in configurations
+                    )
+                    if already_present:
+                        continue
+                    configurations.append(copy.deepcopy(template))
+                    logger.debug(
+                        "Back-populated under-documented config %s into %s @ %s",
+                        declarative_name,
+                        item.get("name"),
+                        version,
+                    )
+
+    return versioned_inventories_newest_first

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/instrumentation_transformer.py
@@ -14,6 +14,7 @@
 #
 """Transforms instrumentation data from different file format versions to a common schema."""
 
+import copy
 import logging
 from typing import Any
 
@@ -40,6 +41,9 @@ def transform_instrumentation_format(inventory_data: dict[str, Any]) -> dict[str
 
     file_format = inventory_data["file_format"]
 
+    if file_format == 0.6:
+        logger.debug("File format 0.6 detected, resolving definition references to 0.5 inline shape")
+        return _transform_0_6_to_0_5(inventory_data)
     if file_format == 0.5:
         logger.debug("File format 0.5 detected, no transformation needed")
         return inventory_data
@@ -177,6 +181,89 @@ def _transform_0_3_to_0_5(inventory_data: dict[str, Any]) -> dict[str, Any]:
     transformed_data = inventory_data.copy()
     transformed_data["file_format"] = 0.5
     logger.info("Transformed inventory from format 0.3 to 0.5")
+    return transformed_data
+
+
+def _resolve_refs(
+    library: dict[str, Any],
+    configuration_defs: dict[str, Any],
+    metric_defs: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve a single library's ``*_refs`` into the inline 0.5 shape.
+
+    ``configuration_refs`` becomes an inline ``configurations`` list and each
+    telemetry entry's ``metric_refs`` becomes an inline ``metrics`` list, looked
+    up in the top-level definitions catalog. Definitions are deep-copied so the
+    same shared definition referenced by multiple libraries yields independent
+    objects (downstream passes mutate these in place). Refs with no matching
+    definition are logged and skipped rather than crashing the build.
+    """
+    resolved = library.copy()
+
+    config_refs = resolved.pop("configuration_refs", None)
+    if config_refs is not None:
+        configurations = []
+        for ref in config_refs:
+            definition = configuration_defs.get(ref)
+            if definition is None:
+                logger.warning("Library %s references unknown configuration '%s'", library.get("name"), ref)
+                continue
+            configurations.append(copy.deepcopy(definition))
+        resolved["configurations"] = configurations
+
+    telemetry = resolved.get("telemetry")
+    if telemetry is not None:
+        resolved_telemetry = []
+        for entry in telemetry:
+            resolved_entry = entry.copy()
+            metric_refs = resolved_entry.pop("metric_refs", None)
+            if metric_refs is not None:
+                metrics = []
+                for ref in metric_refs:
+                    definition = metric_defs.get(ref)
+                    if definition is None:
+                        logger.warning("Library %s references unknown metric '%s'", library.get("name"), ref)
+                        continue
+                    metrics.append(copy.deepcopy(definition))
+                resolved_entry["metrics"] = metrics
+            resolved_telemetry.append(resolved_entry)
+        resolved["telemetry"] = resolved_telemetry
+
+    return resolved
+
+
+def _transform_0_6_to_0_5(inventory_data: dict[str, Any]) -> dict[str, Any]:
+    """Transform file_format 0.6 to the inline 0.5 common schema.
+
+    0.6 hoists shared metrics and configurations into a top-level ``definitions``
+    catalog; libraries reference them by id via ``configuration_refs`` and
+    ``telemetry[].metric_refs``. Downstream consumers (list/index projection,
+    configuration aggregator, and the frontend) all expect the fully-inline 0.5
+    shape, so we resolve every reference against the catalog, drop the ``*_refs``
+    keys and the ``definitions`` block, and tag the result as 0.5.
+
+    Args:
+        inventory_data: Inventory data in format 0.6
+
+    Returns:
+        Inventory data with references resolved inline, tagged as format 0.5
+    """
+    definitions = inventory_data.get("definitions") or {}
+    configuration_defs = definitions.get("configurations") or {}
+    metric_defs = definitions.get("metrics") or {}
+
+    transformed_data = inventory_data.copy()
+    transformed_data.pop("definitions", None)
+
+    for key in ("libraries", "custom"):
+        library_list = inventory_data.get(key)
+        if library_list is not None:
+            transformed_data[key] = [
+                _resolve_refs(library, configuration_defs, metric_defs) for library in library_list
+            ]
+
+    transformed_data["file_format"] = 0.5
+    logger.info("Transformed inventory from format 0.6 to 0.5")
     return transformed_data
 
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -26,7 +26,11 @@ from explorer_db_builder.collector_builder import run_collector_builder
 from explorer_db_builder.configuration_aggregator import build_global_configurations
 from explorer_db_builder.configuration_builder import run_configuration_builder
 from explorer_db_builder.database_writer import DatabaseWriter
-from explorer_db_builder.declarative_name_corrections import apply_declarative_name_corrections
+from explorer_db_builder.declarative_name_corrections import (
+    apply_declarative_name_corrections,
+    backfill_underdocumented_configs,
+    normalize_config_descriptions,
+)
 from explorer_db_builder.ecosystem_stats import count_unique_java_library_names
 from explorer_db_builder.instrumentation_transformer import (
     make_list_instrumentation,
@@ -182,8 +186,15 @@ def run_javaagent_builder(
             inventory = inventory_manager.load_versioned_inventory(version)
             readme_map = readme_maps.get(version, {})
 
-            # Correct known-bad declarative_name values before backfill and aggregation so the
-            # fix lands in both the per-version files and global-configurations.json.
+            # Resolve catalog/ref file formats (e.g. 0.6) to the inline 0.5 shape up front so every
+            # downstream correction/backfill step operates on inline `configurations`/`metrics`
+            # regardless of the registry file format. Corrections that walk inline configs were
+            # silent no-ops for 0.6 when this transform still ran later in process_version.
+            inventory = transform_instrumentation_format(inventory)
+
+            # Correct known-bad declarative_name values (and backfill missing config names) before
+            # backfill and aggregation so the fix lands in both the per-version files and
+            # global-configurations.json.
             apply_declarative_name_corrections(inventory)
             # Correct known-bad telemetry when-conditions:
             # - fold known test-harness artifact when-conditions back into "default"
@@ -217,6 +228,17 @@ def run_javaagent_builder(
             lambda v: backfilled_libraries[v],
             item_key="custom",
         )
+
+        # Pin reworded-but-unchanged config descriptions to their newest value across versions so
+        # cosmetic upstream rewordings of shared configs don't show as per-library changes in the
+        # release comparison. Runs after backfill (so config names are populated) and before both
+        # per-version writes and global-configurations aggregation. versions is newest-first.
+        normalize_config_descriptions([backfilled_inventories[v] for v in versions])
+
+        # Back-populate configs the agent supported before upstream documented them (e.g.
+        # url_template_rules, new in 2.29.1) into earlier versions, so they don't read as spuriously
+        # "added" in the release comparison.
+        backfill_underdocumented_configs([(v, backfilled_inventories[v]) for v in versions])
 
         # versions[0] is the latest release (the same version write_version_list
         # flags as is_latest), so the first processed version's instrumentations

--- a/ecosystem-automation/explorer-db-builder/tests/test_declarative_name_corrections.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_declarative_name_corrections.py
@@ -16,7 +16,10 @@
 
 from explorer_db_builder.declarative_name_corrections import (
     apply_declarative_name_corrections,
+    backfill_underdocumented_configs,
+    normalize_config_descriptions,
 )
+from semantic_version import Version
 
 
 def _config(name, declarative_name):
@@ -235,3 +238,186 @@ class TestApplyDeclarativeNameCorrections:
         assert "pattern" in config["declarative_schema"]["required"]
         assert "template" in config["declarative_schema"]["required"]
         assert "override" in config["declarative_schema"]["properties"]
+
+
+class TestConfigNameFallback:
+    def test_declarative_only_config_gets_name_from_declarative_name(self):
+        """A config with a declarative_name but no name falls back to the declarative_name."""
+        inventory = {
+            "libraries": [
+                {
+                    "name": "apache-httpasyncclient-4.1",
+                    "configurations": [{"declarative_name": "java.common.http.client.url_template_rules"}],
+                }
+            ]
+        }
+
+        apply_declarative_name_corrections(inventory)
+
+        config = inventory["libraries"][0]["configurations"][0]
+        assert config["name"] == "java.common.http.client.url_template_rules"
+
+    def test_existing_name_is_not_overwritten(self):
+        """A config that already has a name keeps it; the fallback only fills a missing name."""
+        inventory = {
+            "libraries": [
+                {
+                    "name": "lib",
+                    "configurations": [_config("otel.instrumentation.real.name", "java.common.real")],
+                }
+            ]
+        }
+
+        apply_declarative_name_corrections(inventory)
+
+        assert inventory["libraries"][0]["configurations"][0]["name"] == "otel.instrumentation.real.name"
+
+    def test_config_without_name_or_declarative_name_stays_nameless(self):
+        """No declarative_name means there's nothing to fall back to; name stays absent."""
+        inventory = {"libraries": [{"name": "lib", "configurations": [{"description": "x"}]}]}
+
+        apply_declarative_name_corrections(inventory)
+
+        assert "name" not in inventory["libraries"][0]["configurations"][0]
+
+
+class TestNormalizeConfigDescriptions:
+    _DN = "java.common.db.query_sanitization.enabled"
+
+    def _inventory(self, description):
+        return {
+            "libraries": [
+                {
+                    "name": "some-lib",
+                    "configurations": [
+                        {
+                            "name": "otel.instrumentation.common.db.query-sanitization.enabled",
+                            "declarative_name": self._DN,
+                            "description": description,
+                        }
+                    ],
+                }
+            ]
+        }
+
+    def test_pins_older_description_to_newest(self):
+        """Whitelisted configs get the newest version's description in every version."""
+        newest = self._inventory("Enables query sanitization for database queries.")
+        older = self._inventory("Enables or disables query sanitization for database queries.")
+
+        normalize_config_descriptions([newest, older])  # newest-first
+
+        assert older["libraries"][0]["configurations"][0]["description"] == (
+            "Enables query sanitization for database queries."
+        )
+        # Newest is unchanged.
+        assert newest["libraries"][0]["configurations"][0]["description"] == (
+            "Enables query sanitization for database queries."
+        )
+
+    def test_does_not_touch_non_whitelisted_configs(self):
+        """A config whose declarative_name isn't whitelisted keeps its per-version description."""
+
+        def inv(description):
+            config = _config("c", "java.common.not_whitelisted") | {"description": description}
+            return {"libraries": [{"name": "lib", "configurations": [config]}]}
+
+        newest = inv("new")
+        older = inv("old")
+
+        normalize_config_descriptions([newest, older])
+
+        assert older["libraries"][0]["configurations"][0]["description"] == "old"
+
+    def test_scoped_per_instrumentation(self):
+        """Two libraries referencing the same whitelisted config each keep their own newest value."""
+        newest = {
+            "libraries": [
+                {
+                    "name": "lib-a",
+                    "configurations": [
+                        {"name": "n", "declarative_name": self._DN, "description": "A newest"},
+                    ],
+                },
+                {
+                    "name": "lib-b",
+                    "configurations": [
+                        {"name": "n", "declarative_name": self._DN, "description": "B newest"},
+                    ],
+                },
+            ]
+        }
+        older = {
+            "libraries": [
+                {
+                    "name": "lib-a",
+                    "configurations": [
+                        {"name": "n", "declarative_name": self._DN, "description": "A old"},
+                    ],
+                },
+                {
+                    "name": "lib-b",
+                    "configurations": [
+                        {"name": "n", "declarative_name": self._DN, "description": "B old"},
+                    ],
+                },
+            ]
+        }
+
+        normalize_config_descriptions([newest, older])
+
+        assert older["libraries"][0]["configurations"][0]["description"] == "A newest"
+        assert older["libraries"][1]["configurations"][0]["description"] == "B newest"
+
+    def test_returns_same_list_and_handles_empty(self):
+        inventories: list = []
+        assert normalize_config_descriptions(inventories) is inventories
+
+
+class TestBackfillUnderdocumentedConfigs:
+    _DN = "java.common.http.client.url_template_rules"
+
+    def _lib(self, name, has_config):
+        configs = []
+        if has_config:
+            configs.append(
+                {
+                    "name": self._DN,
+                    "declarative_name": self._DN,
+                    "type": "list",
+                    "default": "",
+                }
+            )
+        return {"name": name, "configurations": configs}
+
+    def test_backfills_config_into_earlier_version(self):
+        """A config present only in the newest version is injected into earlier versions."""
+        newest = {"libraries": [self._lib("apache-httpasyncclient-4.1", has_config=True)]}
+        older = {"libraries": [self._lib("apache-httpasyncclient-4.1", has_config=False)]}
+
+        backfill_underdocumented_configs([(Version("2.29.1"), newest), (Version("2.29.0"), older)])
+
+        older_configs = older["libraries"][0]["configurations"]
+        assert [c["declarative_name"] for c in older_configs] == [self._DN]
+        # Injected config is an independent deep copy, not the template object.
+        assert older_configs[0] is not newest["libraries"][0]["configurations"][0]
+
+    def test_does_not_duplicate_when_already_present(self):
+        """A version that already carries the config is left untouched."""
+        newest = {"libraries": [self._lib("lib", has_config=True)]}
+        older = {"libraries": [self._lib("lib", has_config=True)]}
+
+        backfill_underdocumented_configs([(Version("2.29.1"), newest), (Version("2.29.0"), older)])
+
+        assert len(older["libraries"][0]["configurations"]) == 1
+
+    def test_does_not_add_to_instrumentation_absent_from_older_version(self):
+        """Only instrumentations already present in the older version receive the config."""
+        newest = {"libraries": [self._lib("new-lib", has_config=True)]}
+        older = {"libraries": [self._lib("other-lib", has_config=False)]}
+
+        backfill_underdocumented_configs([(Version("2.29.1"), newest), (Version("2.29.0"), older)])
+
+        # other-lib doesn't carry the config in the newest version, so it isn't a template target.
+        assert older["libraries"][0]["configurations"] == []
+        assert len(older["libraries"]) == 1

--- a/ecosystem-automation/explorer-db-builder/tests/test_instrumentation_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_instrumentation_transformer.py
@@ -352,6 +352,110 @@ class TestTransformInstrumentationFormat:
             transform_instrumentation_format(data)
 
 
+class TestTransform06To05:
+    def _catalog_data(self):
+        """0.6 inventory: two libraries sharing one config/metric via the definitions catalog."""
+        return {
+            "file_format": 0.6,
+            "definitions": {
+                "configurations": {
+                    "http.known-methods": {
+                        "name": "otel.instrumentation.http.known-methods",
+                        "declarative_name": "java.common.http.known_methods",
+                        "description": "Configures known methods.",
+                        "type": "list",
+                        "default": "GET,POST",
+                    },
+                },
+                "metrics": {
+                    "http.server.request.duration-639e2d0b": {
+                        "name": "http.server.request.duration",
+                        "description": "Duration of HTTP server requests.",
+                        "instrument": "histogram",
+                        "data_type": "HISTOGRAM",
+                        "unit": "s",
+                    },
+                },
+            },
+            "libraries": [
+                {
+                    "name": "activej-http-6.0",
+                    "configuration_refs": ["http.known-methods"],
+                    "telemetry": [
+                        {"when": "default", "metric_refs": ["http.server.request.duration-639e2d0b"]},
+                    ],
+                },
+                {
+                    "name": "akka-http-10.0",
+                    "configuration_refs": ["http.known-methods"],
+                    "telemetry": [
+                        {"when": "default", "metric_refs": ["http.server.request.duration-639e2d0b"]},
+                    ],
+                },
+            ],
+        }
+
+    def test_resolves_refs_to_inline_shape(self):
+        result = transform_instrumentation_format(self._catalog_data())
+
+        assert result["file_format"] == 0.5
+        # Catalog and ref keys are dropped after resolution.
+        assert "definitions" not in result
+        lib = result["libraries"][0]
+        assert "configuration_refs" not in lib
+        assert "metric_refs" not in lib["telemetry"][0]
+        # References resolved into the inline 0.5 shape consumers expect.
+        assert lib["configurations"][0]["name"] == "otel.instrumentation.http.known-methods"
+        assert lib["telemetry"][0]["metrics"][0]["data_type"] == "HISTOGRAM"
+
+    def test_shared_definition_yields_independent_copies(self):
+        result = transform_instrumentation_format(self._catalog_data())
+
+        config_a = result["libraries"][0]["configurations"][0]
+        config_b = result["libraries"][1]["configurations"][0]
+        metric_a = result["libraries"][0]["telemetry"][0]["metrics"][0]
+        metric_b = result["libraries"][1]["telemetry"][0]["metrics"][0]
+
+        # Same values, but distinct objects so later in-place mutation can't leak across libraries.
+        assert config_a == config_b
+        assert config_a is not config_b
+        assert metric_a is not metric_b
+
+    def test_unknown_ref_is_skipped(self):
+        data = {
+            "file_format": 0.6,
+            "definitions": {"configurations": {}, "metrics": {}},
+            "libraries": [
+                {
+                    "name": "test-lib",
+                    "configuration_refs": ["does.not.exist"],
+                    "telemetry": [{"when": "default", "metric_refs": ["missing-metric"]}],
+                }
+            ],
+        }
+
+        result = transform_instrumentation_format(data)
+
+        lib = result["libraries"][0]
+        assert lib["configurations"] == []
+        assert lib["telemetry"][0]["metrics"] == []
+
+    def test_resolves_custom_libraries(self):
+        data = self._catalog_data()
+        data["custom"] = [
+            {
+                "name": "custom-lib",
+                "configuration_refs": ["http.known-methods"],
+                "telemetry": [],
+            }
+        ]
+
+        result = transform_instrumentation_format(data)
+
+        assert result["custom"][0]["configurations"][0]["name"] == "otel.instrumentation.http.known-methods"
+        assert "configuration_refs" not in result["custom"][0]
+
+
 class TestTransform01To02:
     def test_transforms_javaagent_and_library_fields(self):
         """Transforms target_versions to new format with both javaagent and library."""

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_parser.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_parser.py
@@ -205,6 +205,25 @@ class ParserV05(ParserV03):
             raise ValueError(f"Error parsing instrumentation YAML: {e}") from e
 
 
+class ParserV06(ParserV05):
+    """Parser for file_format 0.6.
+
+    Changes from 0.5:
+    - Common metrics and configurations are hoisted into a top-level ``definitions``
+      catalog. Each library references them by id via ``metric_refs`` (inside
+      ``telemetry`` entries) and ``configuration_refs`` (at the library level)
+      instead of inlining them.
+
+    The parser preserves this compact catalog-and-refs shape verbatim in the
+    registry (only cleaning whitespace); reference resolution back to the inline
+    shape happens downstream in the explorer-db-builder. See
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468
+    """
+
+    def get_file_format(self) -> float:
+        return 0.6
+
+
 class ParserFactory:
     """Factory for creating version-specific parsers."""
 
@@ -213,6 +232,7 @@ class ParserFactory:
         0.2: ParserV02,
         0.3: ParserV03,
         0.5: ParserV05,
+        0.6: ParserV06,
     }
 
     @classmethod

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_parser.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_parser.py
@@ -22,6 +22,7 @@ from java_instrumentation_watcher.instrumentation_parser import (
     ParserV02,
     ParserV03,
     ParserV05,
+    ParserV06,
     parse_instrumentation_yaml,
 )
 
@@ -263,6 +264,59 @@ class TestParserV05:
         assert lib["has_javaagent"] is True
 
 
+class TestParserV06:
+    def test_get_file_format(self):
+        parser = ParserV06()
+        assert parser.get_file_format() == 0.6
+
+    def test_parse_preserves_definitions_and_refs(self):
+        # 0.6 hoists shared configs/metrics into a top-level ``definitions`` catalog
+        # and references them by id. The parser must preserve this compact shape
+        # verbatim (resolution happens downstream in the db-builder).
+        yaml_content = """
+file_format: 0.6
+definitions:
+  configurations:
+    http.known-methods:
+      name: otel.instrumentation.http.known-methods
+      declarative_name: java.common.http.known_methods
+      description: '  Configures known methods.  '
+      type: list
+      default: GET,POST
+  metrics:
+    http.server.request.duration-639e2d0b:
+      name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+libraries:
+- name: activej-http-6.0
+  display_name: ActiveJ
+  configuration_refs:
+  - http.known-methods
+  telemetry:
+  - when: default
+    metric_refs:
+    - http.server.request.duration-639e2d0b
+"""
+        parser = ParserV06()
+        data = parser.parse(yaml_content)
+
+        assert data["file_format"] == 0.6
+        # Catalog is preserved and whitespace cleaned.
+        assert data["definitions"]["configurations"]["http.known-methods"]["description"] == "Configures known methods."
+        assert "http.server.request.duration-639e2d0b" in data["definitions"]["metrics"]
+        # Libraries stay a flat list and keep their references (not resolved here).
+        lib = data["libraries"][0]
+        assert lib["name"] == "activej-http-6.0"
+        assert lib["configuration_refs"] == ["http.known-methods"]
+        assert lib["telemetry"][0]["metric_refs"] == ["http.server.request.duration-639e2d0b"]
+        # No inline resolution happened in the parser.
+        assert "configurations" not in lib
+        assert "metrics" not in lib["telemetry"][0]
+
+
 class TestParserFactory:
     def test_get_parser_v0_1(self):
         parser = ParserFactory.get_parser(0.1)
@@ -283,11 +337,16 @@ class TestParserFactory:
         with pytest.raises(ValueError, match="Unsupported file_format: 999.0"):
             ParserFactory.get_parser(999.0)
 
+    def test_get_parser_v0_6(self):
+        parser = ParserFactory.get_parser(0.6)
+        assert isinstance(parser, ParserV06)
+        assert parser.get_file_format() == 0.6
+
     def test_get_default_parser(self):
         parser = ParserFactory.get_default_parser()
         assert isinstance(parser, InstrumentationParser)
         # Should return the latest version
-        assert parser.get_file_format() == 0.5
+        assert parser.get_file_format() == 0.6
 
 
 class TestParseInstrumentationYaml:


### PR DESCRIPTION
## What changed

This PR adds support for the new java agent format, as well as adds some corrections to the db-builder to account for some fixes to the data itself.

## Why

The upstream java agent file format changed, see:
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19244
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19077

Fixes #829

## How it was tested

I ran a fresh db-builder locally and then served the site. Manually checked some of the instrumentation list page, as well as the release comparison tool, which is where i found some of the descrepancies that lead to adding some additioanl corrections to the db-builder

## Is this a breaking change?

No