### PR TITLE
fix(i18n): localize Java Agent instrumentation list strings

### DIFF
--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -347,11 +347,11 @@ export function JavaInstrumentationListPage() {
         {versionsError || error ? (
           <div className="flex flex-col items-center justify-center space-y-4 py-32 text-center text-red-500">
             <AlertCircle className="mx-auto h-12 w-12 opacity-50" aria-hidden="true" />
-            <h3 className="text-xl font-semibold">Error loading data</h3>
+            <h3 className="text-xl font-semibold">{t("list.error.title")}</h3>
             {(versionsError ?? error)?.message && (
               <p className="text-muted-foreground text-sm">{(versionsError ?? error)!.message}</p>
             )}
-            <p className="text-muted-foreground">Please try refreshing the page.</p>
+            <p className="text-muted-foreground">{t("list.error.description")}</p>
           </div>
         ) : versionsLoading || instrumentationsLoading || (!resolvedVersion && !versionsError) ? (
           <Loader label={t("list.loading")} />
@@ -370,10 +370,10 @@ export function JavaInstrumentationListPage() {
               <div className="border-border/50 bg-card/30 flex min-h-[300px] items-center justify-center rounded-lg border">
                 <div className="text-center">
                   <p className="text-muted-foreground text-base">
-                    No instrumentations found matching your filters.
+                    {t("list.results.empty")}
                   </p>
                   <p className="text-muted-foreground/70 mt-2 text-sm">
-                    Try adjusting your search or filter criteria
+                    {t("list.results.emptySuggestion")}
                   </p>
                 </div>
               </div>
@@ -406,11 +406,10 @@ export function JavaInstrumentationListPage() {
                   <div className="space-y-6">
                     <div className="border-border/50 border-b pb-2">
                       <h2 className="text-foreground text-2xl font-semibold tracking-tight">
-                        Custom Instrumentations
+                        {t("list.customSection.title")}
                       </h2>
                       <p className="text-muted-foreground mt-1 text-sm">
-                        Non-library instrumentations such as methods, JMX metrics, and external
-                        annotations.
+                        {t("list.customSection.description")}
                       </p>
                     </div>
                     <div className="space-y-4">

--- a/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-instrumentation-list-page.tsx
@@ -369,9 +369,7 @@ export function JavaInstrumentationListPage() {
             {filteredInstrumentations.length === 0 ? (
               <div className="border-border/50 bg-card/30 flex min-h-[300px] items-center justify-center rounded-lg border">
                 <div className="text-center">
-                  <p className="text-muted-foreground text-base">
-                    {t("list.results.empty")}
-                  </p>
+                  <p className="text-muted-foreground text-base">{t("list.results.empty")}</p>
                   <p className="text-muted-foreground/70 mt-2 text-sm">
                     {t("list.results.emptySuggestion")}
                   </p>


### PR DESCRIPTION
## Summary

Fixes #835

This replaces the remaining hardcoded English strings on the Java Agent instrumentation list page with the existing translation keys..!

The affected strings were shown in the empty state, error state, and Custom Instrumentations section when using a non-English locale!

## Changes

- Replace hardcoded user-facing strings with existing i18n translation keys
- Reuse existing locale entries (no new translation keys added)
- Preserve existing UI and behavior

## Verification

- Verified the issue locally in both English and Spanish
- Confirmed the empty state and related messages are now correctly localized
- Ran lint, typecheck, and relevant tests successfully