### PR TITLE
Fix flaky test

### DIFF
--- a/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
+++ b/ecosystem-explorer/src/test/integration/instrumentation-list.integration.test.tsx
@@ -110,7 +110,9 @@ describe("JavaInstrumentationListPage — integration", () => {
 
     // Each group card links to one or more detail pages; verify at least one
     // link is rendered, which confirms the group cards actually rendered content.
-    const links = screen.getAllByRole("link");
+    // waitForList only waits for the count text; the cards (and their links) may
+    // paint a tick later, so use findAllByRole to retry until they appear.
+    const links = await screen.findAllByRole("link");
     expect(links.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
I am trying to get the l[ockfile PR](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/pull/619) to be green, it is failing on this test. I think this should fix it