### PR TITLE
Pin runtime dependencies instead of relying on lockfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,17 @@
       matchManagers: ["pre-commit"],
       pinDigests: true,
     },
+    {
+      matchManagers: ["npm"],
+      matchDepTypes: ["dependencies"],
+      rangeStrategy: "pin",
+    },
+    // The faro packages are version-locked to each other, so group them into a
+    // single PR to avoid mismatched partial upgrades.
+    {
+      matchPackageNames: ["@grafana/faro-react", "@grafana/faro-web-tracing"],
+      groupName: "faro",
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
switches our renovate strategy for runtime dependencies from caret ranges (^x.y.z) to pinned exact versions. 

Previously, in-range upgrades only landed via the weekly "Lock file maintenance" PR, which bumps many unrelated dependencies at once and those PRs are hard to review and validate, so they tended to pile up unmerged (see #619)