### PR TITLE
Exclude dbauth collector component from scanning

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
@@ -35,6 +35,7 @@ class ComponentScanner:
         "extensioncapabilities",  # Capabilities framework
         "extensionmiddleware",  # Middleware framework
         "opampcustommessages",  # OpAMP utilities
+        "dbauth",  # Database auth interface
     ]
 
     EXCLUDED_COMPONENTS = [


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/pull/871/changes#r3619163696

This new component looks to be an internally used interface (added [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49464)), and has incomplete metadata, so excluding it from our scans