### PR TITLE
Add flag to prune unspecified releases in registry rebuild

### DIFF
--- a/.github/workflows/regenerate-collector-registry.yml
+++ b/.github/workflows/regenerate-collector-registry.yml
@@ -16,6 +16,14 @@ on:
         type: string
         required: false
         default: ""
+      prune_unlisted_versions:
+        description:
+          "When 'versions' is set, delete any existing release versions NOT in that list from the
+          registry (both distributions) before regenerating. SNAPSHOT versions are always kept.
+          Errors if 'versions' is empty."
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read # Default minimum; the job declares its own elevated scopes below
@@ -103,6 +111,7 @@ jobs:
         id: backfill
         env:
           VERSIONS: ${{ inputs.versions }}
+          PRUNE_UNLISTED: ${{ inputs.prune_unlisted_versions }}
         run: |
           # Backfill re-extracts both core and contrib. Contrib's schema is
           # resolved from the core clone at each version's ref, so both
@@ -110,6 +119,12 @@ jobs:
           ARGS=(--backfill)
           if [ -n "$VERSIONS" ]; then
             ARGS+=(--versions "$VERSIONS")
+            if [ "$PRUNE_UNLISTED" == "true" ]; then
+              ARGS+=(--prune-unlisted)
+            fi
+          elif [ "$PRUNE_UNLISTED" == "true" ]; then
+            echo "::error::prune_unlisted_versions requires 'versions' to be set; refusing to prune the entire registry." >&2
+            exit 1
           fi
           echo "Running: uv run collector-watcher ${ARGS[*]}"
           uv run collector-watcher "${ARGS[@]}"
@@ -135,6 +150,7 @@ jobs:
             ${{ steps.repo_check.outputs.is_primary == 'true' && steps.otelbot-token.outputs.token
             || secrets.GITHUB_TOKEN }}
           VERSIONS: ${{ inputs.versions }}
+          PRUNE_UNLISTED: ${{ inputs.prune_unlisted_versions }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
         run: |
@@ -148,6 +164,7 @@ jobs:
           PR_BODY="Re-extracted collector registry versions via \`collector-watcher --backfill\`.
 
           - **Versions:** ${VERSIONS:-all existing}
+          - **Pruned unlisted versions:** ${PRUNE_UNLISTED:-false}
 
           See [workflow run](https://github.com/${REPO}/actions/runs/${RUN_ID}).
 

--- a/ecosystem-automation/collector-watcher/README.md
+++ b/ecosystem-automation/collector-watcher/README.md
@@ -89,11 +89,25 @@ Apply a version list to all distributions:
 uv run collector-watcher --backfill --versions "0.144.0,0.145.0"
 ```
 
+#### Prune Unlisted Versions
+
+Reduce the registry to exactly the listed versions — regenerate them and delete every other release
+version (e.g. after raising the minimum supported version). SNAPSHOT versions are always kept:
+
+```bash
+uv run collector-watcher --backfill --versions "0.156.0,0.157.0" --prune-unlisted
+```
+
+`--prune-unlisted` requires both `--backfill` and `--versions`; running it without a version list
+exits with an error rather than wiping the registry.
+
 #### Options
 
 - `--backfill` - Enable backfill mode (regenerates existing versions)
 - `--distribution {core,contrib}` - Target a specific distribution
 - `--versions VERSION_LIST` - Comma-separated list of versions (e.g., "0.144.0,0.145.0")
+- `--prune-unlisted` - Delete existing release versions not in `--versions` before backfilling
+  (SNAPSHOTs kept); requires `--backfill` and `--versions`
 - `--inventory-dir PATH` - Custom path to inventory directory (default:
   ecosystem-registry/collector)
 

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/collector_sync.py
@@ -25,7 +25,7 @@ from .deprecation_detector import DeprecationDetector
 from .inventory_manager import InventoryManager
 from .readme_scanner import discover_component_readmes
 from .schema_copier import SCHEMA_RELATIVE_PATH, UNKNOWN_HASH, CollectorSchemaCopier
-from .type_defs import DistributionName
+from .type_defs import COMPONENT_TYPES, DistributionName
 
 logger = logging.getLogger(__name__)
 
@@ -544,13 +544,21 @@ class CollectorSync:
             "versions_processed": processed,
         }
 
-    def backfill(self, versions_by_dist: dict[DistributionName, list[Version] | None] | None = None) -> dict[str, Any]:
+    def backfill(
+        self,
+        versions_by_dist: dict[DistributionName, list[Version] | None] | None = None,
+        prune_unlisted: bool = False,
+    ) -> dict[str, Any]:
         """
         Backfill versions across all distributions.
 
         Args:
             versions_by_dist: Dictionary mapping distribution to list of versions to backfill,
                             or None to auto-detect all existing versions for all distributions
+            prune_unlisted: When True, delete existing release versions not in the provided
+                            list for each distribution before backfilling. Requires an explicit
+                            version list per distribution (distributions mapped to None are left
+                            untouched). SNAPSHOT versions are always kept.
 
         Returns:
             Summary of backfill operation
@@ -565,7 +573,16 @@ class CollectorSync:
         logger.info("=" * 60)
 
         for distribution in versions_by_dist.keys():
-            result = self.backfill_versions(distribution, versions_by_dist[distribution])
+            keep = versions_by_dist[distribution]
+            if prune_unlisted and keep is not None:
+                # Reset this distribution's deprecation index so it is recomputed cleanly over
+                # only the surviving versions. Otherwise entries referencing now-deleted versions
+                # would linger in deprecations.yaml (backfill_versions appends, never clears).
+                self.deprecations[distribution] = {component_type: [] for component_type in COMPONENT_TYPES}
+                removed = self.inventory_manager.prune_release_versions_not_in(distribution, keep)
+                if removed:
+                    logger.info("Pruned %d unlisted release version(s) from %s", removed, distribution)
+            result = self.backfill_versions(distribution, keep)
             summary["backfilled"].append(result)
 
         logger.info("")

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/inventory_manager.py
@@ -403,6 +403,38 @@ class InventoryManager:
 
         return count
 
+    def prune_release_versions_not_in(self, distribution: DistributionName, keep_versions: Iterable[Version]) -> int:
+        """
+        Delete release version directories not present in ``keep_versions``.
+
+        SNAPSHOT/prerelease versions are always preserved — deleting the current
+        snapshot would leave the frontend without one until the next nightly
+        sync. Orphaned schema files are pruned once after deletion.
+
+        Args:
+            distribution: Distribution name (core or contrib)
+            keep_versions: Release versions to keep; every other release version
+                is removed
+
+        Returns:
+            Number of release version directories removed
+        """
+        keep = {str(v) for v in keep_versions}
+        removed = 0
+
+        for version in self.list_release_versions(distribution):
+            if str(version) in keep:
+                continue
+            version_dir = self.get_version_dir(distribution, version)
+            if version_dir.exists():
+                shutil.rmtree(version_dir)
+                removed += 1
+
+        if removed > 0:
+            self.prune_orphan_schemas()
+
+        return removed
+
     def version_exists(self, distribution: DistributionName, version: Version) -> bool:
         """
         Check if a specific version exists for a distribution.

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/main.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/main.py
@@ -66,7 +66,17 @@ def main():
         help="Specific distribution to backfill (core or contrib). "
         "If not specified, all distributions will be processed.",
     )
+    parser.add_argument(
+        "--prune-unlisted",
+        action="store_true",
+        help="Delete existing release versions NOT listed in --versions before backfilling "
+        "(SNAPSHOT versions are always kept). Requires --backfill and --versions.",
+    )
     args = parser.parse_args()
+
+    if args.prune_unlisted and not (args.backfill and args.versions):
+        logger.error("--prune-unlisted requires both --backfill and --versions")
+        sys.exit(1)
 
     logger.info("Collector Watcher")
     logger.info("Inventory directory: %s", args.inventory_dir)
@@ -79,6 +89,8 @@ def main():
             logger.info("Versions: %s", args.versions)
         else:
             logger.info("Versions: auto-detect all existing versions")
+        if args.prune_unlisted:
+            logger.info("Prune unlisted: delete release versions not in --versions (keeping SNAPSHOTs)")
     else:
         logger.info("Mode: SYNC")
 
@@ -126,7 +138,7 @@ def main():
             elif args.distribution:
                 versions_by_dist = {args.distribution: None}
 
-            collector_sync.backfill(versions_by_dist)
+            collector_sync.backfill(versions_by_dist, prune_unlisted=args.prune_unlisted)
         else:
             collector_sync.sync()
 

--- a/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
+++ b/ecosystem-automation/collector-watcher/tests/test_collector_sync.py
@@ -808,3 +808,80 @@ def test_backfill_processes_all_distributions_when_none_specified(
 
     distributions_processed = {item["distribution"] for item in summary["backfilled"]}
     assert distributions_processed == {"core", "contrib"}
+
+
+def _seed(inventory_manager, distribution, version, sample_components):
+    inventory_manager.save_versioned_inventory(
+        distribution=distribution,
+        version=version,
+        components=sample_components,
+        repository=CollectorSync.get_repository_name(distribution),
+    )
+
+
+def test_backfill_prune_unlisted_removes_unlisted_release_versions(
+    collector_sync, sample_components, temp_inventory_dir
+):
+    im = collector_sync.inventory_manager
+    keep = Version("0.112.0")
+    snapshot = Version(major=0, minor=113, patch=0, prerelease=("SNAPSHOT",))
+    for version in [Version("0.110.0"), Version("0.111.0"), keep, snapshot]:
+        _seed(im, "core", version, sample_components)
+
+    with patch("collector_watcher.collector_sync.ComponentScanner") as mock_scanner:
+        mock_instance = Mock()
+        mock_instance.scan_all_components.return_value = sample_components
+        mock_scanner.return_value = mock_instance
+
+        summary = collector_sync.backfill(versions_by_dist={"core": [keep]}, prune_unlisted=True)
+
+    # Only the listed version is regenerated.
+    assert summary["backfilled"][0]["versions_processed"] == ["0.112.0"]
+    # Unlisted release versions are deleted.
+    assert not im.version_exists("core", Version("0.110.0"))
+    assert not im.version_exists("core", Version("0.111.0"))
+    # Listed version survives (regenerated).
+    assert im.version_exists("core", keep)
+    # The SNAPSHOT is preserved even though it is not in the keep list.
+    assert im.version_exists("core", snapshot)
+
+
+def test_backfill_without_prune_keeps_unlisted_versions(collector_sync, sample_components, temp_inventory_dir):
+    im = collector_sync.inventory_manager
+    keep = Version("0.112.0")
+    other = Version("0.110.0")
+    _seed(im, "core", keep, sample_components)
+    _seed(im, "core", other, sample_components)
+
+    with patch("collector_watcher.collector_sync.ComponentScanner") as mock_scanner:
+        mock_instance = Mock()
+        mock_instance.scan_all_components.return_value = sample_components
+        mock_scanner.return_value = mock_instance
+
+        collector_sync.backfill(versions_by_dist={"core": [keep]})
+
+    # Default behaviour leaves the unlisted version untouched.
+    assert im.version_exists("core", keep)
+    assert im.version_exists("core", other)
+
+
+def test_backfill_prune_unlisted_resets_deprecations_for_distribution(
+    collector_sync, sample_components, temp_inventory_dir
+):
+    im = collector_sync.inventory_manager
+    keep = Version("0.112.0")
+    _seed(im, "core", Version("0.110.0"), sample_components)
+    _seed(im, "core", keep, sample_components)
+
+    # Pre-existing deprecation entry that references a now-pruned version.
+    collector_sync.deprecations["core"]["receiver"] = [{"name": "gonereceiver", "deprecated_in_version": "0.111.0"}]
+
+    with patch("collector_watcher.collector_sync.ComponentScanner") as mock_scanner:
+        mock_instance = Mock()
+        mock_instance.scan_all_components.return_value = sample_components
+        mock_scanner.return_value = mock_instance
+
+        collector_sync.backfill(versions_by_dist={"core": [keep]}, prune_unlisted=True)
+
+    # The stale entry is cleared so deprecations.yaml reflects only surviving versions.
+    assert collector_sync.deprecations["core"]["receiver"] == []

--- a/ecosystem-automation/collector-watcher/tests/test_inventory.py
+++ b/ecosystem-automation/collector-watcher/tests/test_inventory.py
@@ -384,6 +384,89 @@ def test_cleanup_snapshots(temp_inventory_dir, sample_components):
     assert not manager.version_exists("contrib", v3)
 
 
+def test_prune_release_versions_not_in(temp_inventory_dir, sample_components):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    keep = Version("0.112.0")
+    drop_older = Version("0.110.0")
+    drop_newer = Version("0.113.0")
+    snapshot = Version(major=0, minor=114, patch=0, prerelease=("SNAPSHOT",))
+
+    for version in [keep, drop_older, drop_newer, snapshot]:
+        manager.save_versioned_inventory(
+            distribution="core",
+            version=version,
+            components=sample_components,
+            repository="opentelemetry-collector",
+        )
+
+    removed = manager.prune_release_versions_not_in("core", [keep])
+
+    assert removed == 2
+    # Listed release survives
+    assert manager.version_exists("core", keep)
+    # Unlisted releases are gone
+    assert not manager.version_exists("core", drop_older)
+    assert not manager.version_exists("core", drop_newer)
+    # Snapshots are always preserved, even though they are not in the keep list
+    assert manager.version_exists("core", snapshot)
+
+
+def test_prune_release_versions_not_in_keeps_all_listed(temp_inventory_dir, sample_components):
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    v1 = Version("0.111.0")
+    v2 = Version("0.112.0")
+
+    for version in [v1, v2]:
+        manager.save_versioned_inventory(
+            distribution="contrib",
+            version=version,
+            components=sample_components,
+            repository="opentelemetry-collector-contrib",
+        )
+
+    removed = manager.prune_release_versions_not_in("contrib", [v1, v2])
+
+    assert removed == 0
+    assert manager.version_exists("contrib", v1)
+    assert manager.version_exists("contrib", v2)
+
+
+def test_prune_release_versions_not_in_prunes_orphan_schemas(temp_inventory_dir, sample_components):
+    """Pruning the last version that referenced a schema removes the schema file."""
+    manager = InventoryManager(str(temp_inventory_dir))
+
+    keep = Version("0.112.0")
+    drop = Version("0.110.0")
+
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=keep,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="keepkeepkeep",
+    )
+    manager.save_versioned_inventory(
+        distribution="core",
+        version=drop,
+        components=sample_components,
+        repository="opentelemetry-collector",
+        schema_hash="dropdropdrop",
+    )
+
+    schemas_dir = manager.meta_schemas_dir()
+    schemas_dir.mkdir(parents=True, exist_ok=True)
+    (schemas_dir / "keepkeepkeep.yaml").write_text("type: object\n")
+    (schemas_dir / "dropdropdrop.yaml").write_text("type: object\n")
+
+    manager.prune_release_versions_not_in("core", [keep])
+
+    # Schema referenced only by the pruned version is removed; the kept one stays.
+    assert (schemas_dir / "keepkeepkeep.yaml").exists()
+    assert not (schemas_dir / "dropdropdrop.yaml").exists()
+
+
 def test_version_exists(temp_inventory_dir, sample_components, sample_version):
     manager = InventoryManager(str(temp_inventory_dir))
 


### PR DESCRIPTION
The github action we use to regenerate the registry has an option to run it for specific versions, but it leaves the other versions alone if they already exist in the registry. This adds a flag to prune any version not specified by that type of backfill to clean up the others.