### PR TITLE
Perf/875 java release comparison

### DIFF
--- a/ecosystem-explorer/public/locales/en/java-agent.json
+++ b/ecosystem-explorer/public/locales/en/java-agent.json
@@ -164,6 +164,7 @@
     "analyzing": "Analyzing {{fromVersion}} and {{toVersion}}",
     "loadingMetrics": "Loading all metrics in {{version}}...",
     "errorLoading": "Error loading comparison data: {{message}}",
+    "errorLoadingMetrics": "Error loading metrics: {{message}}",
     "from": "From",
     "to": "To",
     "latest": "(latest)",

--- a/ecosystem-explorer/public/locales/en/java-agent.json
+++ b/ecosystem-explorer/public/locales/en/java-agent.json
@@ -162,6 +162,7 @@
     "selectDifferent": "Select two different versions to see changes.",
     "comparingReleases": "Comparing Releases...",
     "analyzing": "Analyzing {{fromVersion}} and {{toVersion}}",
+    "loadingMetrics": "Loading all metrics in {{version}}...",
     "errorLoading": "Error loading comparison data: {{message}}",
     "from": "From",
     "to": "To",

--- a/ecosystem-explorer/public/locales/es/java-agent.json
+++ b/ecosystem-explorer/public/locales/es/java-agent.json
@@ -162,6 +162,7 @@
     "selectDifferent": "Selecciona dos versiones diferentes para ver los cambios.",
     "comparingReleases": "Comparando versiones...",
     "analyzing": "Analizando {{fromVersion}} y {{toVersion}}",
+    "loadingMetrics": "Cargando todas las métricas en {{version}}...",
     "errorLoading": "Error al cargar datos de comparación: {{message}}",
     "from": "Desde",
     "to": "Hasta",

--- a/ecosystem-explorer/public/locales/es/java-agent.json
+++ b/ecosystem-explorer/public/locales/es/java-agent.json
@@ -164,6 +164,7 @@
     "analyzing": "Analizando {{fromVersion}} y {{toVersion}}",
     "loadingMetrics": "Cargando todas las métricas en {{version}}...",
     "errorLoading": "Error al cargar datos de comparación: {{message}}",
+    "errorLoadingMetrics": "Error al cargar las métricas: {{message}}",
     "from": "Desde",
     "to": "Hasta",
     "latest": "(última)",

--- a/ecosystem-explorer/scripts/benchmarks/measure-release-comparison.mjs
+++ b/ecosystem-explorer/scripts/benchmarks/measure-release-comparison.mjs
@@ -1,0 +1,270 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Benchmarks Java Agent release-comparison performance: compares a server
+// running `main` against a server running a PR branch, on the same
+// comparison URL, across simulated network latencies.
+//
+// Usage:
+//   bun scripts/benchmarks/measure-release-comparison.mjs [options]
+//
+// Options (all optional, shown with defaults):
+//   --main-url=http://localhost:5180
+//   --pr-url=http://localhost:5181
+//   --from=2.28.1
+//   --to=2.29.0
+//   --runs=5                per branch, per latency
+//   --latencies=0,40,80     comma-separated milliseconds
+import { chromium } from "playwright";
+
+function parseArgs(argv) {
+  const opts = {
+    mainUrl: "http://localhost:5180",
+    prUrl: "http://localhost:5181",
+    from: "2.28.1",
+    to: "2.29.0",
+    runs: 5,
+    latencies: [0, 40, 80],
+  };
+  for (const arg of argv) {
+    const [key, value] = arg.replace(/^--/, "").split("=");
+    if (key === "main-url") opts.mainUrl = value;
+    else if (key === "pr-url") opts.prUrl = value;
+    else if (key === "from") opts.from = value;
+    else if (key === "to") opts.to = value;
+    else if (key === "runs") opts.runs = Number(value);
+    else if (key === "latencies") opts.latencies = value.split(",").map(Number);
+  }
+  return opts;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const urlPath = `/java-agent/releases?from=${opts.from}&to=${opts.to}`;
+
+// A stuck browser.close() or CDP call can pin the event loop past a
+// Promise.race timeout (there's no real cancellation in JS), so this is the
+// actual backstop against the script hanging forever.
+const totalMeasurements = 2 * opts.latencies.length * opts.runs;
+const WATCHDOG_MS = totalMeasurements * 30000 + 30000;
+setTimeout(() => {
+  console.error(`watchdog fired after ${WATCHDOG_MS}ms - forcing exit`);
+  process.exit(1);
+}, WATCHDOG_MS);
+
+function classify(url) {
+  if (url.includes("/versions-index.json")) return "versions-index";
+  if (/\/versions\/[^/]+-index\.json$/.test(url)) return "manifest";
+  if (url.includes("/instrumentations/") && url.endsWith(".json")) return "detail";
+  if (url.includes("/bundles/")) return "bundle";
+  return "other";
+}
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    ),
+  ]);
+}
+
+async function measureOnce(baseUrl, latencyMs) {
+  const browser = await chromium.launch();
+  try {
+    return await withTimeout(
+      measureWithBrowser(browser, baseUrl, latencyMs),
+      25000,
+      "measureWithBrowser"
+    );
+  } finally {
+    // Give up on a hung close() after 5s rather than block the retry loop;
+    // the watchdog above is the real backstop against a leaked handle.
+    await withTimeout(browser.close(), 5000, "browser.close").catch(() => {});
+  }
+}
+
+async function measureWithBrowser(browser, baseUrl, latencyMs) {
+  // Fresh, unpersisted context per run: no HTTP cache, no IndexedDB, so every
+  // run issues the same network requests a reader's first visit would.
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  if (latencyMs > 0) {
+    const client = await context.newCDPSession(page);
+    await client.send("Network.emulateNetworkConditions", {
+      offline: false,
+      latency: latencyMs,
+      downloadThroughput: (20 * 1024 * 1024) / 8, // 20 Mbps, generous - isolate latency
+      uploadThroughput: (10 * 1024 * 1024) / 8,
+    });
+  }
+
+  const responses = [];
+  page.on("response", async (res) => {
+    const url = res.url();
+    if (!url.includes("/data/javaagent/")) return;
+    let bytes = 0;
+    try {
+      bytes = (await res.body()).length;
+    } catch {
+      // response body unavailable (e.g. redirected/aborted) - count as 0
+      // bytes, the request is still counted.
+    }
+    responses.push({ url, kind: classify(url), bytes });
+  });
+
+  const t0 = performance.now();
+  await page.goto(`${baseUrl}${urlPath}`, { waitUntil: "domcontentloaded" });
+
+  // #panel-changes only renders once the diff has finished loading (see
+  // java-release-comparison-page.tsx), so waiting for it plus real content
+  // (diff cards or the "no changes" state) is the first point the
+  // comparison result is actually visible to the user.
+  await page.waitForSelector('[role="tabpanel"]#panel-changes', { timeout: 30000 });
+  await page.waitForFunction(
+    () => {
+      const panel = document.querySelector("#panel-changes");
+      if (!panel) return false;
+      const hasCards = panel.querySelector('[class*="grid"] > *') !== null;
+      const hasEmptyState = panel.textContent && panel.textContent.trim().length > 0;
+      return hasCards || hasEmptyState;
+    },
+    { timeout: 30000 }
+  );
+  await page.waitForTimeout(100); // let any trailing microtask/render settle
+  const comparisonReadyMs = Math.round(performance.now() - t0);
+
+  const detailRequests = responses.filter((r) => r.kind === "detail").length;
+  const detailBytes = responses.filter((r) => r.kind === "detail").reduce((s, r) => s + r.bytes, 0);
+
+  return {
+    comparisonReadyMs,
+    totalRequests: responses.length,
+    detailRequests,
+    detailBytes,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+async function runCondition(label, baseUrl, latencyMs, runs) {
+  const results = [];
+  for (let i = 1; i <= runs; i++) {
+    let result;
+    let attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        result = await measureOnce(baseUrl, latencyMs);
+        break;
+      } catch (err) {
+        console.error(
+          `[${label}@${latencyMs}ms] run ${i} attempt ${attempt} failed: ${err.message}`
+        );
+        if (attempt >= 3) throw err;
+        await sleep(2000);
+      }
+    }
+    results.push(result);
+    console.error(
+      `[${label}@${latencyMs}ms] run ${i}/${runs}: comparisonReady=${result.comparisonReadyMs}ms ` +
+        `detailRequests=${result.detailRequests} totalRequests=${result.totalRequests} detailBytes=${result.detailBytes}`
+    );
+    await sleep(500);
+  }
+  return results;
+}
+
+const allResults = { main: {}, pr: {} };
+
+for (const latencyMs of opts.latencies) {
+  allResults.main[latencyMs] = await runCondition("main", opts.mainUrl, latencyMs, opts.runs);
+  allResults.pr[latencyMs] = await runCondition("pr", opts.prUrl, latencyMs, opts.runs);
+}
+
+function summarize(branchResults) {
+  return {
+    medianMs: median(branchResults.map((r) => r.comparisonReadyMs)),
+    detailRequests: branchResults[0].detailRequests,
+    totalRequests: branchResults[0].totalRequests,
+    detailBytes: branchResults[0].detailBytes,
+  };
+}
+
+// Positive improvementPct means the PR is faster; negative means slower.
+const rows = opts.latencies.map((latencyMs) => {
+  const main = summarize(allResults.main[latencyMs]);
+  const pr = summarize(allResults.pr[latencyMs]);
+  const improvementPct = ((main.medianMs - pr.medianMs) / main.medianMs) * 100;
+  return { latencyMs, main, pr, improvementPct };
+});
+
+console.log("=== SUMMARY ===");
+console.log(`URL: ${urlPath}`);
+console.log(`Main: ${opts.mainUrl}   PR: ${opts.prUrl}`);
+console.log(`Runs per branch per latency: ${opts.runs}\n`);
+
+const header = [
+  "Latency",
+  "Main median",
+  "PR median",
+  "Improvement",
+  "Main detail reqs",
+  "PR detail reqs",
+  "Main total reqs",
+  "PR total reqs",
+  "Main detail bytes",
+  "PR detail bytes",
+];
+const tableRows = rows.map((r) => [
+  `${r.latencyMs}ms`,
+  `${r.main.medianMs}ms`,
+  `${r.pr.medianMs}ms`,
+  `${Math.abs(r.improvementPct).toFixed(1)}% ${r.improvementPct >= 0 ? "faster" : "slower"}`,
+  String(r.main.detailRequests),
+  String(r.pr.detailRequests),
+  String(r.main.totalRequests),
+  String(r.pr.totalRequests),
+  String(r.main.detailBytes),
+  String(r.pr.detailBytes),
+]);
+const widths = header.map((h, i) => Math.max(h.length, ...tableRows.map((row) => row[i].length)));
+const formatRow = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join(" | ");
+console.log(formatRow(header));
+console.log(widths.map((w) => "-".repeat(w)).join("-|-"));
+for (const row of tableRows) {
+  console.log(formatRow(row));
+}
+
+console.log(
+  "\nNote: request/byte counts are expected to be identical across runs at a given " +
+    "latency (they are driven by content-addressed static files, not timing), so a " +
+    "single value is shown per branch/latency rather than a range."
+);
+
+// Raw per-run results, for auditing the medians above.
+console.log("\n=== RAW RESULTS (every run) ===");
+console.log(JSON.stringify(allResults, null, 2));
+
+process.exit(0);

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useAggregateMetrics } from "./use-aggregate-metrics";
+import * as javaagentData from "@/lib/api/javaagent-data";
+import type { InstrumentationData } from "@/types/javaagent";
+
+vi.mock("@/lib/api/javaagent-data", () => ({
+  loadAllInstrumentationDetails: vi.fn(),
+}));
+
+describe("useAggregateMetrics hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const releaseData: InstrumentationData[] = [
+    {
+      name: "instr1",
+      display_name: "Instr One",
+      scope: { name: "test" },
+      telemetry: [
+        {
+          when: "default",
+          metrics: [
+            {
+              name: "metric.a",
+              description: "d",
+              instrument: "counter",
+              data_type: "COUNTER",
+              unit: "1",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it("should not load while disabled", () => {
+    const { result } = renderHook(() => useAggregateMetrics("2.10.0", false));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metrics).toBeNull();
+    expect(javaagentData.loadAllInstrumentationDetails).not.toHaveBeenCalled();
+  });
+
+  it("should load and roll up metrics once enabled", async () => {
+    vi.mocked(javaagentData.loadAllInstrumentationDetails).mockResolvedValue(releaseData);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAggregateMetrics("2.10.0", enabled),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(javaagentData.loadAllInstrumentationDetails).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(javaagentData.loadAllInstrumentationDetails).toHaveBeenCalledWith("2.10.0");
+    expect(result.current.metrics).toEqual([
+      { name: "metric.a", description: "d", emittedBy: ["Instr One"] },
+    ]);
+  });
+
+  it("should surface load errors", async () => {
+    vi.mocked(javaagentData.loadAllInstrumentationDetails).mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useAggregateMetrics("2.10.0", true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("boom");
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it("should not show the previous version's metrics after the version changes", async () => {
+    vi.mocked(javaagentData.loadAllInstrumentationDetails).mockResolvedValue(releaseData);
+
+    const { result, rerender } = renderHook(({ version }) => useAggregateMetrics(version, true), {
+      initialProps: { version: "2.10.0" },
+    });
+
+    await waitFor(() => expect(result.current.metrics).not.toBeNull());
+    expect(result.current.metrics).toEqual([
+      { name: "metric.a", description: "d", emittedBy: ["Instr One"] },
+    ]);
+
+    // The effect that reloads for "2.11.0" runs after this render commits, so
+    // without version-tagged state this render would still show 2.10.0's
+    // metrics. It must report null instead of stale data for the old version.
+    rerender({ version: "2.11.0" });
+    expect(result.current.metrics).toBeNull();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(javaagentData.loadAllInstrumentationDetails).toHaveBeenCalledWith("2.11.0");
+  });
+});

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.test.ts
@@ -89,6 +89,34 @@ describe("useAggregateMetrics hook", () => {
     expect(result.current.metrics).toBeNull();
   });
 
+  it("should clear loading when disabled while a request is still in flight", async () => {
+    let resolveLoad!: (data: InstrumentationData[]) => void;
+    vi.mocked(javaagentData.loadAllInstrumentationDetails).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAggregateMetrics("2.10.0", enabled),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Closing the tab before the request resolves must not leave the hook
+    // reporting loading forever.
+    rerender({ enabled: false });
+    expect(result.current.loading).toBe(false);
+
+    // The stale request resolving afterward must not resurrect loading or
+    // apply its result.
+    resolveLoad(releaseData);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metrics).toBeNull();
+  });
+
   it("should not show the previous version's metrics after the version changes", async () => {
     vi.mocked(javaagentData.loadAllInstrumentationDetails).mockResolvedValue(releaseData);
 

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from "react";
+import * as javaagentData from "@/lib/api/javaagent-data";
+import { computeAggregateMetrics, type AggregateMetric } from "../utils/release-diff";
+
+/**
+ * Loads every metric emitted by a release, on demand.
+ *
+ * This is a whole-release rollup, so it needs detail for all ~250 modules —
+ * far more than the comparison itself, which only loads the modules that
+ * changed. Keeping it behind `enabled` means opening the comparison page pays
+ * for the diff alone; the larger load happens only if the reader actually opens
+ * the metrics tab, and by then the changed modules are already cached.
+ *
+ * @param version The release to roll metrics up from
+ * @param enabled Whether to load. Stays idle (and keeps prior results) while false.
+ */
+export function useAggregateMetrics(version: string, enabled: boolean) {
+  // Tagged with the version it was loaded for so a version change is never
+  // shown alongside data loaded for the previous one: React runs this effect
+  // after paint, so the first render after `version` changes would otherwise
+  // repaint with the old `metrics` value for one frame before the fetch below
+  // even starts.
+  const [state, setState] = useState<{ version: string; metrics: AggregateMetric[] } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      if (!enabled || !version) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = await javaagentData.loadAllInstrumentationDetails(version);
+        if (cancelled) return;
+        setState({ version, metrics: computeAggregateMetrics(data) });
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [version, enabled]);
+
+  const metrics = state?.version === version ? state.metrics : null;
+
+  return { metrics, loading, error };
+}

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-aggregate-metrics.ts
@@ -44,7 +44,10 @@ export function useAggregateMetrics(version: string, enabled: boolean) {
     let cancelled = false;
 
     async function load() {
-      if (!enabled || !version) return;
+      if (!enabled || !version) {
+        setLoading(false);
+        return;
+      }
 
       setLoading(true);
       setError(null);

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
@@ -118,6 +118,70 @@ describe("useReleaseComparison hook", () => {
     expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(1);
   });
 
+  it("should not let a stale in-flight request overwrite a newer one's result", async () => {
+    // Two deferred promises so the test controls resolution order directly,
+    // rather than relying on timing.
+    let resolveFirst!: (value: {
+      fromData: unknown[];
+      toData: unknown[];
+      unchangedIds: string[];
+    }) => void;
+    let resolveSecond!: (value: {
+      fromData: unknown[];
+      toData: unknown[];
+      unchangedIds: string[];
+    }) => void;
+    const firstCall = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondCall = new Promise((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    vi.mocked(javaagentData.loadComparisonDetails)
+      .mockImplementationOnce(
+        () => firstCall as ReturnType<typeof javaagentData.loadComparisonDetails>
+      )
+      .mockImplementationOnce(
+        () => secondCall as ReturnType<typeof javaagentData.loadComparisonDetails>
+      );
+
+    vi.mocked(compareReleases).mockImplementation((fromVersion, toVersion) => ({
+      fromVersion,
+      toVersion,
+      instrumentations: [],
+      totals: { added: 0, removed: 0, changed: 0 },
+      aggregateMetrics: [],
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ from, to }) => useReleaseComparison(from, to, validVersions),
+      { initialProps: { from: "1.0.0", to: "2.0.0" } }
+    );
+
+    expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(1);
+
+    // Change the target version before the first request resolves - this is
+    // the scenario the "cancelled" flag exists for. The effect's cleanup
+    // marks the first run stale and a second request starts.
+    rerender({ from: "1.5.0", to: "2.0.0" });
+    expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(2);
+
+    // Resolve the SECOND (current) request first, then the stale first one,
+    // to prove ordering of resolution - not call order - is what could cause
+    // a bug, and that the guard prevents it either way.
+    resolveSecond({ fromData: [], toData: [], unchangedIds: [] });
+    await waitFor(() => expect(result.current.diff?.fromVersion).toBe("1.5.0"));
+
+    resolveFirst({ fromData: [], toData: [], unchangedIds: [] });
+    // Give the stale promise's .then chain a chance to run if it were going
+    // to (it shouldn't, because `cancelled` was set true for that effect run).
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(result.current.diff?.fromVersion).toBe("1.5.0");
+    expect(result.current.loading).toBe(false);
+  });
+
   it("should not load data if fromVersion and toVersion are the same", async () => {
     const { result } = renderHook(() => useReleaseComparison("1.0.0", "1.0.0", validVersions));
 

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
@@ -90,13 +90,15 @@ describe("useReleaseComparison hook", () => {
 
   it("should stay loading until the version list arrives", async () => {
     const { result, rerender } = renderHook(
-      ({ versions }) => useReleaseComparison("1.0.0", "2.0.0", versions),
-      { initialProps: { versions: [] as string[] } }
+      ({ versions, versionsLoading }) =>
+        useReleaseComparison("1.0.0", "2.0.0", versions, versionsLoading),
+      { initialProps: { versions: [] as string[], versionsLoading: true } }
     );
 
     // Comparing before the version list lands would start a full load that the
     // next render throws away, doubling the work on every page open.
     expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
     expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
 
     vi.mocked(javaagentData.loadComparisonDetails).mockResolvedValue({
@@ -112,10 +114,34 @@ describe("useReleaseComparison hook", () => {
       aggregateMetrics: [],
     });
 
-    rerender({ versions: validVersions });
+    rerender({ versions: validVersions, versionsLoading: false });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop loading and surface an error if the version list fails to load", async () => {
+    // A stable empty-array reference, matching how the real caller passes a
+    // memoized `validVersionStrings` - an inline `[]` literal here would be a
+    // new reference every render, re-triggering the effect on every state
+    // update it makes and looping.
+    const noVersions: string[] = [];
+    const { result, rerender } = renderHook(
+      ({ versionsLoading }) => useReleaseComparison("1.0.0", "2.0.0", noVersions, versionsLoading),
+      { initialProps: { versionsLoading: true } }
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    // The version list request finished (or failed) and there is still
+    // nothing valid to compare against - it isn't coming, so this must not
+    // stay stuck in a loading state indefinitely.
+    rerender({ versionsLoading: false });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.diff).toBeNull();
+    expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
   });
 
   it("should not let a stale in-flight request overwrite a newer one's result", async () => {

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.test.ts
@@ -20,7 +20,7 @@ import * as javaagentData from "@/lib/api/javaagent-data";
 import { compareReleases } from "../utils/release-diff";
 
 vi.mock("@/lib/api/javaagent-data", () => ({
-  loadAllInstrumentationDetails: vi.fn(),
+  loadComparisonDetails: vi.fn(),
 }));
 
 vi.mock("../utils/release-diff", () => ({
@@ -35,7 +35,11 @@ describe("useReleaseComparison hook", () => {
   const validVersions = ["2.0.0", "1.5.0", "1.0.0"];
 
   it("should handle valid ordered version comparisons", async () => {
-    vi.mocked(javaagentData.loadAllInstrumentationDetails).mockResolvedValue([]);
+    vi.mocked(javaagentData.loadComparisonDetails).mockResolvedValue({
+      fromData: [],
+      toData: [],
+      unchangedIds: [],
+    });
     vi.mocked(compareReleases).mockReturnValue({
       fromVersion: "1.0.0",
       toVersion: "2.0.0",
@@ -53,8 +57,65 @@ describe("useReleaseComparison hook", () => {
     });
 
     expect(result.current.diff).toBeTruthy();
-    expect(javaagentData.loadAllInstrumentationDetails).toHaveBeenCalledTimes(2);
+    // One call for the pair, not one per version: the loader diffs the two
+    // manifests itself so it can skip modules that cannot have changed.
+    expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(1);
+    expect(javaagentData.loadComparisonDetails).toHaveBeenCalledWith("1.0.0", "2.0.0");
     expect(compareReleases).toHaveBeenCalled();
+  });
+
+  it("should skip the release-wide metric rollup", async () => {
+    vi.mocked(javaagentData.loadComparisonDetails).mockResolvedValue({
+      fromData: [],
+      toData: [],
+      unchangedIds: [],
+    });
+    vi.mocked(compareReleases).mockReturnValue({
+      fromVersion: "1.0.0",
+      toVersion: "2.0.0",
+      instrumentations: [],
+      totals: { added: 0, removed: 0, changed: 0 },
+      aggregateMetrics: [],
+    });
+
+    const { result } = renderHook(() => useReleaseComparison("1.0.0", "2.0.0", validVersions));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The comparison only loads changed modules, which is too little data to
+    // roll up release-wide metrics — that tab loads its own data on demand.
+    expect(compareReleases).toHaveBeenCalledWith("1.0.0", "2.0.0", [], [], {
+      includeAggregateMetrics: false,
+    });
+  });
+
+  it("should stay loading until the version list arrives", async () => {
+    const { result, rerender } = renderHook(
+      ({ versions }) => useReleaseComparison("1.0.0", "2.0.0", versions),
+      { initialProps: { versions: [] as string[] } }
+    );
+
+    // Comparing before the version list lands would start a full load that the
+    // next render throws away, doubling the work on every page open.
+    expect(result.current.loading).toBe(true);
+    expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
+
+    vi.mocked(javaagentData.loadComparisonDetails).mockResolvedValue({
+      fromData: [],
+      toData: [],
+      unchangedIds: [],
+    });
+    vi.mocked(compareReleases).mockReturnValue({
+      fromVersion: "1.0.0",
+      toVersion: "2.0.0",
+      instrumentations: [],
+      totals: { added: 0, removed: 0, changed: 0 },
+      aggregateMetrics: [],
+    });
+
+    rerender({ versions: validVersions });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(javaagentData.loadComparisonDetails).toHaveBeenCalledTimes(1);
   });
 
   it("should not load data if fromVersion and toVersion are the same", async () => {
@@ -62,7 +123,7 @@ describe("useReleaseComparison hook", () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.diff).toBeNull();
-    expect(javaagentData.loadAllInstrumentationDetails).not.toHaveBeenCalled();
+    expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
   });
 
   it("should not load data for invalid or non-existent versions", async () => {
@@ -70,7 +131,7 @@ describe("useReleaseComparison hook", () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.diff).toBeNull();
-    expect(javaagentData.loadAllInstrumentationDetails).not.toHaveBeenCalled();
+    expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
   });
 
   it("should not load data if versions are out of order (from > to)", async () => {
@@ -78,6 +139,6 @@ describe("useReleaseComparison hook", () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.diff).toBeNull();
-    expect(javaagentData.loadAllInstrumentationDetails).not.toHaveBeenCalled();
+    expect(javaagentData.loadComparisonDetails).not.toHaveBeenCalled();
   });
 });

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.ts
@@ -32,12 +32,16 @@ import { compareReleases, type ReleaseDiff } from "../utils/release-diff";
  *   idle rather than comparing against an unvalidated pair — the version list
  *   arrives a moment after first render, and starting early would throw the
  *   whole comparison away when it lands.
+ * @param versionsLoading Whether the version list itself is still being fetched.
+ *   Distinguishes "not arrived yet" (keep waiting) from "finished loading and
+ *   still empty" (the fetch failed — stop waiting, since it isn't coming).
  * @returns An object containing the diff results, loading state, and any error encountered
  */
 export function useReleaseComparison(
   fromVersion: string,
   toVersion: string,
-  validVersions: string[] = []
+  validVersions: string[] = [],
+  versionsLoading: boolean = false
 ) {
   const [diff, setDiff] = useState<ReleaseDiff | null>(null);
   const [loading, setLoading] = useState(false);
@@ -65,8 +69,17 @@ export function useReleaseComparison(
       // the very next render discards, doubling the work on every page open.
       if (validVersions.length === 0) {
         setDiff(null);
-        setLoading(true);
-        setError(null);
+        if (versionsLoading) {
+          // Genuinely still waiting on the version list - keep spinning.
+          setLoading(true);
+          setError(null);
+        } else {
+          // The version list finished loading (or failed) and is still
+          // empty, so it isn't coming - stop waiting instead of spinning
+          // forever on a request that will never resolve.
+          setLoading(false);
+          setError(new Error("Failed to load the list of available versions."));
+        }
         return;
       }
 
@@ -114,7 +127,7 @@ export function useReleaseComparison(
     return () => {
       cancelled = true;
     };
-  }, [fromVersion, toVersion, validVersions]);
+  }, [fromVersion, toVersion, validVersions, versionsLoading]);
 
   return { diff, loading, error };
 }

--- a/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.ts
+++ b/ecosystem-explorer/src/features/java-agent/hooks/use-release-comparison.ts
@@ -21,8 +21,17 @@ import { compareReleases, type ReleaseDiff } from "../utils/release-diff";
 /**
  * Custom hook to fetch instrumentation data for two Java Agent versions and compute the difference.
  *
+ * Loads only the modules whose content hash differs between the two versions
+ * (see `loadComparisonDetails`), so `diff.aggregateMetrics` is intentionally
+ * empty — the "all metrics" table is a whole-release rollup and is loaded
+ * separately by `useAggregateMetrics` when that tab is opened.
+ *
  * @param fromVersion The base version for comparison
  * @param toVersion The target version for comparison
+ * @param validVersions Known versions, newest first. While empty the hook stays
+ *   idle rather than comparing against an unvalidated pair — the version list
+ *   arrives a moment after first render, and starting early would throw the
+ *   whole comparison away when it lands.
  * @returns An object containing the diff results, loading state, and any error encountered
  */
 export function useReleaseComparison(
@@ -51,15 +60,23 @@ export function useReleaseComparison(
         return;
       }
 
-      if (validVersions.length > 0) {
-        const fromIndex = validVersions.indexOf(fromVersion);
-        const toIndex = validVersions.indexOf(toVersion);
-        if (fromIndex === -1 || toIndex === -1 || fromIndex <= toIndex) {
-          setDiff(null);
-          setLoading(false);
-          setError(null);
-          return;
-        }
+      // Stay idle until the version list is known. It lands one request after
+      // first render; comparing before it arrives would start a full load that
+      // the very next render discards, doubling the work on every page open.
+      if (validVersions.length === 0) {
+        setDiff(null);
+        setLoading(true);
+        setError(null);
+        return;
+      }
+
+      const fromIndex = validVersions.indexOf(fromVersion);
+      const toIndex = validVersions.indexOf(toVersion);
+      if (fromIndex === -1 || toIndex === -1 || fromIndex <= toIndex) {
+        setDiff(null);
+        setLoading(false);
+        setError(null);
+        return;
       }
 
       setLoading(true);
@@ -67,10 +84,10 @@ export function useReleaseComparison(
       setDiff(null); // Clear previous diff to avoid showing stale data
 
       try {
-        const [fromData, toData] = await Promise.all([
-          javaagentData.loadAllInstrumentationDetails(fromVersion),
-          javaagentData.loadAllInstrumentationDetails(toVersion),
-        ]);
+        const { fromData, toData } = await javaagentData.loadComparisonDetails(
+          fromVersion,
+          toVersion
+        );
 
         if (cancelled) return;
 
@@ -78,7 +95,9 @@ export function useReleaseComparison(
           throw new Error("Failed to load instrumentation data for one or both versions.");
         }
 
-        const result = compareReleases(fromVersion, toVersion, fromData, toData);
+        const result = compareReleases(fromVersion, toVersion, fromData, toData, {
+          includeAggregateMetrics: false,
+        });
         setDiff(result);
         setLoading(false);
       } catch (err) {

--- a/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
@@ -23,6 +23,7 @@ import { Seo } from "@/components/seo/seo";
 import { BackButton } from "@/components/ui/back-button";
 import { useVersions } from "@/hooks/use-javaagent-data";
 import { useReleaseComparison } from "./hooks/use-release-comparison";
+import { useAggregateMetrics } from "./hooks/use-aggregate-metrics";
 import { ReleaseVersionSelector } from "./components/release-comparison/release-version-selector";
 import { InstrumentationDiffCard } from "./components/release-comparison/instrumentation-diff-card";
 import { GlowBadge } from "@/components/ui/glow-badge";
@@ -60,6 +61,14 @@ export function JavaReleaseComparisonPage() {
     loading: diffLoading,
     error,
   } = useReleaseComparison(fromVersion, toVersion, validVersionStrings);
+
+  // The metrics tab is a whole-release rollup and costs far more to load than
+  // the diff, so it stays unloaded until the reader opens that tab.
+  const {
+    metrics: aggregateMetrics,
+    loading: metricsLoading,
+    error: metricsError,
+  } = useAggregateMetrics(toVersion, activeTab === "metrics" && !!diff);
 
   const handleFromVersionChange = (version: string) => {
     setSearchParams({ from: version, to: toVersion });
@@ -335,57 +344,81 @@ export function JavaReleaseComparisonPage() {
                     </h2>
                     <div className="bg-muted/50 text-foreground/70 rounded-full px-4 py-1 text-xs font-bold">
                       {t("releaseComparison.totalMetrics", {
-                        count: diff.aggregateMetrics.length,
+                        count: aggregateMetrics?.length ?? 0,
                         version: toVersion,
                       })}
                     </div>
                   </div>
 
-                  <div className="border-border/30 overflow-hidden rounded-2xl border">
-                    <table className="w-full border-collapse text-left">
-                      <thead>
-                        <tr className="bg-muted/30 border-border/30 border-b">
-                          <th className="p-4 text-xs font-bold tracking-widest uppercase">
-                            {t("releaseComparison.metricName")}
-                          </th>
-                          <th className="p-4 text-xs font-bold tracking-widest uppercase">
-                            {t("releaseComparison.metricDescription")}
-                          </th>
-                          <th className="p-4 text-xs font-bold tracking-widest uppercase">
-                            {t("releaseComparison.emittedBy")}
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {diff.aggregateMetrics.map((metric, index) => (
-                          <tr
-                            key={metric.name}
-                            className={`border-border/10 hover:bg-muted/50 border-b transition-colors ${
-                              index % 2 === 1 ? "bg-muted/40" : ""
-                            }`}
-                          >
-                            <td className="p-4">
-                              <code className="text-primary font-mono text-sm font-bold">
-                                {metric.name}
-                              </code>
-                            </td>
-                            <td className="text-muted-foreground p-4 text-sm">
-                              {metric.description}
-                            </td>
-                            <td className="p-4">
-                              <div className="flex flex-wrap gap-2">
-                                {metric.emittedBy.map((instr) => (
-                                  <GlowBadge key={instr} variant="info">
-                                    {instr}
-                                  </GlowBadge>
-                                ))}
-                              </div>
-                            </td>
+                  {metricsLoading && (
+                    <div className="flex min-h-[300px] items-center justify-center">
+                      <div className="flex flex-col items-center gap-4">
+                        <Loader2 className="text-primary h-10 w-10 animate-spin" />
+                        <p className="text-muted-foreground text-sm">
+                          {t("releaseComparison.loadingMetrics", { version: toVersion })}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {metricsError && (
+                    <div className="rounded-lg border border-red-400/30 bg-red-400/10 p-6 text-red-400">
+                      <div className="flex items-center gap-3">
+                        <AlertCircle className="h-5 w-5" />
+                        <p className="font-medium">
+                          {t("releaseComparison.errorLoading", { message: metricsError.message })}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {aggregateMetrics && !metricsLoading && !metricsError && (
+                    <div className="border-border/30 overflow-hidden rounded-2xl border">
+                      <table className="w-full border-collapse text-left">
+                        <thead>
+                          <tr className="bg-muted/30 border-border/30 border-b">
+                            <th className="p-4 text-xs font-bold tracking-widest uppercase">
+                              {t("releaseComparison.metricName")}
+                            </th>
+                            <th className="p-4 text-xs font-bold tracking-widest uppercase">
+                              {t("releaseComparison.metricDescription")}
+                            </th>
+                            <th className="p-4 text-xs font-bold tracking-widest uppercase">
+                              {t("releaseComparison.emittedBy")}
+                            </th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {aggregateMetrics.map((metric, index) => (
+                            <tr
+                              key={metric.name}
+                              className={`border-border/10 hover:bg-muted/50 border-b transition-colors ${
+                                index % 2 === 1 ? "bg-muted/40" : ""
+                              }`}
+                            >
+                              <td className="p-4">
+                                <code className="text-primary font-mono text-sm font-bold">
+                                  {metric.name}
+                                </code>
+                              </td>
+                              <td className="text-muted-foreground p-4 text-sm">
+                                {metric.description}
+                              </td>
+                              <td className="p-4">
+                                <div className="flex flex-wrap gap-2">
+                                  {metric.emittedBy.map((instr) => (
+                                    <GlowBadge key={instr} variant="info">
+                                      {instr}
+                                    </GlowBadge>
+                                  ))}
+                                </div>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
+++ b/ecosystem-explorer/src/features/java-agent/java-release-comparison-page.tsx
@@ -60,7 +60,7 @@ export function JavaReleaseComparisonPage() {
     diff,
     loading: diffLoading,
     error,
-  } = useReleaseComparison(fromVersion, toVersion, validVersionStrings);
+  } = useReleaseComparison(fromVersion, toVersion, validVersionStrings, versionsLoading);
 
   // The metrics tab is a whole-release rollup and costs far more to load than
   // the diff, so it stays unloaded until the reader opens that tab.
@@ -366,7 +366,9 @@ export function JavaReleaseComparisonPage() {
                       <div className="flex items-center gap-3">
                         <AlertCircle className="h-5 w-5" />
                         <p className="font-medium">
-                          {t("releaseComparison.errorLoading", { message: metricsError.message })}
+                          {t("releaseComparison.errorLoadingMetrics", {
+                            message: metricsError.message,
+                          })}
                         </p>
                       </div>
                     </div>

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compareReleases } from "./release-diff";
+import { compareReleases, computeAggregateMetrics } from "./release-diff";
 import type { InstrumentationData, Metric } from "@/types/javaagent";
 
 describe("release-diff utility", () => {
@@ -161,6 +161,95 @@ describe("release-diff utility", () => {
     expect(diff.aggregateMetrics.length).toBe(2);
     expect(diff.aggregateMetrics.map((m) => m.name)).toEqual(["metric1", "metric2"]);
     expect(diff.aggregateMetrics[0].emittedBy).toEqual(["instr1 Display"]);
+
+    // computeAggregateMetrics is the same rollup, callable without a diff so the
+    // metrics tab can build it from a full version load on demand.
+    expect(computeAggregateMetrics(toData)).toEqual(diff.aggregateMetrics);
+  });
+
+  it("should omit aggregate metrics when the caller opts out", () => {
+    const toData: InstrumentationData[] = [
+      {
+        name: "instr1",
+        display_name: "instr1 Display",
+        scope: { name: "test" },
+        telemetry: [
+          {
+            when: "default",
+            metrics: [
+              {
+                name: "metric1",
+                description: "d1",
+                instrument: "counter",
+                data_type: "COUNTER",
+                unit: "1",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // The comparison path passes only the changed subset of a release, which
+    // cannot produce a correct release-wide rollup, so it opts out.
+    const diff = compareReleases("1.0.0", "1.1.0", [], toData, {
+      includeAggregateMetrics: false,
+    });
+
+    expect(diff.aggregateMetrics).toEqual([]);
+    expect(diff.instrumentations).toHaveLength(1);
+    expect(diff.totals.added).toBe(1);
+  });
+
+  it("should produce the same diff whether or not unchanged modules are passed in", () => {
+    // The loader skips modules with an identical content hash. This pins the
+    // property that makes that safe: dropping a module that is present and
+    // identical on both sides changes nothing except the metric rollup.
+    const unchanged: InstrumentationData = {
+      name: "steady",
+      display_name: "Steady",
+      scope: { name: "test" },
+      telemetry: [
+        {
+          when: "default",
+          metrics: [
+            {
+              name: "steady.metric",
+              description: "d",
+              instrument: "counter",
+              data_type: "COUNTER",
+              unit: "1",
+            },
+          ],
+        },
+      ],
+    };
+    const changedFrom: InstrumentationData = {
+      name: "shifty",
+      display_name: "Shifty",
+      scope: { name: "test" },
+      configurations: [{ name: "opt", description: "before", type: "boolean", default: "false" }],
+    };
+    const changedTo: InstrumentationData = {
+      ...changedFrom,
+      configurations: [{ name: "opt", description: "after", type: "boolean", default: "false" }],
+    };
+
+    const withUnchanged = compareReleases(
+      "1.0.0",
+      "1.1.0",
+      [unchanged, changedFrom],
+      [unchanged, changedTo],
+      { includeAggregateMetrics: false }
+    );
+    const withoutUnchanged = compareReleases("1.0.0", "1.1.0", [changedFrom], [changedTo], {
+      includeAggregateMetrics: false,
+    });
+
+    expect(withUnchanged.totals).toEqual(withoutUnchanged.totals);
+    expect(withUnchanged.instrumentations.filter((i) => i.status !== "unchanged")).toEqual(
+      withoutUnchanged.instrumentations.filter((i) => i.status !== "unchanged")
+    );
   });
 
   it("should detect configuration changes in declarative_name and example", () => {

--- a/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
+++ b/ecosystem-explorer/src/features/java-agent/utils/release-diff.ts
@@ -137,11 +137,7 @@ export interface ReleaseDiff {
   fromVersion: string;
   toVersion: string;
   instrumentations: InstrumentationDiff[];
-  aggregateMetrics: {
-    name: string;
-    description: string;
-    emittedBy: string[];
-  }[];
+  aggregateMetrics: AggregateMetric[];
   totals: {
     added: number;
     removed: number;
@@ -149,9 +145,67 @@ export interface ReleaseDiff {
   };
 }
 
+export interface AggregateMetric {
+  name: string;
+  description: string;
+  emittedBy: string[];
+}
+
+/**
+ * Rolls every metric emitted by a release up into a single name-keyed table.
+ *
+ * Split out of `compareReleases` so the "all metrics" tab can compute it from a
+ * full version load on demand: the comparison itself only loads the modules
+ * that changed, which is not enough data to build this table.
+ */
+export function computeAggregateMetrics(data: InstrumentationData[] = []): AggregateMetric[] {
+  const metricToInstrumentations = new Map<string, { description: string; emittedBy: string[] }>();
+  for (const instr of data) {
+    if (!instr.telemetry) continue;
+    for (const telemetry of instr.telemetry) {
+      if (!telemetry.metrics) continue;
+      for (const metric of telemetry.metrics) {
+        const existing = metricToInstrumentations.get(metric.name) || {
+          description: metric.description,
+          emittedBy: [],
+        };
+        const label = instr.display_name || instr.name;
+        if (!existing.emittedBy.includes(label)) {
+          existing.emittedBy.push(label);
+        }
+        metricToInstrumentations.set(metric.name, existing);
+      }
+    }
+  }
+
+  return Array.from(metricToInstrumentations.entries())
+    .map(([name, entry]) => ({
+      name,
+      description: entry.description,
+      emittedBy: entry.emittedBy.sort(),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export interface CompareReleasesOptions {
+  /**
+   * Set false when `toData` holds only the changed subset of a release, which
+   * is too little data to roll up a release-wide metric table. Callers that opt
+   * out get an empty `aggregateMetrics` and are expected to fill it in
+   * separately via `computeAggregateMetrics`.
+   */
+  includeAggregateMetrics?: boolean;
+}
+
 /**
  * Compares two Java Agent releases to identify added, removed, and changed instrumentation modules.
  * It also computes aggregate metrics for the target release.
+ *
+ * Passing only the modules that differ between the two releases yields the same
+ * `instrumentations` entries and `totals` as passing both releases in full:
+ * a module present in both sides unchanged contributes an "unchanged" entry and
+ * counts toward none of the totals. `aggregateMetrics` is the exception — see
+ * `CompareReleasesOptions.includeAggregateMetrics`.
  *
  * @param fromVersion The base version for comparison
  * @param toVersion The target version for comparison
@@ -163,7 +217,8 @@ export function compareReleases(
   fromVersion: string,
   toVersion: string,
   fromData: InstrumentationData[] = [],
-  toData: InstrumentationData[] = []
+  toData: InstrumentationData[] = [],
+  options: CompareReleasesOptions = {}
 ): ReleaseDiff {
   const safeFromData = fromData || [];
   const safeToData = toData || [];
@@ -301,33 +356,8 @@ export function compareReleases(
     }
   }
 
-  const metricToInstrumentations = new Map<string, { description: string; emittedBy: string[] }>();
-  for (const instr of safeToData) {
-    if (instr.telemetry) {
-      for (const telemetry of instr.telemetry) {
-        if (telemetry.metrics) {
-          for (const metric of telemetry.metrics) {
-            const existing = metricToInstrumentations.get(metric.name) || {
-              description: metric.description,
-              emittedBy: [],
-            };
-            if (!existing.emittedBy.includes(instr.display_name || instr.name)) {
-              existing.emittedBy.push(instr.display_name || instr.name);
-            }
-            metricToInstrumentations.set(metric.name, existing);
-          }
-        }
-      }
-    }
-  }
-
-  const aggregateMetrics = Array.from(metricToInstrumentations.entries())
-    .map(([name, data]) => ({
-      name,
-      description: data.description,
-      emittedBy: data.emittedBy.sort(),
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const aggregateMetrics =
+    options.includeAggregateMetrics === false ? [] : computeAggregateMetrics(safeToData);
 
   return {
     fromVersion,

--- a/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
@@ -544,6 +544,24 @@ describe("javaagent-data", () => {
       expect(result.toData.map((d) => d.name)).toContain("shared");
     });
 
+    it("should treat a module that moves between custom and library as changed", async () => {
+      // Reverse direction of the library->custom move above: same content
+      // hash, but the module was custom in the "from" version and moved to
+      // library in the "to" version.
+      const customFromManifest: VersionManifest = {
+        version: "2.9.0",
+        instrumentations: {},
+        custom_instrumentations: { shared: "same111" },
+      };
+      mockCache({ "manifest-2.9.0": customFromManifest });
+
+      const result = await javaagentData.loadComparisonDetails("2.9.0", "2.10.0");
+
+      expect(result.unchangedIds).not.toContain("shared");
+      expect(result.fromData.map((d) => d.name)).toContain("shared");
+      expect(result.toData.map((d) => d.name)).toContain("shared");
+    });
+
     it("should skip every module when both versions are identical", async () => {
       mockCache({ "manifest-2.10.0": { ...fromManifest, version: "2.10.0" } });
 

--- a/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.test.ts
@@ -471,6 +471,90 @@ describe("javaagent-data", () => {
     });
   });
 
+  describe("loadComparisonDetails", () => {
+    // "shared" keeps the same hash across both versions, so it is byte-identical
+    // and must never be fetched. "moved" changes, "gone"/"fresh" are one-sided.
+    const fromManifest: VersionManifest = {
+      version: "2.9.0",
+      instrumentations: { shared: "same111", moved: "old222", gone: "old333" },
+    };
+    const toManifest: VersionManifest = {
+      version: "2.10.0",
+      instrumentations: { shared: "same111", moved: "new222", fresh: "new444" },
+    };
+
+    const detailFor = (name: string): InstrumentationData => ({
+      ...mockInstrumentationData,
+      name,
+      scope: { name: `io.opentelemetry.${name}` },
+    });
+
+    function mockCache(overrides: Record<string, unknown> = {}) {
+      return vi.spyOn(idbCache, "getCached").mockImplementation(async (key: string) => {
+        const table: Record<string, unknown> = {
+          "manifest-2.9.0": fromManifest,
+          "manifest-2.10.0": toManifest,
+          "instrumentation-same111": detailFor("shared"),
+          "instrumentation-old222": detailFor("moved"),
+          "instrumentation-new222": detailFor("moved"),
+          "instrumentation-old333": detailFor("gone"),
+          "instrumentation-new444": detailFor("fresh"),
+          ...overrides,
+        };
+        return (table[key] ?? null) as never;
+      });
+    }
+
+    it("should skip modules whose content hash is identical in both versions", async () => {
+      const getCachedSpy = mockCache();
+
+      const result = await javaagentData.loadComparisonDetails("2.9.0", "2.10.0");
+
+      expect(result.unchangedIds).toEqual(["shared"]);
+      // The identical file is never requested from either side.
+      const sharedReads = getCachedSpy.mock.calls.filter(
+        (call) => call[0] === "instrumentation-same111"
+      );
+      expect(sharedReads).toHaveLength(0);
+    });
+
+    it("should return changed and one-sided modules split by side", async () => {
+      mockCache();
+
+      const result = await javaagentData.loadComparisonDetails("2.9.0", "2.10.0");
+
+      expect(result.fromData.map((d) => d.name).sort()).toEqual(["gone", "moved"]);
+      expect(result.toData.map((d) => d.name).sort()).toEqual(["fresh", "moved"]);
+    });
+
+    it("should treat a module that moves between library and custom as changed", async () => {
+      // Same content hash, different manifest section: the detail file is
+      // identical but the module's custom-ness flipped, so it must be loaded.
+      const customToManifest: VersionManifest = {
+        version: "2.10.0",
+        instrumentations: {},
+        custom_instrumentations: { shared: "same111" },
+      };
+      mockCache({ "manifest-2.10.0": customToManifest });
+
+      const result = await javaagentData.loadComparisonDetails("2.9.0", "2.10.0");
+
+      expect(result.unchangedIds).not.toContain("shared");
+      expect(result.fromData.map((d) => d.name)).toContain("shared");
+      expect(result.toData.map((d) => d.name)).toContain("shared");
+    });
+
+    it("should skip every module when both versions are identical", async () => {
+      mockCache({ "manifest-2.10.0": { ...fromManifest, version: "2.10.0" } });
+
+      const result = await javaagentData.loadComparisonDetails("2.9.0", "2.10.0");
+
+      expect(result.unchangedIds.sort()).toEqual(["gone", "moved", "shared"]);
+      expect(result.fromData).toEqual([]);
+      expect(result.toData).toEqual([]);
+    });
+  });
+
   describe("loadLibraryReadme", () => {
     it("should load library README markdown", async () => {
       const content = "# My Library README";

--- a/ecosystem-explorer/src/lib/api/javaagent-data.ts
+++ b/ecosystem-explorer/src/lib/api/javaagent-data.ts
@@ -204,6 +204,100 @@ export async function loadAllInstrumentationDetails(
   return entries;
 }
 
+/**
+ * Builds `id -> content identity` for every instrumentation in a manifest.
+ *
+ * The identity folds in which manifest section the id came from: a module that
+ * keeps its content hash while moving between the library and custom sections
+ * has changed in a way callers care about, even though the detail file is
+ * byte-identical.
+ */
+function manifestIdentities(manifest: VersionManifest): Map<string, string> {
+  const identities = new Map<string, string>();
+  for (const [id, hash] of Object.entries(manifest.instrumentations || {})) {
+    identities.set(id, `library:${hash}`);
+  }
+  for (const [id, hash] of Object.entries(manifest.custom_instrumentations || {})) {
+    identities.set(id, `custom:${hash}`);
+  }
+  return identities;
+}
+
+export interface ComparisonDetails {
+  /** Detail for modules that differ between the two versions — the `from` side. */
+  fromData: InstrumentationData[];
+  /** Detail for modules that differ between the two versions — the `to` side. */
+  toData: InstrumentationData[];
+  /** Ids skipped because both manifests point at the identical detail file. */
+  unchangedIds: string[];
+}
+
+/**
+ * Loads the instrumentation detail needed to diff two versions, fetching only
+ * the modules that can actually differ.
+ *
+ * Detail files are content-addressed — the manifest hash is derived from the
+ * file contents — so when both manifests list the same hash for an id, the two
+ * versions resolve to the same file and the module is provably unchanged. Such
+ * modules produce an "unchanged" entry that the comparison UI filters out and
+ * that counts toward none of the totals, so skipping them is unobservable in
+ * the diff. For adjacent releases they are the large majority of the ~250
+ * modules in a version.
+ *
+ * Both sides share one concurrency pool so the bound applies to the comparison
+ * as a whole rather than per version.
+ */
+export async function loadComparisonDetails(
+  fromVersion: string,
+  toVersion: string
+): Promise<ComparisonDetails> {
+  const [fromManifest, toManifest] = await Promise.all([
+    loadVersionManifest(fromVersion),
+    loadVersionManifest(toVersion),
+  ]);
+
+  const fromIdentities = manifestIdentities(fromManifest);
+  const toIdentities = manifestIdentities(toManifest);
+
+  const unchangedIds: string[] = [];
+  const fromIds: string[] = [];
+  const toIds: string[] = [];
+
+  for (const [id, identity] of fromIdentities) {
+    if (toIdentities.get(id) === identity) {
+      unchangedIds.push(id);
+    } else {
+      fromIds.push(id);
+    }
+  }
+  for (const [id, identity] of toIdentities) {
+    if (fromIdentities.get(id) !== identity) {
+      toIds.push(id);
+    }
+  }
+
+  // Tag each request with its side so one shared pool can serve both versions.
+  const requests = [
+    ...fromIds.map((id) => ({ id, version: fromVersion, manifest: fromManifest, side: "from" })),
+    ...toIds.map((id) => ({ id, version: toVersion, manifest: toManifest, side: "to" })),
+  ];
+
+  const loaded = await mapWithConcurrency(
+    requests,
+    MAX_INSTRUMENTATION_FETCH_CONCURRENCY,
+    async (request) => ({
+      side: request.side,
+      data: await loadInstrumentation(request.id, request.version, request.manifest),
+    })
+  );
+
+  return {
+    fromData: loaded.filter((entry) => entry.side === "from").map((entry) => entry.data),
+    toData: loaded.filter((entry) => entry.side === "to").map((entry) => entry.data),
+    unchangedIds,
+  };
+}
+
 export async function loadLibraryReadme(
   libraryName: string,
   markdownHash: string


### PR DESCRIPTION
## What changed

Optimized Java Agent release comparison by avoiding unnecessary work for unchanged modules during release comparisons. Added coverage for custom-to-library and library-to-custom module moves and comparison race conditions.

## Why

Fixes #875

The release comparison previously processed unchanged modules unnecessarily. This change skips unchanged modules while preserving correct behavior for module moves and concurrent comparison scenarios.

## How it was tested

- Ran the existing test suite and added tests covering custom-to-library and library-to-custom module moves and comparison race conditions.
- Verified the release comparison manually at:
  `/java-agent/releases?from=2.28.1&to=2.29.0`
- Verified that the comparison renders successfully and displays the expected module change summary.
- Compared the release comparison on `main` and this branch using the same release versions (`2.28.1` → `2.29.0`).
- On `main`, the comparison made 339 detail requests.
- On this branch, the comparison made 174 detail requests.

### Before
<img width="852" height="102" alt="Screenshot 2026-07-23 at 11 16 40 AM" src="https://github.com/user-attachments/assets/f5420d0c-c5bc-430d-a180-528319fdcf41" />



### After
<img width="874" height="147" alt="Screenshot 2026-07-23 at 11 17 05 AM" src="https://github.com/user-attachments/assets/f1dbe916-b529-4525-a9df-b00d8b0bf94a" />


## Is this a breaking change?

No

## Special notes for your reviewer

The performance optimization skips modules that are unchanged between the selected releases. The added tests cover the edge cases where modules move between custom and library categories and ensure comparison results remain correct under race conditions.

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)