### PR TITLE
Prune unreferenced db items

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -201,6 +201,13 @@ def run_collector_builder(
         db_writer.write_version_list(processed_versions, bundle_hashes)
         db_writer.write_index(latest_components)
 
+        # Incremental runs never overwrite the content-addressed store, so files whose
+        # hash changed this run are left orphaned. Sweep them now that every version index
+        # (the reachability source) is on disk. Skipped after --clean, which already wiped
+        # everything, and run before the stats summary so removals aren't miscounted.
+        if not clean:
+            db_writer.remove_orphans()
+
         db_writer.write_ecosystem_stats(
             {
                 "version_count": len(processed_versions),

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_builder.py
@@ -201,10 +201,9 @@ def run_collector_builder(
         db_writer.write_version_list(processed_versions, bundle_hashes)
         db_writer.write_index(latest_components)
 
-        # Incremental runs never overwrite the content-addressed store, so files whose
-        # hash changed this run are left orphaned. Sweep them now that every version index
-        # (the reachability source) is on disk. Skipped after --clean, which already wiped
-        # everything, and run before the stats summary so removals aren't miscounted.
+        # Incremental runs never overwrite the store, so files whose hash changed are left
+        # orphaned. Sweep them now that every version index (the reachability source) is on
+        # disk. Skipped after --clean, which already wiped everything.
         if not clean:
             db_writer.remove_orphans()
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from semantic_version import Version
 
+from explorer_db_builder import orphan_gc
 from explorer_db_builder.collector_transformer import COMPONENT_TYPES, make_index_component
 from explorer_db_builder.content_hashing import content_hash
 
@@ -86,15 +87,14 @@ class CollectorDatabaseWriter:
         self.total_bytes += len(content.encode("utf-8"))
 
     def _component_file(self, component_id: str, component_hash: str) -> Path:
-        """Compute the content-addressed path for a component (no side effects).
+        """Content-addressed path for a component, without creating its directory (unlike _get_component_path).
 
-        Kept free of directory creation so callers that only need the expected
-        path (e.g. orphan GC) don't materialize empty directories.
+        Lets callers that only need the path (e.g. orphan GC) avoid materializing empty dirs.
         """
         return self.database_dir / "components" / component_id / f"{component_id}-{component_hash}.json"
 
     def _markdown_file(self, component_name: str, markdown_hash: str) -> Path:
-        """Compute the content-addressed path for a component README (no side effects)."""
+        """Content-addressed path for a component README (does not create its directory)."""
         safe_name = self._sanitize_name(component_name)
         return self.database_dir / "markdown" / f"{safe_name}-{markdown_hash}.md"
 
@@ -330,111 +330,16 @@ class CollectorDatabaseWriter:
     def remove_orphans(self) -> int:
         """Delete content-addressed files no longer referenced by any version index.
 
-        The store is append-only on incremental runs: ``write_components``,
-        ``write_version_bundle``, and ``write_markdown`` all skip the write when a
-        file with that hash already exists, and nothing removes old files. So a
-        changed content hash (upstream metadata edit, transform change, README
-        update) leaves the previous file behind forever without a full ``--clean``.
-
-        This walks the on-disk store and deletes any file not referenced by the
-        current index set:
-
-        - ``components/*/*.json`` referenced by the ``components`` map of any
-          ``versions/*-index.json``.
-        - ``markdown/*.md`` referenced (transitively) via the ``markdown_hash``
-          field inside each live component file. Note markdown is keyed by the
-          component's ``name``, not its ``id``.
-        - ``bundles/*.json`` referenced by ``bundle_hash`` in the top-level
-          ``versions-index.json``.
-
-        Corrupt or unreadable index files are skipped with a warning rather than
-        aborting: a GC failure must never fail the build.
-
-        Returns:
-            The number of files deleted.
+        See :func:`explorer_db_builder.orphan_gc.remove_orphans`. Markdown is keyed
+        by the component's ``name``, not its ``id``.
         """
-        versions_dir = self.database_dir / "versions"
-        if not versions_dir.is_dir():
-            return 0
-
-        live_components: set[Path] = set()
-        for index_file in versions_dir.glob("*-index.json"):
-            data = self._read_json(index_file)
-            if data is None:
-                continue
-            for component_id, comp_hash in (data.get("components") or {}).items():
-                live_components.add(self._component_file(component_id, comp_hash))
-
-        # Markdown is reachable only through the markdown_hash stamped inside each
-        # live component file, keyed by the component's name (not its id).
-        live_markdown: set[Path] = set()
-        for path in live_components:
-            data = self._read_json(path)
-            if data is None:
-                continue
-            name = data.get("name")
-            markdown_hash = data.get("markdown_hash")
-            if name and markdown_hash:
-                live_markdown.add(self._markdown_file(name, markdown_hash))
-
-        # Bundle hashes live only in the top-level versions-index.json.
-        live_bundles: set[Path] = set()
-        versions_index = self.database_dir / "versions-index.json"
-        version_list = self._read_json(versions_index) if versions_index.exists() else None
-        if version_list is not None:
-            for entry in version_list.get("versions") or []:
-                bundle_hash = entry.get("bundle_hash")
-                version = entry.get("version")
-                if bundle_hash and version:
-                    live_bundles.add(self.database_dir / "bundles" / f"{version}-{bundle_hash}.json")
-
-        removed = 0
-        removed += self._sweep(self.database_dir / "components", "*/*.json", live_components)
-        removed += self._sweep(self.database_dir / "bundles", "*.json", live_bundles)
-        removed += self._sweep(self.database_dir / "markdown", "*.md", live_markdown)
-
-        # Prune component subdirectories emptied by the sweep above.
-        components_dir = self.database_dir / "components"
-        if components_dir.is_dir():
-            for child in components_dir.iterdir():
-                if child.is_dir() and not any(child.iterdir()):
-                    child.rmdir()
-
-        if removed:
-            logger.info("Removed %d orphaned file(s) from %s", removed, self.database_dir)
-        return removed
-
-    def _read_json(self, path: Path) -> dict[str, Any] | None:
-        """Read and parse a JSON file, returning None (with a warning) on failure.
-
-        Used by orphan GC so a single corrupt/unreadable file can't abort the sweep.
-        """
-        try:
-            with open(path, encoding="utf-8") as f:
-                return json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning("Skipping unreadable file during orphan GC: %s (%s)", path, e)
-            return None
-
-    def _sweep(self, root: Path, pattern: str, live_paths: set[Path]) -> int:
-        """Delete files under ``root`` matching ``pattern`` that aren't in ``live_paths``.
-
-        Returns the number of files deleted.
-        """
-        if not root.is_dir():
-            return 0
-
-        removed = 0
-        for path in root.glob(pattern):
-            if path in live_paths:
-                continue
-            try:
-                path.unlink()
-                removed += 1
-                logger.debug("Removed orphaned file %s", path)
-            except OSError as e:
-                logger.warning("Failed to remove orphaned file %s: %s", path, e)
-        return removed
+        return orphan_gc.remove_orphans(
+            self.database_dir,
+            content_dir="components",
+            index_sections=("components",),
+            content_file=self._component_file,
+            markdown_file=self._markdown_file,
+        )
 
     def clean(self) -> None:
         """Remove the collector database directory and recreate it empty."""

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_database_writer.py
@@ -57,11 +57,9 @@ class CollectorDatabaseWriter:
             callers must check this return value to know whether to stamp
             markdown_hash, rather than assuming success.
         """
-        markdown_dir = self.database_dir / "markdown"
-        markdown_dir.mkdir(parents=True, exist_ok=True)
-
         safe_name = self._sanitize_name(component_name)
-        file_path = markdown_dir / f"{safe_name}-{markdown_hash}.md"
+        file_path = self._markdown_file(component_name, markdown_hash)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
 
         if file_path.exists():
             logger.debug("Markdown for '%s' with hash %s already exists, skipping write", safe_name, markdown_hash)
@@ -87,10 +85,23 @@ class CollectorDatabaseWriter:
         self.files_written += 1
         self.total_bytes += len(content.encode("utf-8"))
 
+    def _component_file(self, component_id: str, component_hash: str) -> Path:
+        """Compute the content-addressed path for a component (no side effects).
+
+        Kept free of directory creation so callers that only need the expected
+        path (e.g. orphan GC) don't materialize empty directories.
+        """
+        return self.database_dir / "components" / component_id / f"{component_id}-{component_hash}.json"
+
+    def _markdown_file(self, component_name: str, markdown_hash: str) -> Path:
+        """Compute the content-addressed path for a component README (no side effects)."""
+        safe_name = self._sanitize_name(component_name)
+        return self.database_dir / "markdown" / f"{safe_name}-{markdown_hash}.md"
+
     def _get_component_path(self, component_id: str, component_hash: str) -> Path:
-        component_dir = self.database_dir / "components" / component_id
-        component_dir.mkdir(parents=True, exist_ok=True)
-        return component_dir / f"{component_id}-{component_hash}.json"
+        file_path = self._component_file(component_id, component_hash)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        return file_path
 
     def write_components(self, components: list[dict[str, Any]]) -> dict[str, str]:
         """Write component data to content-addressed files.
@@ -315,6 +326,115 @@ class CollectorDatabaseWriter:
 
     def get_stats(self) -> dict[str, Any]:
         return {"files_written": self.files_written, "total_bytes": self.total_bytes}
+
+    def remove_orphans(self) -> int:
+        """Delete content-addressed files no longer referenced by any version index.
+
+        The store is append-only on incremental runs: ``write_components``,
+        ``write_version_bundle``, and ``write_markdown`` all skip the write when a
+        file with that hash already exists, and nothing removes old files. So a
+        changed content hash (upstream metadata edit, transform change, README
+        update) leaves the previous file behind forever without a full ``--clean``.
+
+        This walks the on-disk store and deletes any file not referenced by the
+        current index set:
+
+        - ``components/*/*.json`` referenced by the ``components`` map of any
+          ``versions/*-index.json``.
+        - ``markdown/*.md`` referenced (transitively) via the ``markdown_hash``
+          field inside each live component file. Note markdown is keyed by the
+          component's ``name``, not its ``id``.
+        - ``bundles/*.json`` referenced by ``bundle_hash`` in the top-level
+          ``versions-index.json``.
+
+        Corrupt or unreadable index files are skipped with a warning rather than
+        aborting: a GC failure must never fail the build.
+
+        Returns:
+            The number of files deleted.
+        """
+        versions_dir = self.database_dir / "versions"
+        if not versions_dir.is_dir():
+            return 0
+
+        live_components: set[Path] = set()
+        for index_file in versions_dir.glob("*-index.json"):
+            data = self._read_json(index_file)
+            if data is None:
+                continue
+            for component_id, comp_hash in (data.get("components") or {}).items():
+                live_components.add(self._component_file(component_id, comp_hash))
+
+        # Markdown is reachable only through the markdown_hash stamped inside each
+        # live component file, keyed by the component's name (not its id).
+        live_markdown: set[Path] = set()
+        for path in live_components:
+            data = self._read_json(path)
+            if data is None:
+                continue
+            name = data.get("name")
+            markdown_hash = data.get("markdown_hash")
+            if name and markdown_hash:
+                live_markdown.add(self._markdown_file(name, markdown_hash))
+
+        # Bundle hashes live only in the top-level versions-index.json.
+        live_bundles: set[Path] = set()
+        versions_index = self.database_dir / "versions-index.json"
+        version_list = self._read_json(versions_index) if versions_index.exists() else None
+        if version_list is not None:
+            for entry in version_list.get("versions") or []:
+                bundle_hash = entry.get("bundle_hash")
+                version = entry.get("version")
+                if bundle_hash and version:
+                    live_bundles.add(self.database_dir / "bundles" / f"{version}-{bundle_hash}.json")
+
+        removed = 0
+        removed += self._sweep(self.database_dir / "components", "*/*.json", live_components)
+        removed += self._sweep(self.database_dir / "bundles", "*.json", live_bundles)
+        removed += self._sweep(self.database_dir / "markdown", "*.md", live_markdown)
+
+        # Prune component subdirectories emptied by the sweep above.
+        components_dir = self.database_dir / "components"
+        if components_dir.is_dir():
+            for child in components_dir.iterdir():
+                if child.is_dir() and not any(child.iterdir()):
+                    child.rmdir()
+
+        if removed:
+            logger.info("Removed %d orphaned file(s) from %s", removed, self.database_dir)
+        return removed
+
+    def _read_json(self, path: Path) -> dict[str, Any] | None:
+        """Read and parse a JSON file, returning None (with a warning) on failure.
+
+        Used by orphan GC so a single corrupt/unreadable file can't abort the sweep.
+        """
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Skipping unreadable file during orphan GC: %s (%s)", path, e)
+            return None
+
+    def _sweep(self, root: Path, pattern: str, live_paths: set[Path]) -> int:
+        """Delete files under ``root`` matching ``pattern`` that aren't in ``live_paths``.
+
+        Returns the number of files deleted.
+        """
+        if not root.is_dir():
+            return 0
+
+        removed = 0
+        for path in root.glob(pattern):
+            if path in live_paths:
+                continue
+            try:
+                path.unlink()
+                removed += 1
+                logger.debug("Removed orphaned file %s", path)
+            except OSError as e:
+                logger.warning("Failed to remove orphaned file %s: %s", path, e)
+        return removed
 
     def clean(self) -> None:
         """Remove the collector database directory and recreate it empty."""

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from semantic_version import Version
 
+from explorer_db_builder import orphan_gc
 from explorer_db_builder.content_hashing import content_hash
 from explorer_db_builder.instrumentation_transformer import make_index_instrumentation
 
@@ -53,23 +54,15 @@ class DatabaseWriter:
         return re.sub(r"[^a-zA-Z0-9._\-]", "_", name)
 
     def _instrumentation_file(self, library_name: str, library_hash: str) -> Path:
-        """Compute the content-addressed path for a library (no side effects).
+        """Content-addressed path for a library, without creating its directory (unlike _get_file_path).
 
-        Kept free of directory creation so callers that only need the expected
-        path (e.g. orphan GC) don't materialize empty directories.
-
-        Args:
-            library_name: Name of the library/instrumentation
-            library_hash: Content hash of the library data
-
-        Returns:
-            Path to the library JSON file
+        Lets callers that only need the path (e.g. orphan GC) avoid materializing empty dirs.
         """
         safe_name = self._sanitize_name(library_name)
         return self.database_dir / "instrumentations" / safe_name / f"{safe_name}-{library_hash}.json"
 
     def _markdown_file(self, library_name: str, markdown_hash: str) -> Path:
-        """Compute the content-addressed path for a README (no side effects)."""
+        """Content-addressed path for a README (does not create its directory)."""
         safe_name = self._sanitize_name(library_name)
         return self.database_dir / "markdown" / f"{safe_name}-{markdown_hash}.md"
 
@@ -414,113 +407,17 @@ class DatabaseWriter:
     def remove_orphans(self) -> int:
         """Delete content-addressed files no longer referenced by any version index.
 
-        The store is append-only on incremental runs: ``write_libraries``,
-        ``write_version_bundle``, and ``write_markdown`` all skip the write when a
-        file with that hash already exists, and nothing removes old files. So
-        whenever a content hash changes (an upstream metadata edit, a
-        schema/transform change that re-hashes instrumentations, a corrections
-        overlay tweak, or a README update), the previous file lingers forever
-        without a full ``--clean``.
-
-        This walks the on-disk store and deletes any file not referenced by the
-        current index set, keeping incremental runs clean:
-
-        - ``instrumentations/*/*.json`` referenced by the ``instrumentations`` /
-          ``custom_instrumentations`` maps of any ``versions/*-index.json``.
-        - ``markdown/*.md`` referenced (transitively) via the ``markdown_hash``
-          field inside each live instrumentation file.
-        - ``bundles/*.json`` referenced by ``bundle_hash`` in the top-level
-          ``versions-index.json``.
-
-        Corrupt or unreadable index files are skipped with a warning rather than
-        aborting: a GC failure must never fail the build.
-
-        Returns:
-            The number of files deleted.
+        See :func:`explorer_db_builder.orphan_gc.remove_orphans`. Java
+        instrumentations are referenced from two index sections (regular and
+        custom); markdown is keyed by the instrumentation's ``name``.
         """
-        versions_dir = self.database_dir / "versions"
-        if not versions_dir.is_dir():
-            return 0
-
-        live_instrumentations: set[Path] = set()
-        for index_file in versions_dir.glob("*-index.json"):
-            data = self._read_json(index_file)
-            if data is None:
-                continue
-            for section in ("instrumentations", "custom_instrumentations"):
-                for name, library_hash in (data.get(section) or {}).items():
-                    live_instrumentations.add(self._instrumentation_file(name, library_hash))
-
-        # Markdown is reachable only through the markdown_hash stamped inside each
-        # live instrumentation file, so resolve it from the referenced files.
-        live_markdown: set[Path] = set()
-        for path in live_instrumentations:
-            data = self._read_json(path)
-            if data is None:
-                continue
-            name = data.get("name")
-            markdown_hash = data.get("markdown_hash")
-            if name and markdown_hash:
-                live_markdown.add(self._markdown_file(name, markdown_hash))
-
-        # Bundle hashes live only in the top-level versions-index.json.
-        live_bundles: set[Path] = set()
-        versions_index = self.database_dir / "versions-index.json"
-        version_list = self._read_json(versions_index) if versions_index.exists() else None
-        if version_list is not None:
-            for entry in version_list.get("versions") or []:
-                bundle_hash = entry.get("bundle_hash")
-                version = entry.get("version")
-                if bundle_hash and version:
-                    live_bundles.add(self.database_dir / "bundles" / f"{version}-{bundle_hash}.json")
-
-        removed = 0
-        removed += self._sweep(self.database_dir / "instrumentations", "*/*.json", live_instrumentations)
-        removed += self._sweep(self.database_dir / "bundles", "*.json", live_bundles)
-        removed += self._sweep(self.database_dir / "markdown", "*.md", live_markdown)
-
-        # Prune instrumentation subdirectories emptied by the sweep above.
-        instrumentations_dir = self.database_dir / "instrumentations"
-        if instrumentations_dir.is_dir():
-            for child in instrumentations_dir.iterdir():
-                if child.is_dir() and not any(child.iterdir()):
-                    child.rmdir()
-
-        if removed:
-            logger.info("Removed %d orphaned file(s) from %s", removed, self.database_dir)
-        return removed
-
-    def _read_json(self, path: Path) -> dict[str, Any] | None:
-        """Read and parse a JSON file, returning None (with a warning) on failure.
-
-        Used by orphan GC so a single corrupt/unreadable file can't abort the sweep.
-        """
-        try:
-            with open(path, encoding="utf-8") as f:
-                return json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning("Skipping unreadable file during orphan GC: %s (%s)", path, e)
-            return None
-
-    def _sweep(self, root: Path, pattern: str, live_paths: set[Path]) -> int:
-        """Delete files under ``root`` matching ``pattern`` that aren't in ``live_paths``.
-
-        Returns the number of files deleted.
-        """
-        if not root.is_dir():
-            return 0
-
-        removed = 0
-        for path in root.glob(pattern):
-            if path in live_paths:
-                continue
-            try:
-                path.unlink()
-                removed += 1
-                logger.debug("Removed orphaned file %s", path)
-            except OSError as e:
-                logger.warning("Failed to remove orphaned file %s: %s", path, e)
-        return removed
+        return orphan_gc.remove_orphans(
+            self.database_dir,
+            content_dir="instrumentations",
+            index_sections=("instrumentations", "custom_instrumentations"),
+            content_file=self._instrumentation_file,
+            markdown_file=self._markdown_file,
+        )
 
     def clean(self) -> None:
         """Remove all files in the database directory.

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/database_writer.py
@@ -52,6 +52,27 @@ class DatabaseWriter:
         """Sanitizes a name for use as a filename to prevent path traversal."""
         return re.sub(r"[^a-zA-Z0-9._\-]", "_", name)
 
+    def _instrumentation_file(self, library_name: str, library_hash: str) -> Path:
+        """Compute the content-addressed path for a library (no side effects).
+
+        Kept free of directory creation so callers that only need the expected
+        path (e.g. orphan GC) don't materialize empty directories.
+
+        Args:
+            library_name: Name of the library/instrumentation
+            library_hash: Content hash of the library data
+
+        Returns:
+            Path to the library JSON file
+        """
+        safe_name = self._sanitize_name(library_name)
+        return self.database_dir / "instrumentations" / safe_name / f"{safe_name}-{library_hash}.json"
+
+    def _markdown_file(self, library_name: str, markdown_hash: str) -> Path:
+        """Compute the content-addressed path for a README (no side effects)."""
+        safe_name = self._sanitize_name(library_name)
+        return self.database_dir / "markdown" / f"{safe_name}-{markdown_hash}.md"
+
     def _get_file_path(self, library_name: str, library_hash: str) -> Path:
         """Get the file path for a library with the given name and hash.
 
@@ -64,10 +85,9 @@ class DatabaseWriter:
         Returns:
             Path to the library JSON file
         """
-        safe_name = self._sanitize_name(library_name)
-        instrumentations_dir = self.database_dir / "instrumentations" / safe_name
-        instrumentations_dir.mkdir(parents=True, exist_ok=True)
-        return instrumentations_dir / f"{safe_name}-{library_hash}.json"
+        file_path = self._instrumentation_file(library_name, library_hash)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        return file_path
 
     def write_libraries(self, libraries: list[dict[str, Any]]) -> dict[str, str]:
         """Write library data to content-addressed files.
@@ -327,11 +347,9 @@ class DatabaseWriter:
             markdown_hash: Hash of the markdown content
             content: Markdown content string
         """
-        markdown_dir = self.database_dir / "markdown"
-        markdown_dir.mkdir(parents=True, exist_ok=True)
-
         safe_name = self._sanitize_name(library_name)
-        file_path = markdown_dir / f"{safe_name}-{markdown_hash}.md"
+        file_path = self._markdown_file(library_name, markdown_hash)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
 
         if file_path.exists():
             logger.debug(f"Markdown for '{safe_name}' with hash {markdown_hash} already exists, skipping write")
@@ -392,6 +410,117 @@ class DatabaseWriter:
             Dictionary with 'files_written' (int) and 'total_bytes' (int)
         """
         return {"files_written": self.files_written, "total_bytes": self.total_bytes}
+
+    def remove_orphans(self) -> int:
+        """Delete content-addressed files no longer referenced by any version index.
+
+        The store is append-only on incremental runs: ``write_libraries``,
+        ``write_version_bundle``, and ``write_markdown`` all skip the write when a
+        file with that hash already exists, and nothing removes old files. So
+        whenever a content hash changes (an upstream metadata edit, a
+        schema/transform change that re-hashes instrumentations, a corrections
+        overlay tweak, or a README update), the previous file lingers forever
+        without a full ``--clean``.
+
+        This walks the on-disk store and deletes any file not referenced by the
+        current index set, keeping incremental runs clean:
+
+        - ``instrumentations/*/*.json`` referenced by the ``instrumentations`` /
+          ``custom_instrumentations`` maps of any ``versions/*-index.json``.
+        - ``markdown/*.md`` referenced (transitively) via the ``markdown_hash``
+          field inside each live instrumentation file.
+        - ``bundles/*.json`` referenced by ``bundle_hash`` in the top-level
+          ``versions-index.json``.
+
+        Corrupt or unreadable index files are skipped with a warning rather than
+        aborting: a GC failure must never fail the build.
+
+        Returns:
+            The number of files deleted.
+        """
+        versions_dir = self.database_dir / "versions"
+        if not versions_dir.is_dir():
+            return 0
+
+        live_instrumentations: set[Path] = set()
+        for index_file in versions_dir.glob("*-index.json"):
+            data = self._read_json(index_file)
+            if data is None:
+                continue
+            for section in ("instrumentations", "custom_instrumentations"):
+                for name, library_hash in (data.get(section) or {}).items():
+                    live_instrumentations.add(self._instrumentation_file(name, library_hash))
+
+        # Markdown is reachable only through the markdown_hash stamped inside each
+        # live instrumentation file, so resolve it from the referenced files.
+        live_markdown: set[Path] = set()
+        for path in live_instrumentations:
+            data = self._read_json(path)
+            if data is None:
+                continue
+            name = data.get("name")
+            markdown_hash = data.get("markdown_hash")
+            if name and markdown_hash:
+                live_markdown.add(self._markdown_file(name, markdown_hash))
+
+        # Bundle hashes live only in the top-level versions-index.json.
+        live_bundles: set[Path] = set()
+        versions_index = self.database_dir / "versions-index.json"
+        version_list = self._read_json(versions_index) if versions_index.exists() else None
+        if version_list is not None:
+            for entry in version_list.get("versions") or []:
+                bundle_hash = entry.get("bundle_hash")
+                version = entry.get("version")
+                if bundle_hash and version:
+                    live_bundles.add(self.database_dir / "bundles" / f"{version}-{bundle_hash}.json")
+
+        removed = 0
+        removed += self._sweep(self.database_dir / "instrumentations", "*/*.json", live_instrumentations)
+        removed += self._sweep(self.database_dir / "bundles", "*.json", live_bundles)
+        removed += self._sweep(self.database_dir / "markdown", "*.md", live_markdown)
+
+        # Prune instrumentation subdirectories emptied by the sweep above.
+        instrumentations_dir = self.database_dir / "instrumentations"
+        if instrumentations_dir.is_dir():
+            for child in instrumentations_dir.iterdir():
+                if child.is_dir() and not any(child.iterdir()):
+                    child.rmdir()
+
+        if removed:
+            logger.info("Removed %d orphaned file(s) from %s", removed, self.database_dir)
+        return removed
+
+    def _read_json(self, path: Path) -> dict[str, Any] | None:
+        """Read and parse a JSON file, returning None (with a warning) on failure.
+
+        Used by orphan GC so a single corrupt/unreadable file can't abort the sweep.
+        """
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Skipping unreadable file during orphan GC: %s (%s)", path, e)
+            return None
+
+    def _sweep(self, root: Path, pattern: str, live_paths: set[Path]) -> int:
+        """Delete files under ``root`` matching ``pattern`` that aren't in ``live_paths``.
+
+        Returns the number of files deleted.
+        """
+        if not root.is_dir():
+            return 0
+
+        removed = 0
+        for path in root.glob(pattern):
+            if path in live_paths:
+                continue
+            try:
+                path.unlink()
+                removed += 1
+                logger.debug("Removed orphaned file %s", path)
+            except OSError as e:
+                logger.warning("Failed to remove orphaned file %s: %s", path, e)
+        return removed
 
     def clean(self) -> None:
         """Remove all files in the database directory.

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -255,6 +255,13 @@ def run_javaagent_builder(
         db_writer.write_version_list(versions, bundle_hashes)
         db_writer.write_index(latest_instrumentations)
 
+        # Incremental runs never overwrite the content-addressed store, so files whose
+        # hash changed this run are left orphaned. Sweep them now that every version index
+        # (the reachability source) is on disk. Skipped after --clean, which already wiped
+        # everything, and run before the stats summary so removals aren't miscounted.
+        if not clean:
+            db_writer.remove_orphans()
+
         global_configurations = build_global_configurations([backfilled_inventories[v] for v in versions])
         db_writer.write_global_configurations(global_configurations)
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/main.py
@@ -255,10 +255,9 @@ def run_javaagent_builder(
         db_writer.write_version_list(versions, bundle_hashes)
         db_writer.write_index(latest_instrumentations)
 
-        # Incremental runs never overwrite the content-addressed store, so files whose
-        # hash changed this run are left orphaned. Sweep them now that every version index
-        # (the reachability source) is on disk. Skipped after --clean, which already wiped
-        # everything, and run before the stats summary so removals aren't miscounted.
+        # Incremental runs never overwrite the store, so files whose hash changed are left
+        # orphaned. Sweep them now that every version index (the reachability source) is on
+        # disk. Skipped after --clean, which already wiped everything.
         if not clean:
             db_writer.remove_orphans()
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/orphan_gc.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/orphan_gc.py
@@ -1,0 +1,149 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Shared orphan garbage collection for the content-addressed writers.
+
+DatabaseWriter and CollectorDatabaseWriter both keep an append-only,
+content-addressed store and must sweep files no longer referenced by any version
+index. The stores differ only in directory names and how a content file's path is
+derived, so the reachability walk lives here, parameterized by those two things.
+"""
+
+import json
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    """Read and parse a JSON file, returning None (with a warning) on failure.
+
+    Used by orphan GC so a single corrupt/unreadable file can't abort the sweep.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Skipping unreadable file during orphan GC: %s (%s)", path, e)
+        return None
+
+
+def _sweep(root: Path, pattern: str, live_paths: set[Path]) -> int:
+    """Delete files under ``root`` matching ``pattern`` that aren't in ``live_paths``.
+
+    Returns the number of files deleted.
+    """
+    if not root.is_dir():
+        return 0
+
+    removed = 0
+    for path in root.glob(pattern):
+        if path in live_paths:
+            continue
+        try:
+            path.unlink()
+            removed += 1
+            logger.debug("Removed orphaned file %s", path)
+        except OSError as e:
+            logger.warning("Failed to remove orphaned file %s: %s", path, e)
+    return removed
+
+
+def remove_orphans(
+    database_dir: Path,
+    *,
+    content_dir: str,
+    index_sections: tuple[str, ...],
+    content_file: Callable[[str, str], Path],
+    markdown_file: Callable[[str, str], Path],
+) -> int:
+    """Delete content-addressed files no longer referenced by any version index.
+
+    The store is append-only: writers skip a write when a file with that hash
+    already exists, so a changed content hash leaves the old file behind forever
+    without a full ``--clean``. This walks the store and deletes anything not
+    referenced by the current indexes.
+
+    Args:
+        database_dir: Root of the content-addressed store.
+        content_dir: Content subdirectory ("components" / "instrumentations").
+        index_sections: Keys in each ``versions/*-index.json`` whose ``{key: hash}``
+            maps reference live content files.
+        content_file: Maps ``(index key, hash)`` to a content file path.
+        markdown_file: Maps ``(name, markdown_hash)`` to a markdown file path.
+
+    Returns:
+        The number of files deleted.
+    """
+    versions_dir = database_dir / "versions"
+    if not versions_dir.is_dir():
+        return 0
+
+    live_content: set[Path] = set()
+    readable_indexes = 0
+    for index_file in versions_dir.glob("*-index.json"):
+        data = read_json(index_file)
+        if data is None:
+            continue
+        readable_indexes += 1
+        for section in index_sections:
+            for key, item_hash in (data.get(section) or {}).items():
+                live_content.add(content_file(key, item_hash))
+
+    # If no version index was readable, reachability is unknown and an empty
+    # live set would sweep the entire store. Skip GC rather than delete everything.
+    if readable_indexes == 0:
+        logger.warning("Skipping orphan GC: no readable version index found in %s", versions_dir)
+        return 0
+
+    # Markdown is reachable only via markdown_hash inside each live content file.
+    live_markdown: set[Path] = set()
+    for path in live_content:
+        data = read_json(path)
+        if data is None:
+            continue
+        name = data.get("name")
+        markdown_hash = data.get("markdown_hash")
+        if name and markdown_hash:
+            live_markdown.add(markdown_file(name, markdown_hash))
+
+    # Bundle hashes live only in the top-level versions-index.json.
+    live_bundles: set[Path] = set()
+    versions_index = database_dir / "versions-index.json"
+    version_list = read_json(versions_index) if versions_index.exists() else None
+    if version_list is not None:
+        for entry in version_list.get("versions") or []:
+            bundle_hash = entry.get("bundle_hash")
+            version = entry.get("version")
+            if bundle_hash and version:
+                live_bundles.add(database_dir / "bundles" / f"{version}-{bundle_hash}.json")
+
+    removed = 0
+    removed += _sweep(database_dir / content_dir, "*/*.json", live_content)
+    removed += _sweep(database_dir / "bundles", "*.json", live_bundles)
+    removed += _sweep(database_dir / "markdown", "*.md", live_markdown)
+
+    # Prune content subdirectories emptied by the sweep above.
+    content_root = database_dir / content_dir
+    if content_root.is_dir():
+        for child in content_root.iterdir():
+            if child.is_dir() and not any(child.iterdir()):
+                child.rmdir()
+
+    if removed:
+        logger.info("Removed %d orphaned file(s) from %s", removed, database_dir)
+    return removed

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_builder.py
@@ -277,6 +277,45 @@ class TestRunCollectorBuilder:
 
         assert not stale.exists()
 
+    def test_removes_orphans_when_incremental(self):
+        manager = _make_mock_inventory_manager()
+        db_writer = MagicMock()
+        db_writer.write_components.return_value = {"core-nop": "hash1"}
+        db_writer.write_version_bundle.return_value = "bundlehash"
+        db_writer.get_stats.return_value = {"files_written": 1, "total_bytes": 10}
+
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer, clean=False)
+
+        db_writer.remove_orphans.assert_called_once()
+
+    def test_skips_orphan_gc_when_clean(self):
+        manager = _make_mock_inventory_manager()
+        db_writer = MagicMock()
+        db_writer.write_components.return_value = {"core-nop": "hash1"}
+        db_writer.write_version_bundle.return_value = "bundlehash"
+        db_writer.get_stats.return_value = {"files_written": 1, "total_bytes": 10}
+
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer, clean=True)
+
+        db_writer.remove_orphans.assert_not_called()
+
+    def test_orphaned_component_removed_on_incremental_rebuild(self, tmp_path):
+        """End-to-end: a stale component file from a prior run is swept on the next incremental build."""
+        manager = _make_mock_inventory_manager()
+        out_dir = tmp_path / "collector"
+        db_writer = CollectorDatabaseWriter(database_dir=str(out_dir))
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer)
+
+        # Simulate a stale content-addressed file left by an earlier build.
+        stale = out_dir / "components" / "core-nop" / "core-nop-staleoldhash1.json"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text("{}", encoding="utf-8")
+
+        db_writer2 = CollectorDatabaseWriter(database_dir=str(out_dir))
+        run_collector_builder(inventory_manager=manager, db_writer=db_writer2, clean=False)
+
+        assert not stale.exists()
+
     def test_returns_1_on_no_versions(self, tmp_path):
         manager = MagicMock()
         manager.list_release_versions.return_value = []

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
@@ -485,3 +485,15 @@ class TestRemoveOrphans:
 
         assert db_writer.remove_orphans() == 0
         assert "Skipping unreadable file during orphan GC" in caplog.text
+
+    def test_skips_gc_when_no_index_readable(self, db_writer, temp_db_dir, sample_components, caplog):
+        # Store has content on disk but every version index is unreadable, so
+        # reachability is unknown. GC must skip rather than sweep the whole store.
+        component_map = db_writer.write_components(sample_components)
+        (temp_db_dir / "versions").mkdir(exist_ok=True)
+        (temp_db_dir / "versions" / "0.150.0-index.json").write_text("{ not json", encoding="utf-8")
+
+        assert db_writer.remove_orphans() == 0
+        assert "Skipping orphan GC: no readable version index found" in caplog.text
+        first_id = next(iter(component_map))
+        assert db_writer._component_file(first_id, component_map[first_id]).exists()

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_database_writer.py
@@ -390,3 +390,98 @@ class TestWriteMarkdown:
                 mock_logger.error.assert_called()
                 args, _ = mock_logger.error.call_args
                 assert "Failed to write markdown" in args[0]
+
+
+class TestRemoveOrphans:
+    """Tests for the incremental orphan-GC sweep."""
+
+    def test_no_op_when_versions_dir_missing(self, db_writer):
+        assert db_writer.remove_orphans() == 0
+
+    def test_no_op_when_everything_referenced(self, db_writer, sample_components):
+        version = Version("0.150.0")
+        component_map = db_writer.write_components(sample_components)
+        db_writer.write_version_index(version, component_map)
+
+        assert db_writer.remove_orphans() == 0
+
+    def test_removes_rehashed_component(self, db_writer):
+        version = Version("0.150.0")
+        component = {"id": "core-batch", "name": "batchprocessor", "distribution": "core", "type": "processor"}
+        map_a = db_writer.write_components([component])
+        db_writer.write_version_index(version, map_a)
+        # Content changes -> new hash; index rewritten to reference the new file only.
+        map_b = db_writer.write_components([{**component, "description": "now documented"}])
+        db_writer.write_version_index(version, map_b)
+
+        file_a = db_writer._component_file("core-batch", map_a["core-batch"])
+        file_b = db_writer._component_file("core-batch", map_b["core-batch"])
+        assert file_a.exists() and file_b.exists()
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not file_a.exists()
+        assert file_b.exists()
+
+    def test_prunes_emptied_component_dir(self, db_writer, temp_db_dir):
+        version = Version("0.150.0")
+        keep = {"id": "core-keep", "name": "keep", "distribution": "core", "type": "processor"}
+        drop = {"id": "core-drop", "name": "drop", "distribution": "core", "type": "processor"}
+        keep_map = db_writer.write_components([keep])
+        db_writer.write_components([drop])  # written but referenced by no index
+        db_writer.write_version_index(version, keep_map)
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not (temp_db_dir / "components" / "core-drop").exists()
+        assert (temp_db_dir / "components" / "core-keep").exists()
+
+    def test_removes_orphaned_bundle(self, db_writer, temp_db_dir, sample_components):
+        version = Version("0.150.0")
+        component_map = db_writer.write_components(sample_components)
+        db_writer.write_version_index(version, component_map)
+        bundle_hash = db_writer.write_version_bundle(version, sample_components)
+        db_writer.write_version_list([version], {version: bundle_hash})
+
+        orphan = temp_db_dir / "bundles" / "0.150.0-deadbeefcafe.json"
+        orphan.write_text("[]", encoding="utf-8")
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not orphan.exists()
+        assert (temp_db_dir / "bundles" / f"0.150.0-{bundle_hash}.json").exists()
+
+    def test_removes_orphaned_markdown_keyed_by_name(self, db_writer, temp_db_dir):
+        version = Version("0.150.0")
+        live_hash = "livehash1234"
+        orphan_hash = "orphanhash56"
+        # Markdown is keyed by the component's name ("otlpreceiver"), not its id ("contrib-otlp").
+        db_writer.write_markdown("otlpreceiver", live_hash, "# live")
+        db_writer.write_markdown("otlpreceiver", orphan_hash, "# orphan")
+        component = {
+            "id": "contrib-otlp",
+            "name": "otlpreceiver",
+            "distribution": "contrib",
+            "type": "receiver",
+            "markdown_hash": live_hash,
+        }
+        component_map = db_writer.write_components([component])
+        db_writer.write_version_index(version, component_map)
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert (temp_db_dir / "markdown" / f"otlpreceiver-{live_hash}.md").exists()
+        assert not (temp_db_dir / "markdown" / f"otlpreceiver-{orphan_hash}.md").exists()
+
+    def test_skips_unreadable_index(self, db_writer, temp_db_dir, sample_components, caplog):
+        version = Version("0.150.0")
+        component_map = db_writer.write_components(sample_components)
+        db_writer.write_version_index(version, component_map)
+        (temp_db_dir / "versions" / "9.9.9-index.json").write_text("{ not json", encoding="utf-8")
+
+        assert db_writer.remove_orphans() == 0
+        assert "Skipping unreadable file during orphan GC" in caplog.text

--- a/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
@@ -848,3 +848,14 @@ class TestRemoveOrphans:
         assert db_writer.remove_orphans() == 0
         assert "Skipping unreadable file during orphan GC" in caplog.text
         assert db_writer._instrumentation_file("lib1", library_map["lib1"]).exists()
+
+    def test_skips_gc_when_no_index_readable(self, db_writer, temp_db_dir, caplog):
+        # Store has content on disk but every version index is unreadable, so
+        # reachability is unknown. GC must skip rather than sweep the whole store.
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        (temp_db_dir / "versions").mkdir(exist_ok=True)
+        (temp_db_dir / "versions" / "1.0.0-index.json").write_text("{ not json", encoding="utf-8")
+
+        assert db_writer.remove_orphans() == 0
+        assert "Skipping orphan GC: no readable version index found" in caplog.text
+        assert db_writer._instrumentation_file("lib1", library_map["lib1"]).exists()

--- a/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_database_writer.py
@@ -747,3 +747,104 @@ class TestWriteEcosystemStats:
         stats = db_writer.get_stats()
         assert stats["files_written"] == 1
         assert stats["total_bytes"] > 0
+
+
+class TestRemoveOrphans:
+    """Tests for the incremental orphan-GC sweep."""
+
+    def test_no_op_when_versions_dir_missing(self, db_writer):
+        # Nothing has been written yet, so there is no reachability source.
+        assert db_writer.remove_orphans() == 0
+
+    def test_no_op_when_everything_referenced(self, db_writer):
+        version = Version("1.0.0")
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        db_writer.write_version_index(version, library_map)
+
+        assert db_writer.remove_orphans() == 0
+
+    def test_removes_rehashed_instrumentation(self, db_writer):
+        version = Version("2.0.0")
+        # First run: content A, referenced by the version index.
+        map_a = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        db_writer.write_version_index(version, map_a)
+        # Second run: content changed -> content B, index rewritten to reference B only.
+        map_b = db_writer.write_libraries([{"name": "lib1", "version": "2.0"}])
+        db_writer.write_version_index(version, map_b)
+
+        file_a = db_writer._instrumentation_file("lib1", map_a["lib1"])
+        file_b = db_writer._instrumentation_file("lib1", map_b["lib1"])
+        assert file_a.exists() and file_b.exists()
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not file_a.exists()
+        assert file_b.exists()
+
+    def test_keeps_custom_instrumentations(self, db_writer):
+        version = Version("1.0.0")
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        custom_map = db_writer.write_libraries([{"name": "custom1", "version": "1.0"}])
+        db_writer.write_version_index(version, library_map, custom_map)
+
+        assert db_writer.remove_orphans() == 0
+        assert db_writer._instrumentation_file("custom1", custom_map["custom1"]).exists()
+
+    def test_prunes_emptied_instrumentation_dir(self, db_writer, temp_db_dir):
+        version = Version("1.0.0")
+        keep_map = db_writer.write_libraries([{"name": "keep", "version": "1.0"}])
+        # "drop" is written to disk but referenced by no index.
+        db_writer.write_libraries([{"name": "drop", "version": "1.0"}])
+        db_writer.write_version_index(version, keep_map)
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not (temp_db_dir / "instrumentations" / "drop").exists()
+        assert (temp_db_dir / "instrumentations" / "keep").exists()
+
+    def test_removes_orphaned_bundle(self, db_writer, temp_db_dir):
+        version = Version("2.0.0")
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        db_writer.write_version_index(version, library_map)
+        bundle_hash = db_writer.write_version_bundle(version, [{"name": "lib1", "_is_custom": False}])
+        db_writer.write_version_list([version], {version: bundle_hash})
+
+        # A stale bundle from a prior run, referenced by no versions-index entry.
+        orphan = temp_db_dir / "bundles" / "2.0.0-deadbeefcafe.json"
+        orphan.write_text("[]", encoding="utf-8")
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert not orphan.exists()
+        assert (temp_db_dir / "bundles" / f"2.0.0-{bundle_hash}.json").exists()
+
+    def test_removes_orphaned_markdown(self, db_writer, temp_db_dir):
+        version = Version("1.0.0")
+        live_hash = "livehash1234"
+        orphan_hash = "orphanhash56"
+        db_writer.write_markdown("lib1", live_hash, "# live")
+        db_writer.write_markdown("lib1", orphan_hash, "# orphan")
+        # The live instrumentation carries markdown_hash, making the live README reachable.
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0", "markdown_hash": live_hash}])
+        db_writer.write_version_index(version, library_map)
+
+        removed = db_writer.remove_orphans()
+
+        assert removed == 1
+        assert (temp_db_dir / "markdown" / f"lib1-{live_hash}.md").exists()
+        assert not (temp_db_dir / "markdown" / f"lib1-{orphan_hash}.md").exists()
+
+    def test_skips_unreadable_index(self, db_writer, temp_db_dir, caplog):
+        version = Version("1.0.0")
+        library_map = db_writer.write_libraries([{"name": "lib1", "version": "1.0"}])
+        db_writer.write_version_index(version, library_map)
+        # A corrupt sibling index must not abort the sweep.
+        (temp_db_dir / "versions" / "9.9.9-index.json").write_text("{ not json", encoding="utf-8")
+
+        # lib1 is still referenced by the valid index, so nothing is removed.
+        assert db_writer.remove_orphans() == 0
+        assert "Skipping unreadable file during orphan GC" in caplog.text
+        assert db_writer._instrumentation_file("lib1", library_map["lib1"]).exists()

--- a/ecosystem-automation/explorer-db-builder/tests/test_main.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_main.py
@@ -399,6 +399,30 @@ class TestRunJavaagentBuilder:
         assert call_order[0] == "clean"
         assert call_order[1] == "list_versions"
 
+    def test_run_builder_removes_orphans_when_incremental(self, mock_inventory_manager, mock_db_writer):
+        versions = [Version("1.0.0")]
+        inventory_data = {"file_format": 0.2, "libraries": [{"name": "lib1"}]}
+
+        mock_inventory_manager.list_versions.return_value = versions
+        mock_inventory_manager.load_versioned_inventory.return_value = inventory_data
+        mock_db_writer.write_libraries.return_value = {"lib1": "hash1"}
+
+        run_javaagent_builder(mock_inventory_manager, mock_db_writer, clean=False)
+
+        mock_db_writer.remove_orphans.assert_called_once()
+
+    def test_run_builder_skips_orphan_gc_when_clean(self, mock_inventory_manager, mock_db_writer):
+        versions = [Version("1.0.0")]
+        inventory_data = {"file_format": 0.2, "libraries": [{"name": "lib1"}]}
+
+        mock_inventory_manager.list_versions.return_value = versions
+        mock_inventory_manager.load_versioned_inventory.return_value = inventory_data
+        mock_db_writer.write_libraries.return_value = {"lib1": "hash1"}
+
+        run_javaagent_builder(mock_inventory_manager, mock_db_writer, clean=True)
+
+        mock_db_writer.remove_orphans.assert_not_called()
+
     def test_aggregates_global_configurations(self, tmp_path):
         """run_javaagent_builder writes global-configurations.json with newest-version-wins."""
         inventory_manager = MagicMock()


### PR DESCRIPTION
When we run the db-builder, sometimes we backfill values, which changes hashes. We didn't have anything that was cleaning up the old ones, so this adds a garbage collection scan for unreferenced files and deletes them.