### PR TITLE
fix(collector): render backtick-wrapped description text as code

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
@@ -69,6 +69,11 @@ const mockComponentWithReadme: CollectorComponent = {
   markdown_hash: "abc123def456",
 };
 
+const mockComponentWithBacktickDescription: CollectorComponent = {
+  ...mockComponentWithoutTelemetry,
+  description: "Fetches metrics via the `/metrics/json` endpoint.",
+};
+
 function renderAtRoute(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
@@ -150,6 +155,23 @@ describe("CollectorDetailPage", () => {
     expect(
       screen.queryByRole("heading", { name: "Error loading component" })
     ).not.toBeInTheDocument();
+  });
+
+  it("renders backtick-wrapped text in the description as code elements", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithBacktickDescription,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.getByText("/metrics/json").tagName).toBe("CODE");
   });
 
   it("preserves the existing error UI when the component fetch itself fails with a valid version", () => {

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -28,6 +28,7 @@ import { SectionHeader } from "@/components/ui/section-header";
 import { PageContainer } from "@/components/layout/page-container";
 import { Seo } from "@/components/seo/seo";
 import { deriveCollectorMeta } from "@/lib/seo/derive";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 import { useCollectorComponent, useCollectorVersions } from "@/hooks/use-collector-data";
 import { CollectorTelemetryTab } from "./components/collector-telemetry-tab";
 import { CollectorReadmeTab } from "./components/collector-readme-tab";
@@ -216,7 +217,7 @@ export function CollectorDetailPage() {
 
             {component.description && (
               <p className="text-muted-foreground max-w-4xl text-base leading-relaxed">
-                {component.description}
+                {renderWithInlineCode(component.description)}
               </p>
             )}
           </div>


### PR DESCRIPTION
## What changed

collector component descriptions now go through the same `renderWithInlineCode` helper that the java agent side already uses, so stuff wrapped in backticks actually shows up as code instead of just... backticks sitting in a paragraph.

## Why

Fixes #910 

java agent instrumentation descriptions already render backticks as code elements, so on pages like the apache spark receiver, you'd see literal `` `/metrics/json` `` in the description. `collector-detail-page.tsx` was just rendering `component.description` raw, while `instrumentation-detail-page.tsx` was already piping the exact same kind of string through `renderWithInlineCode` from `src/lib/render-inline-code.tsx`. so this just wires collector up to the same utility.

## How it was tested

I have added one new test, for the new test specifically, I actually reverted just the component fix (kept the test) and reran it to make sure it fails without the fix, it did (`getByText` couldn't find `/metrics/json` as its own element since it was buried in one big text block). I put the fix back, reran, it passed.

<img width="1861" height="1007" alt="Screenshot from 2026-07-28 02-03-12" src="https://github.com/user-attachments/assets/4f6c6e1b-3411-493d-a31a-d8fd44a8a66b" />

## Is this a breaking change?

No

## Special notes for your reviewer

I found one more spot with the exact same problem: the collector list/card view (`collector-components-page.tsx`) also renders `comp.description` raw, same as the detail page did. The java agent card (`instrumentation-card.tsx`) already uses `renderWithInlineCode` there too, so it's the same asymmetry, just on the card instead of the detail page.
But I can raise a PR for that too... Just let know :)

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
