### PR TITLE
ci(react-doctor): add advisory PR scan workflow

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -14,11 +14,7 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: {}
 
 # Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
 concurrency:
@@ -27,7 +23,13 @@ concurrency:
 
 jobs:
   react-doctor:
+    name: React Doctor
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Checkout the repository
+      pull-requests: write # Post the sticky PR summary comment and inline review comments
+      issues: write # GitHub models PR conversation comments as issue comments, so posting the summary comment needs this scope too
+      statuses: write # Report the health-score commit status
     steps:
       # fetch-depth: 0 gives React Doctor the full git history it needs to find the merge base with the target branch. Without it a shallow checkout has no merge base, so PR runs can't compare against the base and fall back to reporting every issue in the changed files (pre-existing ones included) instead of only the ones the PR introduced.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,56 @@
+# React Doctor — finds security, performance, correctness, accessibility,
+# bundle-size, and architecture issues in React codebases.
+#
+# Docs: https://www.react.doctor/ci
+# Source: https://github.com/millionco/react-doctor
+
+name: React Doctor
+
+on:
+  # Scans the PR's changed files and posts a sticky summary comment listing only the new issues introduced relative to the merge base of the target branch.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Scans `main` on every push to track the health-score trend and catch regressions that slipped past PR review.
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+# Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gives React Doctor the full git history it needs to find the merge base with the target branch. Without it a shallow checkout has no merge base, so PR runs can't compare against the base and fall back to reporting every issue in the changed files (pre-existing ones included) instead of only the ones the PR introduced.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
+        with:
+          # Monorepo: the React app lives under ecosystem-explorer/, not the repo root.
+          directory: ecosystem-explorer
+        # Advisory by default: React Doctor reports findings on every PR — a
+        # sticky summary comment, inline review comments, and a commit status
+        # with the health score — but never fails the check, so it won't red-X
+        # a teammate's PR on day one. When your team trusts the signal, graduate
+        # the gate: uncomment the block below and set blocking to "error" (fail
+        # on new error-severity findings) or "warning" (fail on any finding).
+        # Full reference: https://www.react.doctor/ci
+        # with:
+        #   blocking: error          # Gate level: "none" (advisory, the default) | "warning" | "error"
+        #   scope: full              # On PRs, scan the whole project instead of just changed files
+        #   comment: false           # Disable the sticky PR summary comment
+        #   review-comments: false   # Disable inline review comments on changed lines
+        #   commit-status: false     # Disable the commit status (score + counts, links to the run)
+        #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
+        #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)


### PR DESCRIPTION
## What changed

Adds a GitHub Actions workflow that runs [react.doctor](https://react.doctor) on every pull request, in advisory mode: it comments and reports a health score, but never fails the check. Scoped to `ecosystem-explorer/`, the only React/TS app in this monorepo. Both third-party actions (`actions/checkout`, `millionco/react-doctor`) are pinned to commit SHAs, matching this repo's Actions convention.

## Why

No issue tracks this yet. We'd discussed trying react.doctor and [fallow-rs/fallow](https://github.com/fallow-rs/fallow) in dry-run mode to see whether either produces useful signal for this codebase, with a token requirement being the main earlier concern. React Doctor no longer needs one for its CI setup, which reopened the question.

A side-by-side run of both tools against `ecosystem-explorer/` showed react.doctor fits better here: it caught two real bugs (a ref mutated during render, an effect subscription that's never cleaned up) that nothing else in this repo's CI checks for today. fallow's dead-code and duplication detection turned out stronger on that specific axis, but adopting it is a separate decision — this PR only adds react.doctor.

## How it was tested

- Ran `npx react-doctor@latest` locally against `ecosystem-explorer/`: 123 diagnostics across 58 files, including the two bugs above. Full comparison in the collapsible section below.
- Validated the workflow file with `zizmor`: no findings.
- Not yet exercised inside GitHub Actions itself — this stays a draft so we can watch the first live run before merging.

## Is this a breaking change?

No. Advisory mode never fails a check, so this can't block any existing merge.

## Special notes for your reviewer

<details>
<summary>react.doctor vs fallow — full evaluation on ecosystem-explorer</summary>

Scope: `ecosystem-explorer/` (453 files, ~64k LOC). Both tools run zero-install via `npx`, no GitHub token required for either.

### What each tool actually checks (not the same category of tool)

| | react.doctor v0.9.2 | fallow v3.10.0 |
|---|---|---|
| Focus | React-specific bugs/perf/a11y/state | JS/TS-wide dead code, duplication, complexity, architecture |
| Stars | 14,164 | 4,207 |
| License / model | Free; paid "enterprise" scoring add-on | Free static analysis; paid "Fallow Runtime" (prod trace) add-on |
| React/JSX-aware? | Yes — hooks, refs, effects, Tailwind, JSX depth | Partially — render fan-in and JSX max depth feed complexity, not rule-based |
| PR-diff mode | `--scope changed`, `ci install` scaffolds the workflow, no token | `fallow audit` gates only new findings vs. a base ref |
| Telemetry | Anonymized, opt-out (`--no-telemetry`) | Opt-in, off by default |

### Real findings on this codebase

**react.doctor** — 123 diagnostics, 58 files affected, 2 errors / 121 warnings:

- Performance 56 (35x `no-transition-all`, a real Tailwind perf antipattern, hitting 22 files)
- Bugs 39, including 2 errors: a ref mutated during render, an effect subscription never cleaned up
- Maintainability 23, including `no-giant-component` x6, `no-multi-comp` x9
- Accessibility 5
- `button-has-type` x16 across 10 files: a real bug class (an unlabeled `<button>` defaults to `type=submit`)
- Its own bundled dead-code pass (the `deslop` plugin, on by default) found only 3 unused exports, far below fallow's 22, and zero unused files, unused types, circular deps, or dev-deps-in-prod. Its supply-chain scan (Socket.dev, also on by default) came back clean: 0 findings, score 100/100.
- 68 of 123 findings (55%), including all 35 `no-transition-all`, all 11 `js-set-map-lookups`, and all 6 `no-giant-component` hits, come from rules react.doctor itself tags `test-noise`, its documented label for "a behavioral family that's noisy." That doesn't make these specific findings wrong: none of the hit files (`back-button.tsx`, `tabs.tsx`, `tooltip.tsx`, etc.) are vendored shadcn boilerplate, a common source of that rule's noise; they're original code built on bare Radix primitives. It does mean react.doctor's own maintainers don't fully trust that rule family's precision, so treat that 55% as worth a human glance, not as confirmed bugs, until someone's read a larger sample.

**fallow** — dead-code + dupes + health combined:

- Dead code: 42 issues (2 unused files, 22 unused exports, 4 unused types, 1 unused dep, 4 circular deps, 5 dev-deps-used-in-prod)
- Duplication: 4.35% (31 clone groups, 71 instances across 34 files)
- Health: average maintainability 92.3/100, 18 critical + 22 high complexity functions, 74 functions over threshold
- Its #1 complexity hotspot is `InstrumentationDetailPage` (cyclomatic 65, cognitive 61, 582 lines): the same file react.doctor's `no-giant-component` flagged independently, a good cross-validation signal
- Bonus: React-aware render fan-in stats (which components are reused/re-rendered most: `GlowBadge`, `PageContainer`, `BackButton`), useful but informational, not a pass/fail finding
- No equivalent "noise self-tagging" mechanism to cross-check against; there's no documented confidence signal for its findings the way react.doctor's tags provide one

### Overlap is smaller than it first looks

Complexity/giant-components overlaps cleanly. Dead code is partially shared, not exclusive to fallow: react.doctor's `deslop` plugin does run unused-export detection by default, just far weaker here (3 vs. 22 findings), and it misses unused files, unused types, dev-deps-in-prod, and circular dependencies entirely, all of which fallow caught. The rest of each tool's output (a11y and ref/effect bugs from react.doctor; duplication and circular deps from fallow) is unique to it. They're solving adjacent, not competing, problems: fallow is meaningfully stronger at repo hygiene than react.doctor's bundled dead-code pass, even though hygiene isn't fallow's whole pitch either.

### Recommendation: ship react.doctor first, not both

1. It matches the actual motivating problem: catching bad React that lands in a PR. Its two hard errors (ref mutated during render, effect subscription never cleaned up) are exactly that failure class, and nothing else in this repo's CI catches it today.
2. The two errors and the `button-has-type` findings are high-confidence (untagged, standard rules). The bulk of the warning volume (the `test-noise`-tagged rules) is plausible but self-flagged by the tool as needing a human look. That's a real caveat, but it doesn't change the tool choice: the high-confidence findings alone justify adoption, and running in `--scope changed` mode means a human reviews new hits on every PR anyway.
3. Zero adoption friction: no token, a one-command CI installer, diff-scoped mode so it doesn't dump the whole backlog on day one.
4. fallow's strongest signal here (the complexity hotspot) is something react.doctor already catches via `no-giant-component`, so adopting fallow for this specific goal buys little marginal coverage on that axis.

**Open question:** fallow's dead-code, duplication, and circular-dependency detection is real and substantially stronger than react.doctor's bundled equivalent. If codebase hygiene beyond "bad React" is a goal worth pursuing, that's a legitimate separate case for fallow, most likely as a periodic health check rather than a blocker on every PR. Worth its own decision, not bundled into this rollout.

**Not decided here:** whether to skip the advisory phase and go blocking sooner, whether to keep the scan scoped to `--scope changed` long-term, and whether fallow gets adopted separately later.

</details>

## Checklist

- [ ] Tests added or updated for new behavior — n/a, CI configuration only
- [ ] Screenshots attached for any UI changes — n/a
- [ ] I wrote this PR description myself (AI tools must not check this box on behalf of the author)

---

> Co-authored with Claude Sonnet 5.
