### PR TITLE
feat(collector): add internal telemetry version comparison

### DIFF
--- a/ecosystem-explorer/public/locales/en/collector.json
+++ b/ecosystem-explorer/public/locales/en/collector.json
@@ -167,7 +167,12 @@
       "details": "Details",
       "stability": "Stability",
       "telemetry": "Telemetry",
-      "readme": "Readme"
+      "readme": "Readme",
+      "internalTelemetry": "Internal Telemetry"
+    },
+    "view": {
+      "current": "Current View",
+      "comparison": "Version Comparison"
     },
     "sections": {
       "componentInfo": "Component Info",
@@ -258,6 +263,59 @@
         "type": "Type",
         "description": "Description"
       }
+    },
+    "internalTelemetryTab": {
+      "empty": "No internal telemetry metrics are defined for this component."
+    }
+  },
+  "telemetryComparison": {
+    "loading": "Loading comparison data...",
+    "error": {
+      "title": "Comparison Error",
+      "bothVersionsFailed": "Both versions could not be loaded. The component may not exist in these versions."
+    },
+    "warnings": {
+      "availability": {
+        "title": "Version Availability Note",
+        "fromNotFound": "The component was not available in version {{fromVersion}}. All telemetry from the \"to\" version is shown as added.",
+        "toNotFound": "The component was not available in version {{toVersion}}. All telemetry from the \"from\" version is shown as removed."
+      },
+      "sameVersion": {
+        "title": "Same Version Selected",
+        "message": "Please select different versions to compare telemetry."
+      }
+    },
+    "versionSelectorPanel": {
+      "banner": "Compare internal telemetry between two releases",
+      "from": "From",
+      "to": "To"
+    },
+    "diffResults": {
+      "addedRemovedHeader": "Telemetry Added/Removed",
+      "changedHeader": "Telemetry Changed",
+      "empty": {
+        "title": "No differences found",
+        "description": "Internal telemetry is identical between the selected versions."
+      }
+    },
+    "diffCard": {
+      "status": {
+        "added": "Added",
+        "removed": "Removed",
+        "changed": "Changed"
+      },
+      "unit": "Unit",
+      "attributeChanges": "Attribute Changes",
+      "descriptionChanged": "Description Changed",
+      "typeChanged": "Type Changed",
+      "enabledChanged": "Enabled Changed",
+      "stabilityChanged": "Stability Changed",
+      "metricRemoved": "This metric is no longer emitted in the comparison version."
+    },
+    "diffAttributeList": {
+      "ariaLabel": "Attribute changes",
+      "added": "Added",
+      "removed": "Removed"
     }
   },
   "explore": {

--- a/ecosystem-explorer/public/locales/es/collector.json
+++ b/ecosystem-explorer/public/locales/es/collector.json
@@ -167,7 +167,12 @@
       "details": "Detalles",
       "stability": "Estabilidad",
       "telemetry": "Telemetría",
-      "readme": "Readme"
+      "readme": "Readme",
+      "internalTelemetry": "Telemetría interna"
+    },
+    "view": {
+      "current": "Vista actual",
+      "comparison": "Comparación de versiones"
     },
     "sections": {
       "componentInfo": "Información del componente",
@@ -258,6 +263,59 @@
         "type": "Tipo",
         "description": "Descripción"
       }
+    },
+    "internalTelemetryTab": {
+      "empty": "No hay métricas de telemetría interna definidas para este componente."
+    }
+  },
+  "telemetryComparison": {
+    "loading": "Cargando datos de comparación...",
+    "error": {
+      "title": "Error de comparación",
+      "bothVersionsFailed": "No se pudieron cargar ambas versiones. Es posible que el componente no exista en estas versiones."
+    },
+    "warnings": {
+      "availability": {
+        "title": "Nota de disponibilidad de versión",
+        "fromNotFound": "El componente no estaba disponible en la versión {{fromVersion}}. Toda la telemetría de la versión \"a\" se muestra como añadida.",
+        "toNotFound": "El componente no estaba disponible en la versión {{toVersion}}. Toda la telemetría de la versión \"desde\" se muestra como eliminada."
+      },
+      "sameVersion": {
+        "title": "Misma versión seleccionada",
+        "message": "Selecciona versiones diferentes para comparar la telemetría."
+      }
+    },
+    "versionSelectorPanel": {
+      "banner": "Compara la telemetría interna entre dos versiones",
+      "from": "Desde",
+      "to": "A"
+    },
+    "diffResults": {
+      "addedRemovedHeader": "Telemetría añadida/eliminada",
+      "changedHeader": "Telemetría modificada",
+      "empty": {
+        "title": "No se encontraron diferencias",
+        "description": "La telemetría interna es idéntica entre las versiones seleccionadas."
+      }
+    },
+    "diffCard": {
+      "status": {
+        "added": "Añadido",
+        "removed": "Eliminado",
+        "changed": "Modificado"
+      },
+      "unit": "Unidad",
+      "attributeChanges": "Cambios de atributos",
+      "descriptionChanged": "Descripción modificada",
+      "typeChanged": "Tipo modificado",
+      "enabledChanged": "Habilitado modificado",
+      "stabilityChanged": "Estabilidad modificada",
+      "metricRemoved": "Esta métrica ya no se emite en la versión de comparación."
+    },
+    "diffAttributeList": {
+      "ariaLabel": "Cambios de atributos",
+      "added": "Añadido",
+      "removed": "Eliminado"
     }
   },
   "explore": {

--- a/ecosystem-explorer/public/schemas/collector-component.schema.json
+++ b/ecosystem-explorer/public/schemas/collector-component.schema.json
@@ -329,6 +329,161 @@
     "markdown_hash": {
       "description": "Content hash of the component's README, if one was found. Used to lazily fetch the markdown file.",
       "type": "string"
+    },
+    "telemetry": {
+      "description": "Internal self-observability telemetry the component emits about its own\noperation (e.g. `processor_memory_limiter_refused_spans`). Distinct from\n`metrics`, which describes the signal data the component produces about\nthe monitored system. Unlike Java Agent telemetry, there is no `when`\ncondition here — Collector metadata has no configuration-dependent axis.",
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "description": "Internal metrics the component emits about its own operation. Same per-metric shape as the top-level `metrics` field.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "A single metric emitted by a Collector component.\nModeled after the metadata.yaml schema used by the collector-contrib repo.",
+            "type": "object",
+            "properties": {
+              "description": {
+                "description": "Description of what this metric measures.",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Whether the metric is collected by default.",
+                "type": "boolean"
+              },
+              "unit": {
+                "description": "Metric unit as defined by https://ucum.org/ucum.html.",
+                "type": "string"
+              },
+              "stability": {
+                "description": "Stability level of this specific metric.",
+                "enum": ["alpha", "beta", "deprecated", "development", "stable", "unmaintained"],
+                "type": "string"
+              },
+              "extended_documentation": {
+                "description": "Extended documentation beyond the description.",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Whether this metric is optional (only initialized under certain conditions).",
+                "type": "boolean"
+              },
+              "sum": {
+                "description": "Sum metric type descriptor. Present when the metric is a sum.",
+                "allOf": [
+                  {
+                    "description": "Shared fields across sum, gauge, and histogram metric type descriptors.",
+                    "type": "object",
+                    "properties": {
+                      "value_type": {
+                        "description": "The numeric type of the metric's data points.",
+                        "type": "string"
+                      },
+                      "aggregation_temporality": {
+                        "description": "Aggregation temporality (e.g., \"cumulative\", \"delta\"). Only present on sum metrics.",
+                        "type": "string"
+                      },
+                      "async": {
+                        "description": "Whether this metric is observed asynchronously.",
+                        "type": "boolean"
+                      }
+                    },
+                    "propertyOrder": ["value_type", "aggregation_temporality", "async"],
+                    "required": ["value_type"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "monotonic": {
+                        "type": "boolean"
+                      }
+                    },
+                    "propertyOrder": ["monotonic"],
+                    "required": ["monotonic"]
+                  }
+                ]
+              },
+              "gauge": {
+                "description": "Gauge metric type descriptor. Present when the metric is a gauge.",
+                "type": "object",
+                "properties": {
+                  "value_type": {
+                    "description": "The numeric type of the metric's data points.",
+                    "type": "string"
+                  },
+                  "aggregation_temporality": {
+                    "description": "Aggregation temporality (e.g., \"cumulative\", \"delta\"). Only present on sum metrics.",
+                    "type": "string"
+                  },
+                  "async": {
+                    "description": "Whether this metric is observed asynchronously.",
+                    "type": "boolean"
+                  }
+                },
+                "propertyOrder": ["value_type", "aggregation_temporality", "async"],
+                "required": ["value_type"]
+              },
+              "histogram": {
+                "description": "Histogram metric type descriptor. Present when the metric is a histogram.",
+                "allOf": [
+                  {
+                    "description": "Shared fields across sum, gauge, and histogram metric type descriptors.",
+                    "type": "object",
+                    "properties": {
+                      "value_type": {
+                        "description": "The numeric type of the metric's data points.",
+                        "type": "string"
+                      },
+                      "aggregation_temporality": {
+                        "description": "Aggregation temporality (e.g., \"cumulative\", \"delta\"). Only present on sum metrics.",
+                        "type": "string"
+                      },
+                      "async": {
+                        "description": "Whether this metric is observed asynchronously.",
+                        "type": "boolean"
+                      }
+                    },
+                    "propertyOrder": ["value_type", "aggregation_temporality", "async"],
+                    "required": ["value_type"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "bucket_boundaries": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "propertyOrder": ["bucket_boundaries"]
+                  }
+                ]
+              },
+              "attributes": {
+                "description": "Attribute keys referencing the component-level attributes map.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "propertyOrder": [
+              "description",
+              "enabled",
+              "unit",
+              "stability",
+              "extended_documentation",
+              "optional",
+              "sum",
+              "gauge",
+              "histogram",
+              "attributes"
+            ],
+            "required": ["description", "enabled", "unit"]
+          },
+          "propertyOrder": []
+        }
+      },
+      "propertyOrder": ["metrics"]
     }
   },
   "propertyOrder": [
@@ -344,7 +499,8 @@
     "metrics",
     "attributes",
     "resource_attributes",
-    "markdown_hash"
+    "markdown_hash",
+    "telemetry"
   ],
   "required": ["distribution", "ecosystem", "id", "name", "type"],
   "$schema": "https://json-schema.org/draft-07/schema#"

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
@@ -74,6 +74,23 @@ const mockComponentWithBacktickDescription: CollectorComponent = {
   description: "Fetches metrics via the `/metrics/json` endpoint.",
 };
 
+const mockComponentWithInternalTelemetry: CollectorComponent = {
+  ...mockComponentWithoutTelemetry,
+  telemetry: {
+    metrics: {
+      processor_memory_limiter_refused_spans: {
+        description: "Number of spans refused.",
+        enabled: true,
+        unit: "{span}",
+        sum: {
+          monotonic: true,
+          value_type: "int",
+        },
+      },
+    },
+  },
+};
+
 function renderAtRoute(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
@@ -358,5 +375,94 @@ describe("CollectorDetailPage", () => {
 
     expect(screen.getByText("Stability Levels")).toBeInTheDocument();
     expect(screen.queryByText("Distribution Availability")).not.toBeInTheDocument();
+  });
+
+  it("does not render the Internal Telemetry tab when the component has no telemetry field", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithoutTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.queryByRole("tab", { name: /internal telemetry/i })).not.toBeInTheDocument();
+  });
+
+  it("does not render the Internal Telemetry tab for a component that only has signal metrics", () => {
+    // Regression guard: the pre-existing "Telemetry" tab (signal metrics) must
+    // not be conflated with the new "Internal Telemetry" tab (telemetry.metrics).
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    expect(screen.getByRole("tab", { name: "Telemetry" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: /internal telemetry/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the Internal Telemetry tab and its Current view when the component has telemetry.metrics", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithInternalTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    const internalTelemetryTab = screen.getByRole("tab", { name: /internal telemetry/i });
+    expect(internalTelemetryTab).toBeInTheDocument();
+
+    await user.click(internalTelemetryTab);
+
+    expect(screen.getByText("processor_memory_limiter_refused_spans")).toBeInTheDocument();
+  });
+
+  it("switches the Internal Telemetry tab to the Comparison view on toggle", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: {
+        versions: [
+          { version: "0.150.0", is_latest: true },
+          { version: "0.149.0", is_latest: false },
+        ],
+      },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithInternalTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver?version=0.150.0");
+
+    await user.click(screen.getByRole("tab", { name: /internal telemetry/i }));
+    await user.click(screen.getByRole("button", { name: "Version Comparison" }));
+
+    // The comparison view renders the From/To version selectors instead of
+    // the flat metric list from the Current view.
+    expect(screen.getByLabelText("From")).toBeInTheDocument();
+    expect(screen.getByLabelText("To")).toBeInTheDocument();
   });
 });

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -16,7 +16,7 @@
 import { useState } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Info, ExternalLink, AlertCircle, Check, Activity, BookOpen } from "lucide-react";
+import { Info, ExternalLink, AlertCircle, Check, Activity, BookOpen, Gauge } from "lucide-react";
 import { Loader } from "@/components/ui/loader";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import { BackButton } from "@/components/ui/back-button";
@@ -32,6 +32,7 @@ import { renderWithInlineCode } from "@/lib/render-inline-code";
 import { useCollectorComponent, useCollectorVersions } from "@/hooks/use-collector-data";
 import { CollectorTelemetryTab } from "./components/collector-telemetry-tab";
 import { CollectorReadmeTab } from "./components/collector-readme-tab";
+import { TelemetryComparisonSection } from "./components/telemetry-comparison/telemetry-comparison-section";
 
 const getBadgeVariant = (level: string): "success" | "info" | "warning" | "muted" => {
   const lower = level.toLowerCase();
@@ -69,6 +70,7 @@ export function CollectorDetailPage() {
     error,
   } = useCollectorComponent(distribution ?? "", name ?? "", version);
   const [activeTab, setActiveTab] = useState("details");
+  const [showInternalTelemetryComparison, setShowInternalTelemetryComparison] = useState(false);
 
   const getStabilityLabel = (level: string) =>
     t(`detail.stabilityLabels.${level.toLowerCase()}`, { defaultValue: level });
@@ -254,6 +256,16 @@ export function CollectorDetailPage() {
                           value: "readme",
                           label: t("detail.tabs.readme"),
                           icon: <BookOpen className="h-4 w-4" aria-hidden="true" />,
+                        },
+                      ]
+                    : []),
+                  ...(component.telemetry?.metrics &&
+                  Object.keys(component.telemetry.metrics).length > 0
+                    ? [
+                        {
+                          value: "internal-telemetry",
+                          label: t("detail.tabs.internalTelemetry"),
+                          icon: <Gauge className="h-4 w-4" aria-hidden="true" />,
                         },
                       ]
                     : []),
@@ -488,6 +500,62 @@ export function CollectorDetailPage() {
                 <CollectorReadmeTab name={component.name} markdownHash={component.markdown_hash} />
               </TabsContent>
             )}
+
+            {component.telemetry?.metrics &&
+              Object.keys(component.telemetry.metrics).length > 0 && (
+                <TabsContent value="internal-telemetry" className="mt-0 p-6">
+                  <div className="space-y-8">
+                    <div className="flex justify-center">
+                      <div
+                        className="border-border inline-flex w-full rounded-lg border bg-transparent p-1 sm:w-auto"
+                        role="group"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => setShowInternalTelemetryComparison(false)}
+                          aria-pressed={!showInternalTelemetryComparison}
+                          className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out sm:flex-none ${
+                            !showInternalTelemetryComparison
+                              ? "bg-card text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          {t("detail.view.current")}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setShowInternalTelemetryComparison(true)}
+                          aria-pressed={showInternalTelemetryComparison}
+                          className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ease-in-out sm:flex-none ${
+                            showInternalTelemetryComparison
+                              ? "bg-card text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          {t("detail.view.comparison")}
+                        </button>
+                      </div>
+                    </div>
+
+                    {!showInternalTelemetryComparison ? (
+                      <CollectorTelemetryTab
+                        metrics={component.telemetry.metrics}
+                        attributes={component.attributes}
+                        resourceAttributes={component.resource_attributes}
+                      />
+                    ) : (
+                      versionData && (
+                        <TelemetryComparisonSection
+                          distribution={distribution ?? ""}
+                          name={name ?? ""}
+                          versions={versionData.versions}
+                          currentVersion={version}
+                        />
+                      )
+                    )}
+                  </div>
+                </TabsContent>
+              )}
           </Tabs>
         </div>
       </div>

--- a/ecosystem-explorer/src/features/collector/components/collector-telemetry-tab.tsx
+++ b/ecosystem-explorer/src/features/collector/components/collector-telemetry-tab.tsx
@@ -19,18 +19,12 @@ import { ChevronDown, ChevronUp, Maximize2, Minimize2 } from "lucide-react";
 import { SectionDivider } from "@/components/ui/section-divider";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import type { CollectorMetric, CollectorAttribute } from "@/types/collector";
+import { getMetricType } from "../utils/metric-type";
 
 interface CollectorTelemetryTabProps {
   metrics: Record<string, CollectorMetric>;
   attributes?: Record<string, CollectorAttribute>;
   resourceAttributes?: Record<string, CollectorAttribute>;
-}
-
-function getMetricType(metric: CollectorMetric): "sum" | "gauge" | "histogram" | null {
-  if (metric.sum) return "sum";
-  if (metric.gauge) return "gauge";
-  if (metric.histogram) return "histogram";
-  return null;
 }
 
 function getStabilityVariant(

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/attribute-diff-list.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/attribute-diff-list.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Plus, Minus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { CollectorAttributeChanges } from "@/types/collector";
+
+interface AttributeDiffListProps {
+  changes: CollectorAttributeChanges;
+}
+
+/**
+ * Renders added/removed attribute keys for a metric. Collector metric
+ * attributes are plain key references into the component's `attributes`
+ * map (`string[]`), not typed inline values like Java Agent's `Attribute`,
+ * so there is no "type changed" row here - a key is either present or not.
+ */
+export function AttributeDiffList({ changes }: AttributeDiffListProps) {
+  const { t } = useTranslation("collector");
+  const hasChanges = changes.added.length > 0 || changes.removed.length > 0;
+
+  if (!hasChanges) {
+    return null;
+  }
+
+  return (
+    <ul
+      aria-label={t("telemetryComparison.diffAttributeList.ariaLabel")}
+      className="border-border/30 divide-border/20 divide-y overflow-hidden rounded-lg border"
+    >
+      {changes.added.map((key) => (
+        <li key={`added-${key}`} className="flex items-center gap-2 p-3">
+          <Plus className="h-3 w-3 flex-shrink-0 text-green-400" aria-hidden="true" />
+          <span className="text-xs font-medium text-green-400">
+            {t("telemetryComparison.diffAttributeList.added")}
+          </span>
+          <code className="font-mono text-sm">{key}</code>
+        </li>
+      ))}
+      {changes.removed.map((key) => (
+        <li key={`removed-${key}`} className="flex items-center gap-2 p-3">
+          <Minus className="h-3 w-3 flex-shrink-0 text-red-400" aria-hidden="true" />
+          <span className="text-xs font-medium text-red-400">
+            {t("telemetryComparison.diffAttributeList.removed")}
+          </span>
+          <code className="font-mono text-sm line-through opacity-60">{key}</code>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/diff-results-section.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/diff-results-section.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useTranslation } from "react-i18next";
+import type { CollectorTelemetryDiffResult } from "@/types/collector";
+import { SectionDivider } from "@/components/ui/section-divider";
+import { MetricDiffCard } from "./metric-diff-card";
+
+interface DiffResultsSectionProps {
+  diffResult: CollectorTelemetryDiffResult;
+}
+
+export function DiffResultsSection({ diffResult }: DiffResultsSectionProps) {
+  const { t } = useTranslation("collector");
+  const { metrics } = diffResult;
+
+  const addedOrRemoved = metrics.filter((m) => m.status === "added" || m.status === "removed");
+  const changed = metrics.filter((m) => m.status === "changed");
+
+  const hasAnyChanges = metrics.some((m) => m.status !== "unchanged");
+
+  if (!hasAnyChanges) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center">
+        <div className="space-y-2 text-center">
+          <p className="text-muted-foreground text-lg font-medium">
+            {t("telemetryComparison.diffResults.empty.title")}
+          </p>
+          <p className="text-muted-foreground/70 text-sm">
+            {t("telemetryComparison.diffResults.empty.description")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-12">
+      {addedOrRemoved.length > 0 && (
+        <div className="space-y-6">
+          <SectionDivider className="my-0">
+            {t("telemetryComparison.diffResults.addedRemovedHeader")}
+          </SectionDivider>
+          <div className="mx-auto max-w-3xl space-y-6">
+            {addedOrRemoved.map((metricDiff) => (
+              <MetricDiffCard key={metricDiff.name} diff={metricDiff} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {changed.length > 0 && (
+        <div className="space-y-6">
+          <SectionDivider className="my-0">
+            {t("telemetryComparison.diffResults.changedHeader")}
+          </SectionDivider>
+          <div className="mx-auto max-w-3xl space-y-6">
+            {changed.map((metricDiff) => (
+              <MetricDiffCard key={metricDiff.name} diff={metricDiff} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/metric-diff-card.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/metric-diff-card.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useTranslation } from "react-i18next";
+import { GlowBadge } from "@/components/ui/glow-badge";
+import type { CollectorMetricDiff } from "@/types/collector";
+import { getMetricType } from "../../utils/metric-type";
+import { AttributeDiffList } from "./attribute-diff-list";
+
+interface MetricDiffCardProps {
+  diff: CollectorMetricDiff;
+}
+
+export function MetricDiffCard({ diff }: MetricDiffCardProps) {
+  const { t } = useTranslation("collector");
+  const { status, name, metric, changes } = diff;
+
+  const statusVariant = status === "added" ? "success" : "warning";
+  const statusLabel =
+    status === "added"
+      ? t("telemetryComparison.diffCard.status.added")
+      : status === "removed"
+        ? t("telemetryComparison.diffCard.status.removed")
+        : t("telemetryComparison.diffCard.status.changed");
+
+  const metricType = getMetricType(metric);
+
+  return (
+    <div className="border-border/30 bg-card/30 hover:bg-card-secondary rounded-2xl border p-6 transition-all duration-300 md:p-10">
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <code className="text-foreground flex-1 font-mono text-lg font-semibold break-all">
+            {name}
+          </code>
+          <div className="flex gap-2">
+            <GlowBadge variant={statusVariant} withGlow className="text-[10px]">
+              {statusLabel}
+            </GlowBadge>
+            {metricType && (
+              <GlowBadge variant="success" withGlow className="text-[10px]">
+                {t(`detail.telemetryTab.metricType.${metricType}`)}
+              </GlowBadge>
+            )}
+          </div>
+        </div>
+
+        {status !== "removed" && (
+          <p className="text-foreground/80 text-base leading-relaxed">{metric.description}</p>
+        )}
+
+        {status === "changed" && changes?.description && (
+          <div className="space-y-2">
+            <span className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+              {t("telemetryComparison.diffCard.descriptionChanged")}
+            </span>
+            <div className="border-border/30 space-y-1 rounded-lg border bg-white/[0.03] p-3">
+              <p className="text-sm text-red-400 line-through opacity-60">
+                {changes.description.before}
+              </p>
+              <p className="text-sm text-green-400">{changes.description.after}</p>
+            </div>
+          </div>
+        )}
+
+        {status === "changed" && changes?.type && (
+          <div className="flex items-center gap-3">
+            <span className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+              {t("telemetryComparison.diffCard.typeChanged")}
+            </span>
+            <div className="flex items-center gap-2">
+              <code className="rounded border border-red-400/30 bg-red-400/10 px-2 py-1 text-sm text-red-400 line-through">
+                {changes.type.before ?? "—"}
+              </code>
+              <span className="text-muted-foreground">→</span>
+              <code className="rounded border border-green-400/30 bg-green-400/10 px-2 py-1 text-sm text-green-400">
+                {changes.type.after ?? "—"}
+              </code>
+            </div>
+          </div>
+        )}
+
+        {status === "changed" && changes?.enabled && (
+          <div className="flex items-center gap-3">
+            <span className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+              {t("telemetryComparison.diffCard.enabledChanged")}
+            </span>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-red-400 line-through opacity-60">
+                {String(changes.enabled.before)}
+              </span>
+              <span className="text-muted-foreground">→</span>
+              <span className="text-green-400">{String(changes.enabled.after)}</span>
+            </div>
+          </div>
+        )}
+
+        {status === "changed" && changes?.stability && (
+          <div className="flex items-center gap-3">
+            <span className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+              {t("telemetryComparison.diffCard.stabilityChanged")}
+            </span>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-red-400 line-through opacity-60">
+                {changes.stability.before ?? "—"}
+              </span>
+              <span className="text-muted-foreground">→</span>
+              <span className="text-green-400">{changes.stability.after ?? "—"}</span>
+            </div>
+          </div>
+        )}
+
+        {status !== "removed" && (
+          <div className="border-border/30 flex items-center gap-3 border-b pb-6">
+            <span className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+              {t("telemetryComparison.diffCard.unit")}
+            </span>
+            <code className="border-border/30 text-foreground/80 rounded border bg-white/[0.03] px-2 py-1 text-sm">
+              {metric.unit}
+            </code>
+            {status === "changed" && changes?.unit && (
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground text-xs">(was:</span>
+                <code className="rounded border border-red-400/30 bg-red-400/10 px-2 py-1 text-sm text-red-400 line-through">
+                  {changes.unit.before}
+                </code>
+                <span className="text-muted-foreground text-xs">)</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {status === "changed" && changes?.attributes && (
+          <div className="space-y-4">
+            <h4 className="text-muted-foreground text-xs font-black tracking-[0.2em] uppercase">
+              {t("telemetryComparison.diffCard.attributeChanges")}
+            </h4>
+            <AttributeDiffList changes={changes.attributes} />
+          </div>
+        )}
+
+        {status === "removed" && (
+          <div className="rounded-lg border border-red-400/30 bg-red-400/10 p-4">
+            <p className="text-sm text-red-400">
+              {t("telemetryComparison.diffCard.metricRemoved")}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/telemetry-comparison-section.test.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/telemetry-comparison-section.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TelemetryComparisonSection } from "./telemetry-comparison-section";
+import * as useTelemetryComparisonModule from "../../hooks/use-telemetry-comparison";
+import type { VersionInfo } from "@/types/collector";
+
+vi.mock("../../hooks/use-telemetry-comparison", () => ({
+  useTelemetryComparison: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const noopHookReturn: useTelemetryComparisonModule.UseCollectorTelemetryComparisonResult = {
+  fromVersion: "0.100.0",
+  toVersion: "0.100.0",
+  setFromVersion: vi.fn(),
+  setToVersion: vi.fn(),
+  diffResult: null,
+  loading: false,
+  error: null,
+  fromNotFound: false,
+  toNotFound: false,
+};
+
+const versions: VersionInfo[] = [
+  { version: "0.102.0", is_latest: true },
+  { version: "0.101.0", is_latest: false },
+  { version: "0.100.0", is_latest: false },
+];
+
+describe("TelemetryComparisonSection (collector) — defaultFromVersion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue(noopHookReturn);
+  });
+
+  it("uses the next-older version as From when viewing the latest version", () => {
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.102.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "core",
+      "memorylimiterprocessor",
+      "0.101.0",
+      "0.102.0"
+    );
+  });
+
+  it("uses the next-older version as From when viewing a middle version", () => {
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.101.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "core",
+      "memorylimiterprocessor",
+      "0.100.0",
+      "0.101.0"
+    );
+  });
+
+  it("uses currentVersion as From when viewing the oldest version (no older version exists)", () => {
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.100.0"
+      />
+    );
+    expect(useTelemetryComparisonModule.useTelemetryComparison).toHaveBeenCalledWith(
+      "core",
+      "memorylimiterprocessor",
+      "0.100.0", // From = oldest (same as To) — triggers same-version warning, not inverted diff
+      "0.100.0"
+    );
+  });
+});
+
+describe("TelemetryComparisonSection (collector) — rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a loading state while the comparison is in flight", () => {
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue({
+      ...noopHookReturn,
+      fromVersion: "0.100.0",
+      toVersion: "0.101.0",
+      loading: true,
+    });
+
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.101.0"
+      />
+    );
+
+    expect(screen.getByText("telemetryComparison.loading")).toBeInTheDocument();
+  });
+
+  it("shows an error message when the comparison fails", () => {
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue({
+      ...noopHookReturn,
+      fromVersion: "0.100.0",
+      toVersion: "0.101.0",
+      error: new Error("boom"),
+    });
+
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.101.0"
+      />
+    );
+
+    expect(screen.getByText("telemetryComparison.error.title")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("shows the same-version warning instead of a diff when From equals To", () => {
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue({
+      ...noopHookReturn,
+      fromVersion: "0.100.0",
+      toVersion: "0.100.0",
+      diffResult: { metrics: [] },
+    });
+
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.100.0"
+      />
+    );
+
+    expect(screen.getByText("telemetryComparison.warnings.sameVersion.title")).toBeInTheDocument();
+  });
+
+  it("renders diff results when the comparison succeeds", () => {
+    vi.mocked(useTelemetryComparisonModule.useTelemetryComparison).mockReturnValue({
+      ...noopHookReturn,
+      fromVersion: "0.100.0",
+      toVersion: "0.101.0",
+      diffResult: {
+        metrics: [
+          {
+            status: "added",
+            name: "processor_memory_limiter_refused_spans",
+            metric: { description: "d", enabled: true, unit: "{span}" },
+          },
+        ],
+      },
+    });
+
+    render(
+      <TelemetryComparisonSection
+        distribution="core"
+        name="memorylimiterprocessor"
+        versions={versions}
+        currentVersion="0.101.0"
+      />
+    );
+
+    expect(screen.getByText("processor_memory_limiter_refused_spans")).toBeInTheDocument();
+  });
+});

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/telemetry-comparison-section.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/telemetry-comparison-section.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AlertCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Loader } from "@/components/ui/loader";
+import type { VersionInfo } from "@/types/collector";
+import { useTelemetryComparison } from "../../hooks/use-telemetry-comparison";
+import { VersionSelectorPanel } from "./version-selector-panel";
+import { DiffResultsSection } from "./diff-results-section";
+
+interface TelemetryComparisonSectionProps {
+  distribution: string;
+  name: string;
+  versions: VersionInfo[];
+  currentVersion: string;
+}
+
+export function TelemetryComparisonSection({
+  distribution,
+  name,
+  versions,
+  currentVersion,
+}: TelemetryComparisonSectionProps) {
+  const { t } = useTranslation("collector");
+  // "To" defaults to the version being viewed. "From" defaults to the previous release,
+  // or falls back to currentVersion (triggering a same-version warning) if viewing the oldest version.
+  const currentIndex = versions.findIndex((v) => v.version === currentVersion);
+  const defaultFromVersion =
+    currentIndex < versions.length - 1 ? versions[currentIndex + 1].version : currentVersion;
+
+  const {
+    fromVersion,
+    toVersion,
+    setFromVersion,
+    setToVersion,
+    diffResult,
+    loading,
+    error,
+    fromNotFound,
+    toNotFound,
+  } = useTelemetryComparison(distribution, name, defaultFromVersion, currentVersion);
+
+  return (
+    <div className="space-y-8">
+      <VersionSelectorPanel
+        versions={versions}
+        fromVersion={fromVersion}
+        toVersion={toVersion}
+        onFromVersionChange={setFromVersion}
+        onToVersionChange={setToVersion}
+      />
+
+      {loading && (
+        <div className="flex min-h-[300px] items-center justify-center">
+          <Loader size="sm" label={t("telemetryComparison.loading")} />
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <div className="max-w-2xl rounded-lg border border-red-400/30 bg-red-400/10 p-6">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-400" />
+              <div className="space-y-1">
+                <p className="font-medium text-red-400">{t("telemetryComparison.error.title")}</p>
+                <p className="text-sm text-red-400/80">{error.message}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && (fromNotFound || toNotFound) && (
+        <div className="rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-6">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-400" />
+            <div className="space-y-1">
+              <p className="font-medium text-yellow-400">
+                {t("telemetryComparison.warnings.availability.title")}
+              </p>
+              {fromNotFound && (
+                <p className="text-sm text-yellow-400/80">
+                  {t("telemetryComparison.warnings.availability.fromNotFound", { fromVersion })}
+                </p>
+              )}
+              {toNotFound && !fromNotFound && (
+                <p className="text-sm text-yellow-400/80">
+                  {t("telemetryComparison.warnings.availability.toNotFound", { toVersion })}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && fromVersion === toVersion && (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <div className="rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-6">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-400" />
+              <div className="space-y-1">
+                <p className="font-medium text-yellow-400">
+                  {t("telemetryComparison.warnings.sameVersion.title")}
+                </p>
+                <p className="text-sm text-yellow-400/80">
+                  {t("telemetryComparison.warnings.sameVersion.message")}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && diffResult && fromVersion !== toVersion && (
+        <DiffResultsSection diffResult={diffResult} />
+      )}
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/collector/components/telemetry-comparison/version-selector-panel.tsx
+++ b/ecosystem-explorer/src/features/collector/components/telemetry-comparison/version-selector-panel.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Info, ChevronDown } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { VersionInfo } from "@/types/collector";
+
+interface VersionSelectorPanelProps {
+  versions: VersionInfo[];
+  fromVersion: string;
+  toVersion: string;
+  onFromVersionChange: (version: string) => void;
+  onToVersionChange: (version: string) => void;
+}
+
+/**
+ * From/To version pickers for comparing a component's internal telemetry.
+ * Unlike the Java Agent version of this panel, there is no configuration/
+ * when-condition selector: Collector metadata has no equivalent axis.
+ */
+export function VersionSelectorPanel({
+  versions,
+  fromVersion,
+  toVersion,
+  onFromVersionChange,
+  onToVersionChange,
+}: VersionSelectorPanelProps) {
+  const { t } = useTranslation("collector");
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="border-border/30 bg-card/40 flex flex-col gap-6 rounded-xl border p-6 shadow-sm backdrop-blur-sm">
+        <div className="bg-secondary/10 border-secondary/20 flex w-fit items-center gap-2 rounded-lg border px-3 py-2">
+          <Info className="text-secondary h-4 w-4" aria-hidden="true" />
+          <span className="text-foreground/90 text-xs font-medium">
+            {t("telemetryComparison.versionSelectorPanel.banner")}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div className="space-y-3">
+            <label
+              htmlFor="collector-from-version-select"
+              className="bg-muted/50 text-foreground/70 block w-fit rounded-md px-3 py-1.5 text-[10px] font-bold tracking-widest uppercase"
+            >
+              {t("telemetryComparison.versionSelectorPanel.from")}
+            </label>
+            <div className="relative">
+              <select
+                id="collector-from-version-select"
+                value={fromVersion}
+                onChange={(e) => onFromVersionChange(e.target.value)}
+                className="border-border/60 bg-background/80 text-foreground hover:border-primary/40 focus:border-primary/50 focus:ring-primary/20 w-full cursor-pointer appearance-none rounded-lg border-2 px-4 py-2.5 text-sm font-medium [color-scheme:dark] backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
+              >
+                {versions.map((v) => (
+                  <option key={v.version} value={v.version}>
+                    {v.version} {v.is_latest ? "(latest)" : ""}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown
+                className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <label
+              htmlFor="collector-to-version-select"
+              className="bg-muted/50 text-foreground/70 block w-fit rounded-md px-3 py-1.5 text-[10px] font-bold tracking-widest uppercase"
+            >
+              {t("telemetryComparison.versionSelectorPanel.to")}
+            </label>
+            <div className="relative">
+              <select
+                id="collector-to-version-select"
+                value={toVersion}
+                onChange={(e) => onToVersionChange(e.target.value)}
+                className="border-border/60 bg-background/80 text-foreground hover:border-primary/40 focus:border-primary/50 focus:ring-primary/20 w-full cursor-pointer appearance-none rounded-lg border-2 px-4 py-2.5 text-sm font-medium [color-scheme:dark] backdrop-blur-sm transition-all duration-200 focus:ring-2 focus:outline-none"
+              >
+                {versions.map((v) => (
+                  <option key={v.version} value={v.version}>
+                    {v.version} {v.is_latest ? "(latest)" : ""}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown
+                className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ecosystem-explorer/src/features/collector/hooks/use-telemetry-comparison.test.ts
+++ b/ecosystem-explorer/src/features/collector/hooks/use-telemetry-comparison.test.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useTelemetryComparison } from "./use-telemetry-comparison";
+import * as collectorData from "@/lib/api/collector-data";
+import { compareTelemetryMetrics } from "../utils/telemetry-diff";
+import type { CollectorComponent, CollectorTelemetryDiffResult } from "@/types/collector";
+
+vi.mock("@/lib/api/collector-data", () => ({
+  loadComponent: vi.fn(),
+}));
+
+vi.mock("../utils/telemetry-diff", () => ({
+  compareTelemetryMetrics: vi.fn(),
+}));
+
+const DISTRIBUTION = "core";
+const NAME = "memorylimiterprocessor";
+
+function stubComponent(version: string): CollectorComponent {
+  return {
+    id: `${DISTRIBUTION}-${NAME}`,
+    name: NAME,
+    ecosystem: "collector",
+    type: "processor",
+    distribution: DISTRIBUTION,
+    description: version,
+  };
+}
+
+describe("useTelemetryComparison hook (collector)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(compareTelemetryMetrics).mockImplementation(
+      (from, to): CollectorTelemetryDiffResult => ({
+        metrics: [
+          {
+            status: "changed",
+            name: "combined",
+            metric: { description: "d", enabled: true, unit: "1" },
+            changes: {
+              description: {
+                before: (from as CollectorComponent | null)?.description ?? "",
+                after: (to as CollectorComponent | null)?.description ?? "",
+              },
+            },
+          },
+        ],
+      })
+    );
+  });
+
+  it("loads both versions and computes a diff", async () => {
+    vi.mocked(collectorData.loadComponent).mockImplementation(async (_d, _n, version) =>
+      stubComponent(version)
+    );
+
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.101.0")
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.diffResult?.metrics[0].changes?.description).toEqual({
+      before: "0.100.0",
+      after: "0.101.0",
+    });
+    expect(result.current.fromNotFound).toBe(false);
+    expect(result.current.toNotFound).toBe(false);
+  });
+
+  it("does not load data when fromVersion and toVersion are the same", () => {
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.100.0")
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.diffResult).toBeNull();
+    expect(collectorData.loadComponent).not.toHaveBeenCalled();
+  });
+
+  it("marks fromNotFound when only the base version fails to load, but still computes a diff", async () => {
+    vi.mocked(collectorData.loadComponent).mockImplementation(async (_d, _n, version) => {
+      if (version === "0.100.0") throw new Error("not found");
+      return stubComponent(version);
+    });
+
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.101.0")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.fromNotFound).toBe(true);
+    expect(result.current.toNotFound).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.diffResult).not.toBeNull();
+  });
+
+  it("marks toNotFound when only the target version fails to load, but still computes a diff", async () => {
+    vi.mocked(collectorData.loadComponent).mockImplementation(async (_d, _n, version) => {
+      if (version === "0.101.0") throw new Error("not found");
+      return stubComponent(version);
+    });
+
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.101.0")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.toNotFound).toBe(true);
+    expect(result.current.fromNotFound).toBe(false);
+    expect(result.current.diffResult).not.toBeNull();
+  });
+
+  it("surfaces an error and does not compute a diff when both versions fail to load", async () => {
+    vi.mocked(collectorData.loadComponent).mockRejectedValue(new Error("not found"));
+
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.101.0")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.fromNotFound).toBe(true);
+    expect(result.current.toNotFound).toBe(true);
+    expect(result.current.diffResult).toBeNull();
+    expect(compareTelemetryMetrics).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale in-flight request overwrite a newer one's result", async () => {
+    let resolveFirst!: (value: CollectorComponent) => void;
+    let resolveSecond!: (value: CollectorComponent) => void;
+    const firstToCall = new Promise<CollectorComponent>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondToCall = new Promise<CollectorComponent>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    vi.mocked(collectorData.loadComponent).mockImplementation(async (_d, _n, version) => {
+      if (version === "0.100.0") return stubComponent(version);
+      if (version === "0.101.0") return firstToCall;
+      if (version === "0.102.0") return secondToCall;
+      throw new Error(`unexpected version ${version}`);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ to }: { to: string }) => useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", to),
+      { initialProps: { to: "0.101.0" } }
+    );
+
+    // Change the target version before the first request resolves - the
+    // "cancelled" guard exists for exactly this case.
+    rerender({ to: "0.102.0" });
+
+    // Resolve the newer (second) request first, then the stale first one, to
+    // prove ordering of resolution - not call order - can't cause a bug.
+    resolveSecond(stubComponent("0.102.0"));
+    await waitFor(() => expect(result.current.toVersion).toBe("0.102.0"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    resolveFirst(stubComponent("0.101.0"));
+    // Give the stale promise's .then chain a chance to run if it were going to.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(result.current.diffResult?.metrics[0].changes?.description?.after).toBe("0.102.0");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("recomputes the diff when the caller changes the from/to versions via the returned setters", async () => {
+    vi.mocked(collectorData.loadComponent).mockImplementation(async (_d, _n, version) =>
+      stubComponent(version)
+    );
+
+    const { result } = renderHook(() =>
+      useTelemetryComparison(DISTRIBUTION, NAME, "0.100.0", "0.101.0")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.toVersion).toBe("0.101.0");
+
+    result.current.setToVersion("0.102.0");
+
+    await waitFor(() => expect(result.current.toVersion).toBe("0.102.0"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.diffResult?.metrics[0].changes?.description?.after).toBe("0.102.0");
+  });
+});

--- a/ecosystem-explorer/src/features/collector/hooks/use-telemetry-comparison.ts
+++ b/ecosystem-explorer/src/features/collector/hooks/use-telemetry-comparison.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import type { CollectorComponent, CollectorTelemetryDiffResult } from "@/types/collector";
+import * as collectorData from "@/lib/api/collector-data";
+import { compareTelemetryMetrics } from "../utils/telemetry-diff";
+
+export interface UseCollectorTelemetryComparisonResult {
+  fromVersion: string;
+  toVersion: string;
+  setFromVersion: (version: string) => void;
+  setToVersion: (version: string) => void;
+  diffResult: CollectorTelemetryDiffResult | null;
+  loading: boolean;
+  error: Error | null;
+  fromNotFound: boolean;
+  toNotFound: boolean;
+}
+
+/**
+ * Compares the internal self-observability telemetry (`telemetry.metrics`) of
+ * one Collector component across two versions. Unlike the Java Agent
+ * equivalent, there is no when-condition state to track here: Collector
+ * metadata has no configuration-dependent telemetry axis.
+ */
+export function useTelemetryComparison(
+  distribution: string,
+  name: string,
+  initialFromVersion: string,
+  initialToVersion: string
+): UseCollectorTelemetryComparisonResult {
+  const { t } = useTranslation("collector");
+  const [customFromVersion, setCustomFromVersion] = useState<string | null>(null);
+  const [customToVersion, setCustomToVersion] = useState<string | null>(null);
+  const [diffResult, setDiffResult] = useState<CollectorTelemetryDiffResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [fromNotFound, setFromNotFound] = useState(false);
+  const [toNotFound, setToNotFound] = useState(false);
+
+  const fromVersion = customFromVersion ?? initialFromVersion;
+  const toVersion = customToVersion ?? initialToVersion;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadComparison() {
+      if (!distribution || !name || !fromVersion || !toVersion) {
+        setDiffResult(null);
+        setLoading(false);
+        setError(null);
+        setFromNotFound(false);
+        setToNotFound(false);
+        return;
+      }
+
+      if (fromVersion === toVersion) {
+        setDiffResult(null);
+        setLoading(false);
+        setError(null);
+        setFromNotFound(false);
+        setToNotFound(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      setFromNotFound(false);
+      setToNotFound(false);
+
+      try {
+        const [fromResult, toResult] = await Promise.allSettled([
+          collectorData.loadComponent(distribution, name, fromVersion),
+          collectorData.loadComponent(distribution, name, toVersion),
+        ]);
+
+        if (cancelled) return;
+
+        const fromComponent: CollectorComponent | null =
+          fromResult.status === "fulfilled" ? fromResult.value : null;
+        const fromLoadFailed = fromResult.status === "rejected";
+
+        const toComponent: CollectorComponent | null =
+          toResult.status === "fulfilled" ? toResult.value : null;
+        const toLoadFailed = toResult.status === "rejected";
+
+        if (fromLoadFailed && toLoadFailed) {
+          setError(new Error(t("telemetryComparison.error.bothVersionsFailed")));
+          setFromNotFound(true);
+          setToNotFound(true);
+          setDiffResult(null);
+          setLoading(false);
+          return;
+        }
+
+        if (fromLoadFailed) {
+          setFromNotFound(true);
+        }
+
+        if (toLoadFailed) {
+          setToNotFound(true);
+        }
+
+        const diff = compareTelemetryMetrics(fromComponent, toComponent);
+        setDiffResult(diff);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setDiffResult(null);
+          setLoading(false);
+        }
+      }
+    }
+
+    loadComparison();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [distribution, name, fromVersion, toVersion, t]);
+
+  return {
+    fromVersion,
+    toVersion,
+    setFromVersion: setCustomFromVersion,
+    setToVersion: setCustomToVersion,
+    diffResult,
+    loading,
+    error,
+    fromNotFound,
+    toNotFound,
+  };
+}

--- a/ecosystem-explorer/src/features/collector/utils/metric-type.test.ts
+++ b/ecosystem-explorer/src/features/collector/utils/metric-type.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { getMetricType } from "./metric-type";
+import type { CollectorMetric } from "@/types/collector";
+
+function makeMetric(overrides: Partial<CollectorMetric> = {}): CollectorMetric {
+  return { description: "d", enabled: true, unit: "1", ...overrides };
+}
+
+describe("getMetricType", () => {
+  it("returns 'sum' when the metric has a sum descriptor", () => {
+    expect(getMetricType(makeMetric({ sum: { value_type: "int", monotonic: true } }))).toBe("sum");
+  });
+
+  it("returns 'gauge' when the metric has a gauge descriptor", () => {
+    expect(getMetricType(makeMetric({ gauge: { value_type: "double" } }))).toBe("gauge");
+  });
+
+  it("returns 'histogram' when the metric has a histogram descriptor", () => {
+    expect(getMetricType(makeMetric({ histogram: { value_type: "int" } }))).toBe("histogram");
+  });
+
+  it("returns null when no descriptor is present", () => {
+    expect(getMetricType(makeMetric())).toBeNull();
+  });
+});

--- a/ecosystem-explorer/src/features/collector/utils/metric-type.ts
+++ b/ecosystem-explorer/src/features/collector/utils/metric-type.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { CollectorMetric } from "@/types/collector";
+
+/** The instrument descriptor kind present on a metric, derived from which of `sum`/`gauge`/`histogram` is set. */
+export function getMetricType(metric: CollectorMetric): "sum" | "gauge" | "histogram" | null {
+  if (metric.sum) return "sum";
+  if (metric.gauge) return "gauge";
+  if (metric.histogram) return "histogram";
+  return null;
+}

--- a/ecosystem-explorer/src/features/collector/utils/telemetry-diff.test.ts
+++ b/ecosystem-explorer/src/features/collector/utils/telemetry-diff.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from "vitest";
+import { compareTelemetryMetrics } from "./telemetry-diff";
+import type { CollectorComponent, CollectorMetric } from "@/types/collector";
+
+function makeMetric(overrides: Partial<CollectorMetric> = {}): CollectorMetric {
+  return {
+    description: "A test metric",
+    enabled: true,
+    unit: "{span}",
+    sum: { value_type: "int", monotonic: true },
+    ...overrides,
+  };
+}
+
+function makeComponent(telemetryMetrics?: Record<string, CollectorMetric>): CollectorComponent {
+  return {
+    id: "core-memorylimiterprocessor",
+    name: "memorylimiterprocessor",
+    ecosystem: "collector",
+    type: "processor",
+    distribution: "core",
+    ...(telemetryMetrics ? { telemetry: { metrics: telemetryMetrics } } : {}),
+  };
+}
+
+describe("compareTelemetryMetrics", () => {
+  it("reports no diffs when telemetry is identical between versions", () => {
+    const metric = makeMetric();
+    const from = makeComponent({ "processor.refused_spans": metric });
+    const to = makeComponent({ "processor.refused_spans": { ...metric } });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics).toEqual([
+      {
+        status: "unchanged",
+        name: "processor.refused_spans",
+        metric: to.telemetry!.metrics!["processor.refused_spans"],
+      },
+    ]);
+  });
+
+  it("reports a metric present only in the target version as added", () => {
+    const from = makeComponent({});
+    const to = makeComponent({ "processor.new_metric": makeMetric() });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics).toHaveLength(1);
+    expect(result.metrics[0]).toMatchObject({ status: "added", name: "processor.new_metric" });
+  });
+
+  it("reports a metric present only in the base version as removed", () => {
+    const from = makeComponent({ "processor.old_metric": makeMetric() });
+    const to = makeComponent({});
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics).toHaveLength(1);
+    expect(result.metrics[0]).toMatchObject({ status: "removed", name: "processor.old_metric" });
+  });
+
+  it("detects a description change", () => {
+    const from = makeComponent({ "processor.metric": makeMetric({ description: "Old desc" }) });
+    const to = makeComponent({ "processor.metric": makeMetric({ description: "New desc" }) });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].status).toBe("changed");
+    expect(result.metrics[0].changes?.description).toEqual({
+      before: "Old desc",
+      after: "New desc",
+    });
+  });
+
+  it("detects a unit change", () => {
+    const from = makeComponent({ "processor.metric": makeMetric({ unit: "ms" }) });
+    const to = makeComponent({ "processor.metric": makeMetric({ unit: "s" }) });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].changes?.unit).toEqual({ before: "ms", after: "s" });
+  });
+
+  it("detects an enabled/opt-in change", () => {
+    const from = makeComponent({ "processor.metric": makeMetric({ enabled: false }) });
+    const to = makeComponent({ "processor.metric": makeMetric({ enabled: true }) });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].changes?.enabled).toEqual({ before: false, after: true });
+  });
+
+  it("detects a stability change", () => {
+    const from = makeComponent({ "processor.metric": makeMetric({ stability: "alpha" }) });
+    const to = makeComponent({ "processor.metric": makeMetric({ stability: "beta" }) });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].changes?.stability).toEqual({ before: "alpha", after: "beta" });
+  });
+
+  it("detects an instrument type change (sum -> gauge)", () => {
+    const from = makeComponent({
+      "processor.metric": makeMetric({
+        sum: { value_type: "int", monotonic: true },
+        gauge: undefined,
+      }),
+    });
+    const to = makeComponent({
+      "processor.metric": makeMetric({ sum: undefined, gauge: { value_type: "int" } }),
+    });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].changes?.type).toEqual({ before: "sum", after: "gauge" });
+  });
+
+  it("detects added and removed attribute keys on the same metric", () => {
+    const from = makeComponent({
+      "processor.metric": makeMetric({ attributes: ["exporter", "success"] }),
+    });
+    const to = makeComponent({
+      "processor.metric": makeMetric({ attributes: ["success", "data_type"] }),
+    });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].changes?.attributes).toEqual({
+      added: ["data_type"],
+      removed: ["exporter"],
+    });
+  });
+
+  it("handles multiple metrics at once, each independently classified", () => {
+    const from = makeComponent({
+      "processor.unchanged": makeMetric(),
+      "processor.removed": makeMetric(),
+      "processor.changed": makeMetric({ description: "before" }),
+    });
+    const to = makeComponent({
+      "processor.unchanged": makeMetric(),
+      "processor.changed": makeMetric({ description: "after" }),
+      "processor.added": makeMetric(),
+    });
+
+    const result = compareTelemetryMetrics(from, to);
+    const byName = Object.fromEntries(result.metrics.map((m) => [m.name, m.status]));
+
+    expect(byName).toEqual({
+      "processor.unchanged": "unchanged",
+      "processor.removed": "removed",
+      "processor.changed": "changed",
+      "processor.added": "added",
+    });
+  });
+
+  it("returns an empty diff when neither version has telemetry", () => {
+    const from = makeComponent();
+    const to = makeComponent();
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics).toEqual([]);
+  });
+
+  it("treats a component with no telemetry.metrics field the same as one with an empty map", () => {
+    const from = makeComponent();
+    const to = makeComponent({ "processor.new": makeMetric() });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics).toEqual([
+      { status: "added", name: "processor.new", metric: to.telemetry!.metrics!["processor.new"] },
+    ]);
+  });
+
+  it("treats a null component (failed to load) as having no telemetry, reporting all of the other side as added", () => {
+    const to = makeComponent({ "processor.a": makeMetric(), "processor.b": makeMetric() });
+
+    const result = compareTelemetryMetrics(null, to);
+
+    expect(result.metrics.map((m) => m.status)).toEqual(["added", "added"]);
+  });
+
+  it("treats a null component (failed to load) as having no telemetry, reporting all of the other side as removed", () => {
+    const from = makeComponent({ "processor.a": makeMetric(), "processor.b": makeMetric() });
+
+    const result = compareTelemetryMetrics(from, null);
+
+    expect(result.metrics.map((m) => m.status)).toEqual(["removed", "removed"]);
+  });
+
+  it("returns an empty diff when both components are null", () => {
+    const result = compareTelemetryMetrics(null, null);
+    expect(result.metrics).toEqual([]);
+  });
+
+  it("does not flag a change when attributes are the same set in a different order", () => {
+    const from = makeComponent({ "processor.metric": makeMetric({ attributes: ["a", "b"] }) });
+    const to = makeComponent({ "processor.metric": makeMetric({ attributes: ["b", "a"] }) });
+
+    const result = compareTelemetryMetrics(from, to);
+
+    expect(result.metrics[0].status).toBe("unchanged");
+  });
+});

--- a/ecosystem-explorer/src/features/collector/utils/telemetry-diff.ts
+++ b/ecosystem-explorer/src/features/collector/utils/telemetry-diff.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+  CollectorComponent,
+  CollectorMetric,
+  CollectorMetricChanges,
+  CollectorMetricDiff,
+  CollectorTelemetryDiffResult,
+} from "@/types/collector";
+import { getMetricType } from "./metric-type";
+
+function diffAttributes(
+  before: string[] = [],
+  after: string[] = []
+): { added: string[]; removed: string[] } | undefined {
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  const added = after.filter((a) => !beforeSet.has(a));
+  const removed = before.filter((a) => !afterSet.has(a));
+  if (added.length === 0 && removed.length === 0) return undefined;
+  return { added, removed };
+}
+
+/**
+ * Compares two versions of the same metric. Returns undefined when nothing
+ * observable changed. There is no `when`-condition axis to consider here:
+ * unlike Java Agent instrumentation telemetry, Collector metadata has no
+ * configuration-dependent variants of a metric.
+ */
+function compareMetric(
+  before: CollectorMetric,
+  after: CollectorMetric
+): CollectorMetricChanges | undefined {
+  const changes: CollectorMetricChanges = {};
+
+  if (before.description !== after.description) {
+    changes.description = { before: before.description, after: after.description };
+  }
+
+  if (before.unit !== after.unit) {
+    changes.unit = { before: before.unit, after: after.unit };
+  }
+
+  if (before.enabled !== after.enabled) {
+    changes.enabled = { before: before.enabled, after: after.enabled };
+  }
+
+  if (before.stability !== after.stability) {
+    changes.stability = { before: before.stability, after: after.stability };
+  }
+
+  const beforeType = getMetricType(before);
+  const afterType = getMetricType(after);
+  if (beforeType !== afterType) {
+    changes.type = { before: beforeType, after: afterType };
+  }
+
+  const attributeChanges = diffAttributes(before.attributes, after.attributes);
+  if (attributeChanges) {
+    changes.attributes = attributeChanges;
+  }
+
+  return Object.keys(changes).length > 0 ? changes : undefined;
+}
+
+/**
+ * Compares the internal self-observability `telemetry.metrics` of two
+ * versions of the same Collector component. Either component may be null
+ * (component missing/failed to load in one version), in which case every
+ * metric on the other side is reported as fully added or removed.
+ */
+export function compareTelemetryMetrics(
+  fromComponent: CollectorComponent | null,
+  toComponent: CollectorComponent | null
+): CollectorTelemetryDiffResult {
+  const fromMetrics = fromComponent?.telemetry?.metrics ?? {};
+  const toMetrics = toComponent?.telemetry?.metrics ?? {};
+
+  const allNames = Array.from(
+    new Set([...Object.keys(fromMetrics), ...Object.keys(toMetrics)])
+  ).sort();
+
+  const metrics: CollectorMetricDiff[] = [];
+
+  for (const name of allNames) {
+    const before = fromMetrics[name];
+    const after = toMetrics[name];
+
+    if (!before && after) {
+      metrics.push({ status: "added", name, metric: after });
+    } else if (before && !after) {
+      metrics.push({ status: "removed", name, metric: before });
+    } else if (before && after) {
+      const changes = compareMetric(before, after);
+      if (changes) {
+        metrics.push({ status: "changed", name, metric: after, changes });
+      } else {
+        metrics.push({ status: "unchanged", name, metric: after });
+      }
+    }
+  }
+
+  return { metrics };
+}

--- a/ecosystem-explorer/src/types/collector.ts
+++ b/ecosystem-explorer/src/types/collector.ts
@@ -70,6 +70,23 @@ export interface CollectorComponent {
   resource_attributes?: { [key: string]: CollectorAttribute };
   /** Content hash of the component's README, if one was found. Used to lazily fetch the markdown file. */
   markdown_hash?: string;
+  /**
+   * Internal self-observability telemetry the component emits about its own
+   * operation (e.g. `processor_memory_limiter_refused_spans`). Distinct from
+   * `metrics`, which describes the signal data the component produces about
+   * the monitored system. Unlike Java Agent telemetry, there is no `when`
+   * condition here — Collector metadata has no configuration-dependent axis.
+   */
+  telemetry?: CollectorTelemetry;
+}
+
+/**
+ * Internal self-observability telemetry block for a Collector component.
+ * Introduced by the upstream mdatagen `telemetry:` field.
+ */
+export interface CollectorTelemetry {
+  /** Internal metrics the component emits about its own operation. Same per-metric shape as the top-level `metrics` field. */
+  metrics?: { [key: string]: CollectorMetric };
 }
 
 /**
@@ -162,4 +179,35 @@ export interface IndexComponent {
   has_readme?: boolean;
   /** Telemetry signals supported across all stability levels (e.g. ["metrics", "traces"]). */
   signals?: string[];
+}
+
+// Internal telemetry comparison types
+export type DiffStatus = "added" | "removed" | "changed" | "unchanged";
+
+/** Metric attribute keys added/removed between versions. Collector attributes are plain key references (`string[]`), so there is no per-attribute type-change concept like Java Agent's typed `Attribute`. */
+export interface CollectorAttributeChanges {
+  added: string[];
+  removed: string[];
+}
+
+export interface CollectorMetricChanges {
+  description?: { before: string; after: string };
+  unit?: { before: string; after: string };
+  enabled?: { before: boolean; after: boolean };
+  stability?: { before?: Stability; after?: Stability };
+  /** The instrument descriptor kind: "sum" | "gauge" | "histogram" | null. */
+  type?: { before: string | null; after: string | null };
+  attributes?: CollectorAttributeChanges;
+}
+
+export interface CollectorMetricDiff {
+  status: DiffStatus;
+  /** Metric name (the key in `telemetry.metrics`). */
+  name: string;
+  metric: CollectorMetric;
+  changes?: CollectorMetricChanges;
+}
+
+export interface CollectorTelemetryDiffResult {
+  metrics: CollectorMetricDiff[];
 }


### PR DESCRIPTION
Collector metadata.yaml can define a `telemetry` block describing internal self-observability metrics a component emits about its own operation (e.g. `processor_memory_limiter_refused_spans`), distinct from the existing `metrics` field which describes the signal data a component produces about the monitored system.

Add a per-component "Internal Telemetry" tab (shown only when the field is present) with the same Current/Comparison UX already used for Java Agent instrumentation telemetry: a From/To version picker and diff cards for added, removed, and changed metrics. Collector telemetry has no `when`-condition concept, so unlike the Java Agent version there is no configuration-axis selector.

The `telemetry` field is expected to already be present in the registry data consumed by this UI.

## What changed

Added an "Internal Telemetry" tab to Collector component pages, with Current View and Version Comparison modes. The comparison view allows users to compare internal telemetry metrics between Collector versions and displays added, removed, and changed metrics.

The UI-only changes in this PR depend on the Collector telemetry data being available in the registry/database output.

## Why

Fixes #877

## How it was tested

- Added and updated frontend tests covering the Internal Telemetry tab, telemetry comparison UI, telemetry diffing, metric types, and comparison loading behavior.
- `bun run typecheck` passed.
- `bun run lint` passed.
- Collector feature tests passed: 94/94.
- Manually verified the UI using real Collector registry telemetry data.
- Verified the Current View displays internal telemetry metrics.
- Verified version comparison displays added and removed metrics between Collector versions.
- Verified changed telemetry metrics are displayed with the appropriate before/after diff.
- Verified there were no console or page errors during the manual verification.

## Is this a breaking change?

No

## Special notes for your reviewer

This PR contains the frontend/UI portion of the Collector Internal Telemetry feature.

The Collector DB-builder telemetry passthrough is being handled separately so that the database can be rebuilt independently before this UI is reviewed and previewed with the updated production data.

Collector telemetry does not have a `when`-condition/configuration concept, so no configuration-axis selector is included.

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)