### PR TITLE
feat(explorer-db-builder): pass through collector telemetry metadata

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_transformer.py
@@ -124,6 +124,10 @@ def transform_collector_components(
             if metrics:
                 component["metrics"] = metrics
 
+            telemetry = metadata.get("telemetry")
+            if telemetry:
+                component["telemetry"] = telemetry
+
             if name in readme_map:
                 component["markdown_hash"] = readme_map[name]
 

--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/collector_transformer.py
@@ -125,7 +125,8 @@ def transform_collector_components(
                 component["metrics"] = metrics
 
             telemetry = metadata.get("telemetry")
-            if telemetry:
+            telemetry_metrics = telemetry.get("metrics") if isinstance(telemetry, dict) else None
+            if telemetry_metrics:
                 component["telemetry"] = telemetry
 
             if name in readme_map:

--- a/ecosystem-automation/explorer-db-builder/tests/test_collector_transformer.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_collector_transformer.py
@@ -106,6 +106,7 @@ class TestTransformCollectorComponents:
         assert component["description"] is None
         assert "attributes" not in component
         assert "metrics" not in component
+        assert "telemetry" not in component
 
     def test_attributes_and_metrics_included(self):
         inventory = _make_inventory(
@@ -135,6 +136,71 @@ class TestTransformCollectorComponents:
         assert "attr1" in component["attributes"]
         assert "metrics" in component
         assert "metric.one" in component["metrics"]
+
+    def test_telemetry_included(self):
+        inventory = _make_inventory(
+            components={
+                "processor": [
+                    {
+                        "name": "memorylimiterprocessor",
+                        "metadata": {
+                            "status": {},
+                            "telemetry": {
+                                "metrics": {
+                                    "processor_memory_limiter_refused_spans": {
+                                        "enabled": True,
+                                        "description": "Number of spans refused.",
+                                        "unit": "{span}",
+                                        "sum": {"value_type": "int", "monotonic": True},
+                                    }
+                                }
+                            },
+                        },
+                    }
+                ],
+                "receiver": [],
+                "exporter": [],
+                "connector": [],
+                "extension": [],
+            }
+        )
+
+        result = transform_collector_components(inventory, "contrib")
+
+        assert len(result) == 1
+        component = result[0]
+        assert "telemetry" in component
+        assert "processor_memory_limiter_refused_spans" in component["telemetry"]["metrics"]
+
+    def test_telemetry_absent_when_not_in_metadata(self):
+        inventory = _make_inventory(
+            components={
+                "receiver": [{"name": "minimalreceiver", "metadata": {"status": {}}}],
+                "processor": [],
+                "exporter": [],
+                "connector": [],
+                "extension": [],
+            }
+        )
+
+        result = transform_collector_components(inventory, "core")
+
+        assert "telemetry" not in result[0]
+
+    def test_telemetry_absent_when_empty_dict(self):
+        inventory = _make_inventory(
+            components={
+                "receiver": [{"name": "minimalreceiver", "metadata": {"status": {}, "telemetry": {}}}],
+                "processor": [],
+                "exporter": [],
+                "connector": [],
+                "extension": [],
+            }
+        )
+
+        result = transform_collector_components(inventory, "core")
+
+        assert "telemetry" not in result[0]
 
     def test_id_format(self):
         inventory = _make_inventory(


### PR DESCRIPTION
Collector metadata.yaml can define a `telemetry` block describing internal self-observability metrics a component emits about its own operation (e.g. `processor_memory_limiter_refused_spans`), distinct from the existing `metrics` field which describes the signal data a component produces about the monitored system. The collector transformer only passed through `attributes` and `metrics`, so `telemetry` was silently dropped before reaching the registry database.

Add the missing passthrough in `collector_transformer.py`: `telemetry` is copied onto the component only when present and non-empty, following the same pattern as the existing `metrics` handling.

## What changed

Added the missing `telemetry` passthrough to the Collector transformer and added tests covering telemetry when present, missing, and empty.

## Why

Ensure Collector internal telemetry metadata from `metadata.yaml` is preserved in the generated registry database so it can be consumed by downstream components.

Related to #877

## How it was tested

- `uv run pytest ecosystem-automation/explorer-db-builder/` — 445 tests passed.
- `uv run ruff check` on the changed Python files — passed.
- `uv run ruff format --check` on the changed Python files — passed.
- Added tests covering:
  - telemetry included when present and non-empty
  - telemetry omitted when missing
  - telemetry omitted when present but empty

## Is this a breaking change?

No

## Special notes for your reviewer

This PR contains only the Collector database-builder changes required to preserve the `metadata.telemetry` field.

The frontend/UI portion of the Collector Internal Telemetry feature is handled separately in PR #941.

Once this PR is merged, the Collector database can be rebuilt so the telemetry data is available to the Internal Telemetry UI.

## Checklist

- [x] Tests added or updated for new behavior
- [ ] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)