### PR TITLE
Remove the need for i18n dependencies

### DIFF
--- a/ecosystem-explorer/bun.lock
+++ b/ecosystem-explorer/bun.lock
@@ -15,8 +15,6 @@
         "@radix-ui/react-tooltip": "1.2.16",
         "cmdk": "1.1.1",
         "i18next": "26.3.6",
-        "i18next-browser-languagedetector": "8.2.1",
-        "i18next-http-backend": "4.0.1",
         "idb": "8.0.3",
         "js-yaml": "5.2.2",
         "lucide-react": "1.25.0",
@@ -664,10 +662,6 @@
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "i18next": ["i18next@26.3.6", "", { "peerDependencies": { "typescript": "^5 || ^6 || ^7" }, "optionalPeers": ["typescript"] }, "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA=="],
-
-    "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
-
-    "i18next-http-backend": ["i18next-http-backend@4.0.1", "", {}, "sha512-O+7MwPCJIKCu68vho8JtD1HF8QHyMPzoChIDFfYCrpaDqX6oq3RqASujnpKEdnNCEOb+kLMOHTNTcGKpj7B1BA=="],
 
     "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -38,8 +38,6 @@
     "@radix-ui/react-tooltip": "1.2.16",
     "cmdk": "1.1.1",
     "i18next": "26.3.6",
-    "i18next-browser-languagedetector": "8.2.1",
-    "i18next-http-backend": "4.0.1",
     "idb": "8.0.3",
     "js-yaml": "5.2.2",
     "lucide-react": "1.25.0",

--- a/ecosystem-explorer/src/i18n/config.ts
+++ b/ecosystem-explorer/src/i18n/config.ts
@@ -29,7 +29,7 @@ i18n
     load: "languageOnly",
     ns: [...NAMESPACES],
     defaultNS: "common",
-    // The load path is a constant inside http-backend.ts, not an option here.
+    // No `backend` block: the load path is a constant inside http-backend.ts.
     interpolation: { escapeValue: false },
   });
 

--- a/ecosystem-explorer/src/i18n/config.ts
+++ b/ecosystem-explorer/src/i18n/config.ts
@@ -15,13 +15,13 @@
  */
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
-import HttpBackend from "i18next-http-backend";
+import { languageDetector } from "@/i18n/language-detector";
+import { httpBackend } from "@/i18n/http-backend";
 import { NAMESPACES, SUPPORTED_LANGUAGES } from "@/i18n/languages";
 
 i18n
-  .use(HttpBackend)
-  .use(LanguageDetector)
+  .use(httpBackend)
+  .use(languageDetector)
   .use(initReactI18next)
   .init({
     fallbackLng: "en",
@@ -29,7 +29,7 @@ i18n
     load: "languageOnly",
     ns: [...NAMESPACES],
     defaultNS: "common",
-    backend: { loadPath: "/locales/{{lng}}/{{ns}}.json" },
+    // The load path is a constant inside http-backend.ts, not an option here.
     interpolation: { escapeValue: false },
   });
 

--- a/ecosystem-explorer/src/i18n/http-backend.test.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.test.ts
@@ -63,6 +63,14 @@ describe("httpBackend", () => {
     expect(fetchMock).toHaveBeenCalledWith("/locales/..%2F..%2Fetc%2Fpasswd/common.json");
   });
 
+  it("percent-encodes the namespace too, so neither URL segment can be traversed", async () => {
+    const fetchMock = mockFetch({ ok: true, status: 200, json: () => Promise.resolve({}) });
+
+    await read("en", "../../etc/passwd");
+
+    expect(fetchMock).toHaveBeenCalledWith("/locales/en/..%2F..%2Fetc%2Fpasswd.json");
+  });
+
   it("does not ask i18next to retry a 404 - the file is genuinely absent", async () => {
     mockFetch({ ok: false, status: 404 });
 

--- a/ecosystem-explorer/src/i18n/http-backend.test.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.test.ts
@@ -17,7 +17,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import type { CallbackError, ResourceKey } from "i18next";
 import { httpBackend } from "@/i18n/http-backend";
 
-/** Invokes read() and resolves with whatever it passes to the i18next callback. */
+/** Resolves with whatever read() passes to the i18next callback. */
 function read(
   language: string,
   namespace: string

--- a/ecosystem-explorer/src/i18n/http-backend.test.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { CallbackError, ResourceKey } from "i18next";
+import { httpBackend } from "@/i18n/http-backend";
+
+/** Invokes read() and resolves with whatever it passes to the i18next callback. */
+function read(
+  language: string,
+  namespace: string
+): Promise<{ error: CallbackError; data: ResourceKey | boolean | null | undefined }> {
+  return new Promise((resolve) => {
+    httpBackend.read(language, namespace, (error, data) => resolve({ error, data }));
+  });
+}
+
+function mockFetch(response: Partial<Response> | Error) {
+  const fetchMock = vi.fn(() =>
+    response instanceof Error ? Promise.reject(response) : Promise.resolve(response as Response)
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("httpBackend", () => {
+  it("fetches the locale file for a language/namespace pair and returns parsed JSON", async () => {
+    const translations = { "nav.home": "Home" };
+    const fetchMock = mockFetch({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(translations),
+    });
+
+    const { error, data } = await read("es", "java-agent");
+
+    expect(fetchMock).toHaveBeenCalledWith("/locales/es/java-agent.json");
+    expect(error).toBeNull();
+    expect(data).toEqual(translations);
+  });
+
+  it("percent-encodes the language so a traversal attempt cannot escape /locales", async () => {
+    const fetchMock = mockFetch({ ok: true, status: 200, json: () => Promise.resolve({}) });
+
+    await read("../../etc/passwd", "common");
+
+    expect(fetchMock).toHaveBeenCalledWith("/locales/..%2F..%2Fetc%2Fpasswd/common.json");
+  });
+
+  it("does not ask i18next to retry a 404 - the file is genuinely absent", async () => {
+    mockFetch({ ok: false, status: 404 });
+
+    const { error, data } = await read("en", "common");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(data).toBe(false);
+  });
+
+  it("asks i18next to retry a 5xx", async () => {
+    mockFetch({ ok: false, status: 503 });
+
+    const { error, data } = await read("en", "common");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(data).toBe(true);
+  });
+
+  it("asks i18next to retry when the request itself fails", async () => {
+    mockFetch(new TypeError("Failed to fetch"));
+
+    const { error, data } = await read("en", "common");
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(data).toBe(true);
+  });
+
+  it("does not retry malformed JSON - a second fetch would return the same bytes", async () => {
+    mockFetch({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new SyntaxError("Unexpected token")),
+    });
+
+    const { error, data } = await read("en", "common");
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("failed parsing");
+    expect(data).toBe(false);
+  });
+});

--- a/ecosystem-explorer/src/i18n/http-backend.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.ts
@@ -45,7 +45,8 @@ async function loadResource(url: string, callback: ReadCallback): Promise<void> 
   try {
     response = await fetch(url);
   } catch (error) {
-    callback(error as Error, true);
+    // A thrown value is only conventionally an Error; i18next logs `.message`.
+    callback(error instanceof Error ? error : new Error(String(error)), true);
     return;
   }
 
@@ -59,7 +60,7 @@ async function loadResource(url: string, callback: ReadCallback): Promise<void> 
   try {
     data = await response.json();
   } catch {
-    callback(new Error(`failed parsing ${url} to json`), false);
+    callback(new Error(`failed parsing ${url} to JSON`), false);
     return;
   }
 

--- a/ecosystem-explorer/src/i18n/http-backend.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Minimal i18next backend that fetches locale JSON from the static
+ * public/locales tree. Replaces i18next-http-backend, whose configurable
+ * surface (custom request functions, XHR fallback, reload intervals, missing-key
+ * POSTs, multi-namespace loads) is unused here — the app only ever needs one
+ * GET per (language, namespace).
+ *
+ * i18next accepts a plain object module as long as it carries `type: "backend"`,
+ * so no class or prototype constructor is needed for a single i18n instance.
+ */
+import type { BackendModule, ReadCallback, ResourceKey } from "i18next";
+
+/** Mirrors the `loadPath` previously passed to i18next-http-backend. */
+const LOAD_PATH = "/locales/{{lng}}/{{ns}}.json";
+
+/**
+ * Builds the request URL for one (language, namespace) pair.
+ *
+ * Both values are percent-encoded rather than interpolated raw. `language` can
+ * originate from user-controlled input (the `?lng=` query parameter, or a
+ * localStorage value written by an earlier visit), so encoding is what keeps a
+ * value like `../../secret` from escaping the locales directory. Namespaces are
+ * compile-time constants, but are encoded too so the rule holds for both slots.
+ */
+function buildUrl(language: string, namespace: string): string {
+  return LOAD_PATH.replace("{{lng}}", encodeURIComponent(language)).replace(
+    "{{ns}}",
+    encodeURIComponent(namespace)
+  );
+}
+
+/**
+ * The second callback argument is i18next's retry flag: `true` asks it to try
+ * the same resource again later. Retry only on failures that a later attempt
+ * could plausibly resolve — network errors and 5xx. A 4xx means the file is
+ * genuinely absent, and a parse failure means it is present but malformed;
+ * retrying either just burns requests.
+ */
+async function loadResource(url: string, callback: ReadCallback): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    callback(error as Error, true);
+    return;
+  }
+
+  if (!response.ok) {
+    const retry = response.status >= 500;
+    callback(new Error(`failed loading ${url}; status code: ${response.status}`), retry);
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    callback(new Error(`failed parsing ${url} to json`), false);
+    return;
+  }
+
+  callback(null, data as ResourceKey);
+}
+
+export const httpBackend: BackendModule = {
+  type: "backend",
+
+  // Options come from module constants rather than i18next's `backend` config
+  // block, so there is nothing to wire up here.
+  init() {},
+
+  read(language, namespace, callback) {
+    void loadResource(buildUrl(language, namespace), callback);
+  },
+};

--- a/ecosystem-explorer/src/i18n/http-backend.ts
+++ b/ecosystem-explorer/src/i18n/http-backend.ts
@@ -15,28 +15,17 @@
  */
 
 /*
- * Minimal i18next backend that fetches locale JSON from the static
- * public/locales tree. Replaces i18next-http-backend, whose configurable
- * surface (custom request functions, XHR fallback, reload intervals, missing-key
- * POSTs, multi-namespace loads) is unused here — the app only ever needs one
- * GET per (language, namespace).
- *
- * i18next accepts a plain object module as long as it carries `type: "backend"`,
- * so no class or prototype constructor is needed for a single i18n instance.
+ * Minimal replacement for i18next-http-backend: the app only ever needs one GET
+ * per (language, namespace) from the static public/locales tree.
  */
 import type { BackendModule, ReadCallback, ResourceKey } from "i18next";
 
-/** Mirrors the `loadPath` previously passed to i18next-http-backend. */
 const LOAD_PATH = "/locales/{{lng}}/{{ns}}.json";
 
 /**
- * Builds the request URL for one (language, namespace) pair.
- *
- * Both values are percent-encoded rather than interpolated raw. `language` can
- * originate from user-controlled input (the `?lng=` query parameter, or a
- * localStorage value written by an earlier visit), so encoding is what keeps a
- * value like `../../secret` from escaping the locales directory. Namespaces are
- * compile-time constants, but are encoded too so the rule holds for both slots.
+ * `language` is user-controlled (the `?lng=` query parameter, or a localStorage
+ * value written by an earlier visit), so percent-encoding is what keeps a value
+ * like `../../secret` from escaping the locales directory.
  */
 function buildUrl(language: string, namespace: string): string {
   return LOAD_PATH.replace("{{lng}}", encodeURIComponent(language)).replace(
@@ -46,11 +35,10 @@ function buildUrl(language: string, namespace: string): string {
 }
 
 /**
- * The second callback argument is i18next's retry flag: `true` asks it to try
- * the same resource again later. Retry only on failures that a later attempt
- * could plausibly resolve — network errors and 5xx. A 4xx means the file is
- * genuinely absent, and a parse failure means it is present but malformed;
- * retrying either just burns requests.
+ * The second callback argument is i18next's retry flag. Set it only for failures
+ * a later attempt could plausibly resolve — network errors and 5xx. A 4xx means
+ * the file is absent and a parse failure means it is malformed; retrying either
+ * just burns requests.
  */
 async function loadResource(url: string, callback: ReadCallback): Promise<void> {
   let response: Response;
@@ -81,8 +69,7 @@ async function loadResource(url: string, callback: ReadCallback): Promise<void> 
 export const httpBackend: BackendModule = {
   type: "backend",
 
-  // Options come from module constants rather than i18next's `backend` config
-  // block, so there is nothing to wire up here.
+  // Required by the interface; this backend takes no options.
   init() {},
 
   read(language, namespace, callback) {

--- a/ecosystem-explorer/src/i18n/language-detector.test.ts
+++ b/ecosystem-explorer/src/i18n/language-detector.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { languageDetector } from "@/i18n/language-detector";
+
+const STORAGE_KEY = "i18nextLng";
+
+/** detect() is optional on i18next's async detector interface, so narrow it once. */
+function detect(): string[] {
+  return languageDetector.detect() as string[];
+}
+
+function setQueryString(search: string) {
+  window.history.replaceState({}, "", search === "" ? "/" : `/?${search}`);
+}
+
+function setNavigatorLanguages(languages: string[]) {
+  vi.spyOn(window.navigator, "languages", "get").mockReturnValue(languages);
+}
+
+/**
+ * jsdom reports navigator.language as "en-US", so both navigator sources have to
+ * be silenced for a test to assert on the other detection sources in isolation.
+ */
+function silenceNavigator() {
+  setNavigatorLanguages([]);
+  vi.spyOn(window.navigator, "language", "get").mockReturnValue("");
+}
+
+beforeEach(() => {
+  setQueryString("");
+  window.localStorage.clear();
+  silenceNavigator();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setQueryString("");
+  window.localStorage.clear();
+});
+
+describe("languageDetector.detect", () => {
+  it("returns candidates in priority order: query string, storage, then navigator", () => {
+    setQueryString("lng=de");
+    window.localStorage.setItem(STORAGE_KEY, "es");
+    setNavigatorLanguages(["fr-FR", "fr"]);
+
+    expect(detect()).toEqual(["de", "es", "fr-FR", "fr"]);
+  });
+
+  it("falls back to the stored language when no query string is present", () => {
+    window.localStorage.setItem(STORAGE_KEY, "es");
+
+    expect(detect()).toEqual(["es"]);
+  });
+
+  it("offers the full navigator preference list so i18next can match a region tag to a base language", () => {
+    setNavigatorLanguages(["en-GB", "en"]);
+
+    expect(detect()).toEqual(["en-GB", "en"]);
+  });
+
+  it("uses navigator.language when navigator.languages is empty", () => {
+    vi.spyOn(window.navigator, "language", "get").mockReturnValue("es-419");
+
+    expect(detect()).toEqual(["es-419"]);
+  });
+
+  it("drops candidates that are not shaped like language tags", () => {
+    setQueryString("lng=%3Cscript%3Ealert(1)%3C%2Fscript%3E");
+    window.localStorage.setItem(STORAGE_KEY, "../../etc/passwd");
+    setNavigatorLanguages(["en"]);
+
+    expect(detect()).toEqual(["en"]);
+  });
+
+  it("returns an empty list when nothing is detectable", () => {
+    expect(detect()).toEqual([]);
+  });
+
+  it("survives localStorage access throwing, as in Safari private browsing", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    setNavigatorLanguages(["es"]);
+
+    expect(detect()).toEqual(["es"]);
+  });
+});
+
+describe("languageDetector.cacheUserLanguage", () => {
+  it("persists the choice under the key i18next-browser-languagedetector used", () => {
+    languageDetector.cacheUserLanguage?.("es");
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("es");
+  });
+
+  it("does not persist cimode, which would strand the user in debug mode", () => {
+    languageDetector.cacheUserLanguage?.("cimode");
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("survives localStorage writes throwing", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    expect(() => languageDetector.cacheUserLanguage?.("es")).not.toThrow();
+  });
+});

--- a/ecosystem-explorer/src/i18n/language-detector.test.ts
+++ b/ecosystem-explorer/src/i18n/language-detector.test.ts
@@ -18,7 +18,7 @@ import { languageDetector } from "@/i18n/language-detector";
 
 const STORAGE_KEY = "i18nextLng";
 
-/** detect() is optional on i18next's async detector interface, so narrow it once. */
+/** detect() is optional on i18next's detector interface, so narrow it once. */
 function detect(): string[] {
   return languageDetector.detect() as string[];
 }
@@ -31,10 +31,7 @@ function setNavigatorLanguages(languages: string[]) {
   vi.spyOn(window.navigator, "languages", "get").mockReturnValue(languages);
 }
 
-/**
- * jsdom reports navigator.language as "en-US", so both navigator sources have to
- * be silenced for a test to assert on the other detection sources in isolation.
- */
+/** jsdom reports navigator.language as "en-US", so both navigator sources need silencing to isolate the others. */
 function silenceNavigator() {
   setNavigatorLanguages([]);
   vi.spyOn(window.navigator, "language", "get").mockReturnValue("");

--- a/ecosystem-explorer/src/i18n/language-detector.ts
+++ b/ecosystem-explorer/src/i18n/language-detector.ts
@@ -45,6 +45,7 @@ function fromQueryString(): string | undefined {
 
 /** Reading localStorage throws (not returns null) when storage is disabled, e.g. Safari private browsing. */
 function fromLocalStorage(): string | undefined {
+  if (typeof window === "undefined") return undefined;
   try {
     return window.localStorage.getItem(STORAGE_KEY) ?? undefined;
   } catch {
@@ -74,6 +75,7 @@ export const languageDetector: LanguageDetectorModule = {
 
   cacheUserLanguage(language: string): void {
     if (NEVER_CACHED.includes(language)) return;
+    if (typeof window === "undefined") return;
     try {
       window.localStorage.setItem(STORAGE_KEY, language);
     } catch {

--- a/ecosystem-explorer/src/i18n/language-detector.ts
+++ b/ecosystem-explorer/src/i18n/language-detector.ts
@@ -15,45 +15,26 @@
  */
 
 /*
- * Minimal i18next language detector. Replaces i18next-browser-languagedetector.
- *
- * That package ships eight detection sources (querystring, cookie, localStorage,
- * sessionStorage, navigator, htmlTag, path, subdomain, hash); this keeps the
- * three the app actually uses and drops the rest:
- *
- * - cookie / sessionStorage — the app sets neither.
- * - htmlTag — index.html hardcodes `lang="en"`, and config.ts overwrites the
- *   attribute on every languageChanged, so as a *source* it can only ever echo
- *   back `fallbackLng`.
- * - path / subdomain / hash — off by default upstream; the app has no
- *   locale-prefixed routes.
- *
- * The localStorage key is deliberately unchanged (`i18nextLng`), so a visitor
- * who picked a language before this swap keeps that selection afterwards.
+ * Minimal replacement for i18next-browser-languagedetector, keeping only the
+ * three detection sources the app uses (querystring, localStorage, navigator).
+ * The dropped ones — cookie, sessionStorage, path, subdomain, hash — have no
+ * counterpart here, and htmlTag can only ever echo back `fallbackLng` because
+ * config.ts rewrites that attribute on every languageChanged.
  */
 import type { LanguageDetectorModule } from "i18next";
 
-/** Upstream default for `lookupLocalStorage`. Changing this would silently reset every existing visitor's language. */
+/** Upstream's `lookupLocalStorage` default; changing it would reset every existing visitor's language. */
 const STORAGE_KEY = "i18nextLng";
 
-/** Upstream default for `lookupQuerystring`. */
 const QUERY_PARAM = "lng";
 
-/**
- * i18next's pseudo-language for debugging translation keys. Caching it would
- * strand the user in debug mode across reloads, so it is never persisted —
- * matching upstream's `excludeCacheFor` default.
- */
+/** i18next's key-debugging pseudo-language; persisting it would strand the user in debug mode. */
 const NEVER_CACHED = ["cimode"];
 
 /**
- * Loose BCP-47 shape: a primary subtag plus optional hyphenated subtags.
- *
- * Candidates reach this from the query string and localStorage, so they are
- * untrusted. Upstream screens them with a blocklist of XSS-looking patterns; an
- * allowlist of what a language tag may contain is both shorter and strictly
- * tighter. i18next's own `supportedLngs` filtering is the real gate on which
- * languages activate — this only keeps obvious junk out of the candidate list.
+ * Loose BCP-47 shape, used to keep obvious junk out of the untrusted candidates
+ * (query string, localStorage). i18next's `supportedLngs` is the real gate on
+ * which languages actually activate.
  */
 const LANGUAGE_TAG = /^[a-z]{2,8}(-[a-z0-9]{1,8})*$/i;
 
@@ -62,11 +43,7 @@ function fromQueryString(): string | undefined {
   return new URLSearchParams(window.location.search).get(QUERY_PARAM) ?? undefined;
 }
 
-/**
- * Reading localStorage throws — not returns null — when storage is disabled
- * (Safari private browsing, hardened browser settings), which would otherwise
- * take down i18n init entirely.
- */
+/** Reading localStorage throws (not returns null) when storage is disabled, e.g. Safari private browsing. */
 function fromLocalStorage(): string | undefined {
   try {
     return window.localStorage.getItem(STORAGE_KEY) ?? undefined;
@@ -75,7 +52,6 @@ function fromLocalStorage(): string | undefined {
   }
 }
 
-/** `navigator.languages` is ordered by user preference; `language` is the single top choice. */
 function fromNavigator(): string[] {
   if (typeof navigator === "undefined") return [];
   if (navigator.languages?.length) return [...navigator.languages];
@@ -86,9 +62,9 @@ export const languageDetector: LanguageDetectorModule = {
   type: "languageDetector",
 
   /*
-   * Returns every candidate in priority order rather than a single language.
-   * i18next (>= 19.5) resolves the list against `supportedLngs` and `load`,
-   * which is what lets a browser advertising `en-GB` match the `en` bundle.
+   * Returns all candidates in priority order, not a single language: i18next
+   * resolves the list against `supportedLngs` and `load`, which is what lets a
+   * browser advertising `en-GB` match the `en` bundle.
    */
   detect(): string[] {
     return [fromQueryString(), fromLocalStorage(), ...fromNavigator()].filter(

--- a/ecosystem-explorer/src/i18n/language-detector.ts
+++ b/ecosystem-explorer/src/i18n/language-detector.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Minimal i18next language detector. Replaces i18next-browser-languagedetector.
+ *
+ * That package ships eight detection sources (querystring, cookie, localStorage,
+ * sessionStorage, navigator, htmlTag, path, subdomain, hash); this keeps the
+ * three the app actually uses and drops the rest:
+ *
+ * - cookie / sessionStorage — the app sets neither.
+ * - htmlTag — index.html hardcodes `lang="en"`, and config.ts overwrites the
+ *   attribute on every languageChanged, so as a *source* it can only ever echo
+ *   back `fallbackLng`.
+ * - path / subdomain / hash — off by default upstream; the app has no
+ *   locale-prefixed routes.
+ *
+ * The localStorage key is deliberately unchanged (`i18nextLng`), so a visitor
+ * who picked a language before this swap keeps that selection afterwards.
+ */
+import type { LanguageDetectorModule } from "i18next";
+
+/** Upstream default for `lookupLocalStorage`. Changing this would silently reset every existing visitor's language. */
+const STORAGE_KEY = "i18nextLng";
+
+/** Upstream default for `lookupQuerystring`. */
+const QUERY_PARAM = "lng";
+
+/**
+ * i18next's pseudo-language for debugging translation keys. Caching it would
+ * strand the user in debug mode across reloads, so it is never persisted —
+ * matching upstream's `excludeCacheFor` default.
+ */
+const NEVER_CACHED = ["cimode"];
+
+/**
+ * Loose BCP-47 shape: a primary subtag plus optional hyphenated subtags.
+ *
+ * Candidates reach this from the query string and localStorage, so they are
+ * untrusted. Upstream screens them with a blocklist of XSS-looking patterns; an
+ * allowlist of what a language tag may contain is both shorter and strictly
+ * tighter. i18next's own `supportedLngs` filtering is the real gate on which
+ * languages activate — this only keeps obvious junk out of the candidate list.
+ */
+const LANGUAGE_TAG = /^[a-z]{2,8}(-[a-z0-9]{1,8})*$/i;
+
+function fromQueryString(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return new URLSearchParams(window.location.search).get(QUERY_PARAM) ?? undefined;
+}
+
+/**
+ * Reading localStorage throws — not returns null — when storage is disabled
+ * (Safari private browsing, hardened browser settings), which would otherwise
+ * take down i18n init entirely.
+ */
+function fromLocalStorage(): string | undefined {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** `navigator.languages` is ordered by user preference; `language` is the single top choice. */
+function fromNavigator(): string[] {
+  if (typeof navigator === "undefined") return [];
+  if (navigator.languages?.length) return [...navigator.languages];
+  return navigator.language ? [navigator.language] : [];
+}
+
+export const languageDetector: LanguageDetectorModule = {
+  type: "languageDetector",
+
+  /*
+   * Returns every candidate in priority order rather than a single language.
+   * i18next (>= 19.5) resolves the list against `supportedLngs` and `load`,
+   * which is what lets a browser advertising `en-GB` match the `en` bundle.
+   */
+  detect(): string[] {
+    return [fromQueryString(), fromLocalStorage(), ...fromNavigator()].filter(
+      (candidate): candidate is string => candidate !== undefined && LANGUAGE_TAG.test(candidate)
+    );
+  },
+
+  cacheUserLanguage(language: string): void {
+    if (NEVER_CACHED.includes(language)) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, language);
+    } catch {
+      // Persisting the choice is best-effort; the app still works for this session.
+    }
+  },
+};


### PR DESCRIPTION
Part of an initiative I'm doing to reduce our attack surface by removing/replacing dependencies where reasonable.

These i18n libraries cover a ton of functionality we aren't using, so we can rip them out until a time where we might need more advanced functionality