### PR TITLE
Add prHourlyLimit to Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
   internalChecksFilter: "strict",
   labels: ["dependencies"],
   schedule: ["before 8am on Monday"],
+  prHourlyLimit: 10,
   lockFileMaintenance: {
     enabled: true,
     schedule: ["before 4am on Monday"],


### PR DESCRIPTION
## What changed

Set the hourly pr limit to 10 which is the same as the default concurrent limit.

Note, i would normally suggest to introduce grouping of atleast patches but i see that was previously removed.

## Why

Reduces occurrences of renovate being rate limited from raising pr’s and needing to wait another week before it can raise again.

<img width="810" height="1080" alt="IMG_0347" src="https://github.com/user-attachments/assets/d9004449-4f6b-47a4-a980-292f45447b43" />


## How it was tested

Used in ruby sig repo’s

## Is this a breaking change?

No

## Special notes for your reviewer

<!-- Anything else you would like the reviewer to know? -->

## Checklist

- [ ] Tests added or updated for new behavior
- [ ] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
