### PR TITLE
fix(collector): render backtick-wrapped card descriptions as code

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-components-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.test.tsx
@@ -321,4 +321,27 @@ describe("CollectorComponentsPage", () => {
       expect(screen.queryByText("Profiles", { selector: "span" })).not.toBeInTheDocument();
     });
   });
+
+  it("renders backtick-wrapped text in a card description as code elements", () => {
+    vi.mocked(useCollectorComponents).mockReturnValue({
+      data: [
+        {
+          id: "contrib-apachesparkreceiver",
+          name: "apachesparkreceiver",
+          type: "receiver",
+          distribution: "contrib",
+          display_name: "Apache Spark Receiver",
+          description: "Fetches metrics via the `/metrics/json` endpoint.",
+          stability: "beta",
+          signals: ["metrics"],
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.getByText("/metrics/json").tagName).toBe("CODE");
+  });
 });

--- a/ecosystem-explorer/src/features/collector/collector-components-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-components-page.tsx
@@ -35,6 +35,7 @@ import { BackButton } from "@/components/ui/back-button";
 import { GlowBadge } from "@/components/ui/glow-badge";
 import { DetailCard } from "@/components/ui/detail-card";
 import { SignalBadge } from "@/components/ui/signal-badge";
+import { renderWithInlineCode } from "@/lib/render-inline-code";
 import { useCollectorVersions, useCollectorComponents } from "@/hooks/use-collector-data";
 import { getPresentSignals, SIGNAL_ORDER, type CollectorSignal } from "./utils/signal-badge-info";
 import { SIGNAL_STYLES, getSignalFilterClasses } from "./styles/signal-styles";
@@ -492,7 +493,9 @@ function CollectorComponentsContent({ urlVersion }: { urlVersion?: string }) {
                       </div>
 
                       <p className="text-muted-foreground/80 line-clamp-3 flex-1 text-sm leading-relaxed">
-                        {comp.description || t("card.defaultDescription")}
+                        {comp.description
+                          ? renderWithInlineCode(comp.description)
+                          : t("card.defaultDescription")}
                       </p>
 
                       <div className="border-border/10 flex flex-wrap items-center gap-2 border-t pt-2">


### PR DESCRIPTION
## What changed

collector-components-page.tsx's card grid rendered comp.description as a raw string, so backtick-wrapped text showed up literally instead of styled as code. I wired it up to the same renderWithInlineCode utility instrumentation-card.tsx and collector-detail-page.tsx already use for exactly this, keeping the existing fallback to card.defaultDescription when a component has no description.

## Why

Fixes #961 

## How it was tested

<img width="1844" height="969" alt="Screenshot from 2026-08-10 15-48-02" src="https://github.com/user-attachments/assets/7b6830af-4fc7-44bb-9d73-6bd5b59d3453" />

## Is this a breaking change?

No

## Special notes for your reviewer

NA

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
