### PR TITLE
Add correction for wrong sensitive query parameter property

### DIFF
--- a/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
+++ b/ecosystem-automation/explorer-db-builder/src/explorer_db_builder/declarative_name_corrections.py
@@ -45,6 +45,18 @@ logger = logging.getLogger(__name__)
 
 DECLARATIVE_NAME_CORRECTIONS: dict[str, str] = {
     "java.common.peer_service_mapping": "java.common.service_peer_mapping",
+    # The declarative config schema defines this field as `sensitive_query_parameters` (no
+    # `/development` suffix) in every released version, and `instrumentation/development.general`
+    # is a strictly typed model (`additionalProperties: false` all the way down) — unlike the
+    # free-form `instrumentation/development.java` map, where an unknown key is ignored. So the
+    # suffixed name makes the agent reject the whole file at startup:
+    #   Unrecognized field "sensitive_query_parameters/development"
+    #   (class ExperimentalUrlSanitizationModel), not marked as ignorable
+    # which aborts SDK autoconfiguration ("OpenTelemetry Javaagent failed to start") while leaving
+    # the JVM running uninstrumented.
+    "general.sanitization.url.sensitive_query_parameters/development": (
+        "general.sanitization.url.sensitive_query_parameters"
+    ),
 }
 
 # Configs (keyed by ``declarative_name``) whose ``description`` is normalized to the newest

--- a/ecosystem-automation/explorer-db-builder/tests/test_declarative_name_corrections.py
+++ b/ecosystem-automation/explorer-db-builder/tests/test_declarative_name_corrections.py
@@ -65,6 +65,32 @@ class TestApplyDeclarativeNameCorrections:
 
         assert inventory["custom"][0]["configurations"][0]["declarative_name"] == "java.common.service_peer_mapping"
 
+    def test_strips_development_suffix_from_general_url_sanitization(self):
+        """The general.* URL sanitization config loses its bogus `/development` suffix.
+
+        The suffixed name is not in the declarative config schema's strictly typed
+        `instrumentation/development.general` model, so the agent rejects the whole config file.
+        """
+        inventory = {
+            "libraries": [
+                {
+                    "name": "http-url-connection",
+                    "configurations": [
+                        _config(
+                            "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters",
+                            "general.sanitization.url.sensitive_query_parameters/development",
+                        )
+                    ],
+                }
+            ]
+        }
+
+        apply_declarative_name_corrections(inventory)
+
+        config = inventory["libraries"][0]["configurations"][0]
+        assert config["declarative_name"] == "general.sanitization.url.sensitive_query_parameters"
+        assert config["name"] == "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters"
+
     def test_leaves_unrelated_declarative_names_untouched(self):
         """Declarative names without a correction entry are left as-is."""
         inventory = {


### PR DESCRIPTION
I found that upstream was putting `general.sanitization.url.sensitive_query_parameters/development` instead of `general.sanitization.url.sensitive_query_parameters` which causes the file loading to fail. I am fixing this upstream too, but putting in a shim here to backfill corrections.

After this is merged I will rebuild the database and then I will add a followup PR to add a smoke test that better catches things like this