### PR TITLE
feat(java-watcher): scrape JMX weaver models

### DIFF
--- a/ecosystem-automation/java-instrumentation-watcher/README.md
+++ b/ecosystem-automation/java-instrumentation-watcher/README.md
@@ -19,15 +19,15 @@ Process:
 - Create or update versioned snapshots of instrumentation metadata in YAML format
 - Discover and fetch each instrumentation's upstream `library/README.md` and store it in the
   version's `library_readmes/` directory (content-addressed)
-- Discover and fetch JMX weaver model YAML files from `instrumentation/jmx-metrics/model/*.yaml`,
-  store them content-addressed once in a shared `jmx/` directory, and write a per-version
-  `jmx-models.yaml` index
+- For releases, discover and fetch JMX weaver model YAML files from
+  `instrumentation/jmx-metrics/model/*.yaml`, store them content-addressed once in a shared `jmx/`
+  directory, and write a per-release `jmx-models.yaml` index
 - Update snapshot from the `main` branch
 
 It maintains a versioned inventory of instrumentation snapshots in the
 `ecosystem-registry/java/javaagent` directory. Each version directory contains the aggregated
 `instrumentation.yaml` plus a `library_readmes/` subdirectory of content-addressed README markdown
-files (one per instrumentation that ships a README upstream). Versions that include JMX weaver
+files (one per instrumentation that ships a README upstream). Releases that include JMX weaver
 models also contain `jmx-models.yaml`, which points at shared content-addressed files in
 `ecosystem-registry/java/javaagent/jmx/`.
 

--- a/ecosystem-automation/java-instrumentation-watcher/README.md
+++ b/ecosystem-automation/java-instrumentation-watcher/README.md
@@ -19,12 +19,17 @@ Process:
 - Create or update versioned snapshots of instrumentation metadata in YAML format
 - Discover and fetch each instrumentation's upstream `library/README.md` and store it in the
   version's `library_readmes/` directory (content-addressed)
+- Discover and fetch JMX weaver model YAML files from `instrumentation/jmx-metrics/model/*.yaml`,
+  store them content-addressed once in a shared `jmx/` directory, and write a per-version
+  `jmx-models.yaml` index
 - Update snapshot from the `main` branch
 
 It maintains a versioned inventory of instrumentation snapshots in the
 `ecosystem-registry/java/javaagent` directory. Each version directory contains the aggregated
 `instrumentation.yaml` plus a `library_readmes/` subdirectory of content-addressed README markdown
-files (one per instrumentation that ships a README upstream).
+files (one per instrumentation that ships a README upstream). Versions that include JMX weaver
+models also contain `jmx-models.yaml`, which points at shared content-addressed files in
+`ecosystem-registry/java/javaagent/jmx/`.
 
 ### Data Processing
 

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
@@ -23,6 +23,7 @@ from semantic_version import Version
 from .instrumentation_parser import parse_instrumentation_yaml
 from .inventory_manager import InventoryManager
 from .java_instrumentation_client import GithubAPIError, JavaInstrumentationClient
+from .jmx_model_extractor import JmxModelExtractor
 from .readme_extractor import ReadmeExtractor
 
 logger = logging.getLogger(__name__)
@@ -38,16 +39,19 @@ class InstrumentationSync:
         client: JavaInstrumentationClient,
         inventory_manager: InventoryManager,
         readme_extractor: ReadmeExtractor | None = None,
+        jmx_model_extractor: JmxModelExtractor | None = None,
     ):
         """
         Args:
             client: GitHub API client for fetching data
             inventory_manager: Inventory manager for storing data
             readme_extractor: README extractor (defaults to ReadmeExtractor(client))
+            jmx_model_extractor: JMX model extractor (defaults to JmxModelExtractor(client))
         """
         self.client = client
         self.inventory_manager = inventory_manager
         self.readme_extractor = readme_extractor or ReadmeExtractor(client)
+        self.jmx_model_extractor = jmx_model_extractor or JmxModelExtractor(client)
 
     def sync(self) -> dict[str, Any]:
         """
@@ -96,6 +100,8 @@ class InstrumentationSync:
             if not self.inventory_manager.readme_dir_exists(version):
                 instrumentations = self.inventory_manager.load_versioned_inventory(version)
                 self._sync_library_readmes(version, tag_string, instrumentations)
+            if not self.inventory_manager.jmx_models_index_exists(version):
+                self._sync_jmx_models(version, tag_string)
             return None
 
         logger.info(f"  Fetching instrumentation list for {tag_string}...")
@@ -107,6 +113,7 @@ class InstrumentationSync:
             instrumentations=instrumentations,
         )
         self._sync_library_readmes(version, tag_string, instrumentations)
+        self._sync_jmx_models(version, tag_string)
 
         return version
 
@@ -153,6 +160,7 @@ class InstrumentationSync:
             instrumentations=instrumentations,
         )
         self._sync_library_readmes(snapshot_version, main_ref, instrumentations)
+        self._sync_jmx_models(snapshot_version, main_ref)
 
         return snapshot_version
 
@@ -198,3 +206,50 @@ class InstrumentationSync:
 
         written = self.inventory_manager.save_library_readmes(version, fetched)
         logger.info(f"  Stored {written} library README(s) for v{version}")
+
+    def _sync_jmx_models(self, version: Version, ref: str) -> None:
+        """Best-effort: fetch JMX weaver model files and write version index."""
+        try:
+            sha = ref if _SHA_RE.match(ref) else self.client.resolve_ref_to_sha(ref)
+            discovered_models, manifest_path = self.jmx_model_extractor.discover_jmx_model_paths(sha)
+        except GithubAPIError as e:
+            logger.warning(f"  JMX model discovery failed for {ref}: {e}")
+            return
+
+        if not discovered_models and manifest_path is None:
+            logger.info(f"  No JMX weaver model files found at {ref}")
+            return
+
+        models: dict[str, str] = {}
+        fetch_failed = False
+        for target_system, path in sorted(discovered_models.items()):
+            try:
+                models[target_system] = self.jmx_model_extractor.fetch_model(path, sha)
+            except GithubAPIError as e:
+                logger.warning(f"  JMX model fetch failed for {target_system}: {e}")
+                fetch_failed = True
+
+        manifest_content = None
+        if manifest_path is not None:
+            try:
+                manifest_content = self.jmx_model_extractor.fetch_model(manifest_path, sha)
+            except GithubAPIError as e:
+                logger.warning(f"  JMX manifest fetch failed: {e}")
+                fetch_failed = True
+
+        if fetch_failed:
+            logger.warning(f"  JMX model index not written for v{version}; fetch incomplete")
+            return
+
+        written_models, manifest_file = self.inventory_manager.save_jmx_models_index(
+            version=version,
+            models=models,
+            manifest=manifest_content,
+        )
+
+        if not written_models and manifest_file is None:
+            logger.info(f"  No JMX model index written for v{version}")
+            return
+
+        suffix = " and manifest" if manifest_file else ""
+        logger.info(f"  Stored {len(written_models)} JMX model file(s){suffix} for v{version}")

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/instrumentation_sync.py
@@ -160,7 +160,6 @@ class InstrumentationSync:
             instrumentations=instrumentations,
         )
         self._sync_library_readmes(snapshot_version, main_ref, instrumentations)
-        self._sync_jmx_models(snapshot_version, main_ref)
 
         return snapshot_version
 
@@ -246,10 +245,6 @@ class InstrumentationSync:
             models=models,
             manifest=manifest_content,
         )
-
-        if not written_models and manifest_file is None:
-            logger.info(f"  No JMX model index written for v{version}")
-            return
 
         suffix = " and manifest" if manifest_file else ""
         logger.info(f"  Stored {len(written_models)} JMX model file(s){suffix} for v{version}")

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/inventory_manager.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/inventory_manager.py
@@ -50,7 +50,6 @@ class InventoryManager(JavaagentInventoryManager):
             persisted, returns ({}, None) and does not write an index file.
         """
         jmx_dir = self.get_jmx_store_dir()
-        jmx_dir.mkdir(parents=True, exist_ok=True)
 
         indexed_models: dict[str, str] = {}
         for target_system in sorted(models):
@@ -79,6 +78,7 @@ class InventoryManager(JavaagentInventoryManager):
 
     def _save_jmx_content_addressed_file(self, jmx_dir: Path, name: str, content: str) -> str:
         """Save one JMX YAML file content-addressed in shared JMX directory."""
+        jmx_dir.mkdir(parents=True, exist_ok=True)
         safe_name = self._sanitize_name(name)
         digest = compute_content_hash(content)
         filename = f"{safe_name}-{digest}.yaml"

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/inventory_manager.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/inventory_manager.py
@@ -14,10 +14,75 @@
 #
 """Inventory management for Java instrumentation tracking."""
 
+from pathlib import Path
+from typing import Any
+
+import yaml
+from semantic_version import Version
+from watcher_common.content_hashing import compute_content_hash
 from watcher_common.inventory_manager import JavaagentInventoryManager
 
 
 class InventoryManager(JavaagentInventoryManager):
     """Manages Java instrumentation inventory storage and retrieval."""
 
-    pass
+    JMX_DIR = "jmx"
+    JMX_MODELS_INDEX_FILE = "jmx-models.yaml"
+
+    def get_jmx_store_dir(self) -> Path:
+        """Return shared content-addressed directory for JMX model YAML files."""
+        return self.inventory_dir / self.JMX_DIR
+
+    def jmx_models_index_exists(self, version: Version) -> bool:
+        """Return True when a version has a jmx-models.yaml index file."""
+        return (self.get_version_dir(version) / self.JMX_MODELS_INDEX_FILE).exists()
+
+    def save_jmx_models_index(
+        self,
+        version: Version,
+        models: dict[str, str],
+        manifest: str | None,
+    ) -> tuple[dict[str, str], str | None]:
+        """Persist shared JMX model files and write per-version index.
+
+        Returns:
+            Tuple of (models index map, manifest filename). If nothing was
+            persisted, returns ({}, None) and does not write an index file.
+        """
+        jmx_dir = self.get_jmx_store_dir()
+        jmx_dir.mkdir(parents=True, exist_ok=True)
+
+        indexed_models: dict[str, str] = {}
+        for target_system in sorted(models):
+            indexed_models[target_system] = self._save_jmx_content_addressed_file(
+                jmx_dir, target_system, models[target_system]
+            )
+
+        manifest_file = None
+        if manifest is not None:
+            manifest_file = self._save_jmx_content_addressed_file(jmx_dir, "manifest", manifest)
+
+        if not indexed_models and manifest_file is None:
+            return {}, None
+
+        payload: dict[str, Any] = {"models": indexed_models}
+        if manifest_file is not None:
+            payload["manifest"] = manifest_file
+
+        version_dir = self.get_version_dir(version)
+        version_dir.mkdir(parents=True, exist_ok=True)
+        index_path = version_dir / self.JMX_MODELS_INDEX_FILE
+        with open(index_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(payload, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+        return indexed_models, manifest_file
+
+    def _save_jmx_content_addressed_file(self, jmx_dir: Path, name: str, content: str) -> str:
+        """Save one JMX YAML file content-addressed in shared JMX directory."""
+        safe_name = self._sanitize_name(name)
+        digest = compute_content_hash(content)
+        filename = f"{safe_name}-{digest}.yaml"
+        file_path = jmx_dir / filename
+        if not file_path.exists():
+            file_path.write_text(content, encoding="utf-8")
+        return filename

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/java_instrumentation_client.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/java_instrumentation_client.py
@@ -42,6 +42,7 @@ class JavaInstrumentationClient:
         """
         self.github_token = github_token
         self._session = requests.Session()
+        self._tree_cache: dict[str, list[dict]] = {}
 
         retry_strategy = Retry(
             total=3,
@@ -88,14 +89,19 @@ class JavaInstrumentationClient:
 
     def fetch_tree(self, sha: str) -> list[dict]:
         """Recursively fetch the git tree at a commit SHA. Returns the `tree` array."""
+        if sha in self._tree_cache:
+            return self._tree_cache[sha]
+
         url = f"https://api.github.com/repos/{self.REPO}/git/trees/{sha}?recursive=1"
         try:
             resp = self._session.get(url, timeout=self.TIMEOUT)
             resp.raise_for_status()
             data = resp.json()
             if data.get("truncated"):
-                raise GithubAPIError(f"Tree at {sha} was truncated; README discovery aborted")
-            return data.get("tree", [])
+                raise GithubAPIError(f"Tree at {sha} was truncated")
+            tree = data.get("tree", [])
+            self._tree_cache[sha] = tree
+            return tree
         except (requests.RequestException, ValueError) as e:
             raise GithubAPIError(f"Failed to fetch tree for {sha}: {e}") from e
 

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/jmx_model_extractor.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/jmx_model_extractor.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Discovers and fetches JMX weaver model files from upstream Java instrumentation repo."""
+
+import re
+
+from .java_instrumentation_client import JavaInstrumentationClient
+
+JMX_MODEL_FILE_RE = re.compile(r"^instrumentation/jmx-metrics/model/(?P<name>[^/]+)\.yaml$")
+
+
+class JmxModelExtractor:
+    """Discovers JMX weaver model and manifest YAML files from upstream Java repo."""
+
+    def __init__(self, client: JavaInstrumentationClient):
+        self.client = client
+
+    def discover_jmx_model_paths(self, sha: str) -> tuple[dict[str, str], str | None]:
+        """Return ({target_system: blob_path}, manifest_blob_path_or_none)."""
+        tree = self.client.fetch_tree(sha)
+        models: dict[str, str] = {}
+        manifest_path: str | None = None
+
+        for entry in sorted(tree, key=lambda item: str(item.get("path", ""))):
+            if entry.get("type") != "blob":
+                continue
+            path = entry.get("path")
+            if not isinstance(path, str):
+                continue
+            match = JMX_MODEL_FILE_RE.match(path)
+            if not match:
+                continue
+
+            file_stem = match.group("name")
+            if file_stem == "manifest":
+                manifest_path = path
+            else:
+                models[file_stem] = path
+
+        return models, manifest_path
+
+    def fetch_model(self, path: str, ref: str) -> str:
+        """Fetch a single model file from upstream repository."""
+        return self.client.fetch_raw_file(path, ref)

--- a/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/jmx_model_extractor.py
+++ b/ecosystem-automation/java-instrumentation-watcher/src/java_instrumentation_watcher/jmx_model_extractor.py
@@ -33,7 +33,7 @@ class JmxModelExtractor:
         models: dict[str, str] = {}
         manifest_path: str | None = None
 
-        for entry in sorted(tree, key=lambda item: str(item.get("path", ""))):
+        for entry in tree:
             if entry.get("type") != "blob":
                 continue
             path = entry.get("path")

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
@@ -18,6 +18,7 @@ import tempfile
 from unittest.mock import Mock
 
 import pytest
+import yaml
 from java_instrumentation_watcher.instrumentation_sync import InstrumentationSync
 from java_instrumentation_watcher.inventory_manager import InventoryManager
 from semantic_version import Version
@@ -279,9 +280,11 @@ libraries:
 
         readme_dir = inventory_manager.get_version_dir(snapshot_version) / "library_readmes"
         assert readme_dir.exists()
-        # Called three times: once in update_snapshot, then README and JMX sync
-        assert mock_client.resolve_ref_to_sha.call_count == 3
+        # Called twice: once in update_snapshot, once in _sync_library_readmes
+        assert mock_client.resolve_ref_to_sha.call_count == 2
         mock_client.fetch_instrumentation_list.assert_called_once_with(ref="sha123")
+        assert not inventory_manager.jmx_models_index_exists(snapshot_version)
+        mock_jmx_model_extractor.discover_jmx_model_paths.assert_not_called()
 
     def test_process_latest_release_backfills_missing_readmes(
         self, mock_client, inventory_manager, mock_jmx_model_extractor
@@ -401,6 +404,10 @@ libraries:
         index_path = sync.inventory_manager.get_version_dir(version) / "jmx-models.yaml"
         assert index_path.exists()
         assert sync.inventory_manager.get_jmx_store_dir().exists()
+        index = yaml.safe_load(index_path.read_text(encoding="utf-8"))
+        assert set(index["models"]) == {"jvm", "tomcat"}
+        assert "manifest" not in index["models"]
+        assert index["manifest"]
 
     def test_process_latest_release_backfills_missing_jmx_index(self, sync, mock_client, inventory_manager):
         version = Version("2.30.0")
@@ -444,6 +451,20 @@ libraries:
                 "jvm-model",
                 GithubAPIError("manifest fetch failed"),
             ]
+
+        version = sync.process_latest_release()
+
+        assert version == Version("2.30.0")
+        assert not inventory_manager.jmx_models_index_exists(version)
+        assert not inventory_manager.get_jmx_store_dir().exists()
+
+    def test_jmx_tree_discovery_failure_does_not_abort_release_sync(self, sync, mock_client, inventory_manager):
+        from java_instrumentation_watcher.java_instrumentation_client import GithubAPIError
+
+        mock_client.get_latest_release_tag.return_value = "v2.30.0"
+        mock_client.fetch_instrumentation_list.return_value = "file_format: 0.5\nlibraries: []\n"
+        mock_client.resolve_ref_to_sha.return_value = "sha123"
+        sync.jmx_model_extractor.discover_jmx_model_paths.side_effect = GithubAPIError("tree fetch failed")
 
         version = sync.process_latest_release()
 

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_instrumentation_sync.py
@@ -44,8 +44,19 @@ class TestInstrumentationSync:
         return extractor
 
     @pytest.fixture
-    def sync(self, mock_client, inventory_manager, mock_readme_extractor):
-        return InstrumentationSync(mock_client, inventory_manager, readme_extractor=mock_readme_extractor)
+    def mock_jmx_model_extractor(self):
+        extractor = Mock()
+        extractor.discover_jmx_model_paths.return_value = ({}, None)
+        return extractor
+
+    @pytest.fixture
+    def sync(self, mock_client, inventory_manager, mock_readme_extractor, mock_jmx_model_extractor):
+        return InstrumentationSync(
+            mock_client,
+            inventory_manager,
+            readme_extractor=mock_readme_extractor,
+            jmx_model_extractor=mock_jmx_model_extractor,
+        )
 
     def test_process_latest_release_new_version(self, sync, mock_client):
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
@@ -240,38 +251,41 @@ libraries:
         {"type": "blob", "path": "instrumentation/apache-httpclient/apache-httpclient-4.3/library/README.md"},
     ]
 
-    def test_release_sync_writes_readmes(self, mock_client, inventory_manager):
+    def test_release_sync_writes_readmes(self, mock_client, inventory_manager, mock_jmx_model_extractor):
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
         mock_client.fetch_instrumentation_list.return_value = self._YAML_WITH_LIBRARIES
         mock_client.resolve_ref_to_sha.return_value = "sha123"
         mock_client.fetch_tree.return_value = self._TREE
         mock_client.fetch_raw_file.return_value = "# README"
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         version = sync.process_latest_release()
 
         readme_dir = inventory_manager.get_version_dir(version) / "library_readmes"
         assert readme_dir.exists()
         assert len(list(readme_dir.glob("*.md"))) == 2
-        mock_client.resolve_ref_to_sha.assert_called_once_with("v2.10.0")
+        # Called twice: _sync_library_readmes and _sync_jmx_models
+        assert mock_client.resolve_ref_to_sha.call_count == 2
 
-    def test_snapshot_sync_writes_readmes(self, mock_client, inventory_manager):
+    def test_snapshot_sync_writes_readmes(self, mock_client, inventory_manager, mock_jmx_model_extractor):
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
         mock_client.fetch_instrumentation_list.return_value = self._YAML_WITH_LIBRARIES
         mock_client.resolve_ref_to_sha.return_value = "sha123"
         mock_client.fetch_tree.return_value = self._TREE
         mock_client.fetch_raw_file.return_value = "# README"
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         snapshot_version = sync.update_snapshot()
 
         readme_dir = inventory_manager.get_version_dir(snapshot_version) / "library_readmes"
         assert readme_dir.exists()
-        # resolve_ref_to_sha called twice: once in update_snapshot, once in _sync_library_readmes
-        assert mock_client.resolve_ref_to_sha.call_count == 2
+        # Called three times: once in update_snapshot, then README and JMX sync
+        assert mock_client.resolve_ref_to_sha.call_count == 3
         mock_client.fetch_instrumentation_list.assert_called_once_with(ref="sha123")
 
-    def test_process_latest_release_backfills_missing_readmes(self, mock_client, inventory_manager):
+    def test_process_latest_release_backfills_missing_readmes(
+        self, mock_client, inventory_manager, mock_jmx_model_extractor
+    ):
         version = Version("2.10.0")
         inventory_manager.save_versioned_inventory(
             version=version,
@@ -283,30 +297,33 @@ libraries:
         mock_client.fetch_tree.return_value = self._TREE
         mock_client.fetch_raw_file.return_value = "# README"
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         result = sync.process_latest_release()
 
         assert result is None
         readme_dir = inventory_manager.get_version_dir(version) / "library_readmes"
         assert readme_dir.exists()
 
-    def test_process_latest_release_skips_backfill_when_readmes_exist(self, mock_client, inventory_manager):
+    def test_process_latest_release_skips_backfill_when_readmes_exist(
+        self, mock_client, inventory_manager, mock_jmx_model_extractor
+    ):
         version = Version("2.10.0")
         inventory_manager.save_versioned_inventory(
             version=version,
             instrumentations={"file_format": 0.1, "libraries": []},
         )
         inventory_manager.save_library_readmes(version, [("mylib", "# content")])
+        inventory_manager.save_jmx_models_index(version, models={"jvm": "metrics: []\n"}, manifest=None)
 
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         result = sync.process_latest_release()
 
         assert result is None
         mock_client.resolve_ref_to_sha.assert_not_called()
 
-    def test_one_readme_fetch_failure_others_written(self, mock_client, inventory_manager):
+    def test_one_readme_fetch_failure_others_written(self, mock_client, inventory_manager, mock_jmx_model_extractor):
         from java_instrumentation_watcher.java_instrumentation_client import GithubAPIError
 
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
@@ -318,21 +335,21 @@ libraries:
             "# Apache README",
         ]
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         version = sync.process_latest_release()
 
         assert version == Version("2.10.0")
         readme_dir = inventory_manager.get_version_dir(version) / "library_readmes"
         assert len(list(readme_dir.glob("*.md"))) == 1
 
-    def test_resolve_ref_failure_does_not_abort_sync(self, mock_client, inventory_manager):
+    def test_resolve_ref_failure_does_not_abort_sync(self, mock_client, inventory_manager, mock_jmx_model_extractor):
         from java_instrumentation_watcher.java_instrumentation_client import GithubAPIError
 
         mock_client.get_latest_release_tag.return_value = "v2.10.0"
         mock_client.fetch_instrumentation_list.return_value = self._YAML_WITH_LIBRARIES
         mock_client.resolve_ref_to_sha.side_effect = GithubAPIError("API down")
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         version = sync.process_latest_release()
 
         assert version == Version("2.10.0")
@@ -340,7 +357,7 @@ libraries:
         readme_dir = inventory_manager.get_version_dir(version) / "library_readmes"
         assert not readme_dir.exists()
 
-    def test_library_without_source_path_skipped(self, mock_client, inventory_manager):
+    def test_library_without_source_path_skipped(self, mock_client, inventory_manager, mock_jmx_model_extractor):
         yaml_no_source = """
 file_format: 0.5
 libraries:
@@ -354,8 +371,82 @@ libraries:
             {"type": "blob", "path": "instrumentation/some/lib/library/README.md"},
         ]
 
-        sync = InstrumentationSync(mock_client, inventory_manager)
+        sync = InstrumentationSync(mock_client, inventory_manager, jmx_model_extractor=mock_jmx_model_extractor)
         version = sync.process_latest_release()
 
         assert version == Version("2.10.0")
         mock_client.fetch_raw_file.assert_not_called()
+
+    def test_release_sync_writes_jmx_models(self, sync, mock_client):
+        mock_client.get_latest_release_tag.return_value = "v2.30.0"
+        mock_client.fetch_instrumentation_list.return_value = "file_format: 0.5\nlibraries: []\n"
+        mock_client.resolve_ref_to_sha.return_value = "sha123"
+
+        sync.jmx_model_extractor.discover_jmx_model_paths.return_value = (
+            {
+                "jvm": "instrumentation/jmx-metrics/model/jvm.yaml",
+                "tomcat": "instrumentation/jmx-metrics/model/tomcat.yaml",
+            },
+            "instrumentation/jmx-metrics/model/manifest.yaml",
+        )
+        sync.jmx_model_extractor.fetch_model.side_effect = [
+            "jvm-model",
+            "tomcat-model",
+            "manifest-model",
+        ]
+
+        version = sync.process_latest_release()
+
+        assert version == Version("2.30.0")
+        index_path = sync.inventory_manager.get_version_dir(version) / "jmx-models.yaml"
+        assert index_path.exists()
+        assert sync.inventory_manager.get_jmx_store_dir().exists()
+
+    def test_process_latest_release_backfills_missing_jmx_index(self, sync, mock_client, inventory_manager):
+        version = Version("2.30.0")
+        inventory_manager.save_versioned_inventory(
+            version=version,
+            instrumentations={"file_format": 0.5, "libraries": []},
+        )
+        inventory_manager.save_library_readmes(version, [("mylib", "# content")])
+
+        mock_client.get_latest_release_tag.return_value = "v2.30.0"
+        mock_client.resolve_ref_to_sha.return_value = "sha123"
+        sync.jmx_model_extractor.discover_jmx_model_paths.return_value = (
+            {"jvm": "instrumentation/jmx-metrics/model/jvm.yaml"},
+            None,
+        )
+        sync.jmx_model_extractor.fetch_model.return_value = "jvm-model"
+
+        result = sync.process_latest_release()
+
+        assert result is None
+        assert inventory_manager.jmx_models_index_exists(version)
+
+    @pytest.mark.parametrize("failed_file", ["model", "manifest"])
+    def test_release_sync_does_not_write_partial_jmx_index(self, sync, mock_client, inventory_manager, failed_file):
+        from java_instrumentation_watcher.java_instrumentation_client import GithubAPIError
+
+        mock_client.get_latest_release_tag.return_value = "v2.30.0"
+        mock_client.fetch_instrumentation_list.return_value = "file_format: 0.5\nlibraries: []\n"
+        mock_client.resolve_ref_to_sha.return_value = "sha123"
+        sync.jmx_model_extractor.discover_jmx_model_paths.return_value = (
+            {"jvm": "instrumentation/jmx-metrics/model/jvm.yaml"},
+            "instrumentation/jmx-metrics/model/manifest.yaml",
+        )
+        if failed_file == "model":
+            sync.jmx_model_extractor.fetch_model.side_effect = [
+                GithubAPIError("model fetch failed"),
+                "manifest-model",
+            ]
+        else:
+            sync.jmx_model_extractor.fetch_model.side_effect = [
+                "jvm-model",
+                GithubAPIError("manifest fetch failed"),
+            ]
+
+        version = sync.process_latest_release()
+
+        assert version == Version("2.30.0")
+        assert not inventory_manager.jmx_models_index_exists(version)
+        assert not inventory_manager.get_jmx_store_dir().exists()

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_inventory_manager.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_inventory_manager.py
@@ -416,3 +416,65 @@ class TestLibraryReadme:
         # Should be able to load it using the original (unsanitized) name
         content = inventory_manager.load_library_readme_content(version, library_name, markdown_hash)
         assert content == "safe content"
+
+
+class TestJmxModels:
+    def test_jmx_models_index_exists_false_when_missing(self, inventory_manager):
+        version = Version("2.30.0")
+        assert not inventory_manager.jmx_models_index_exists(version)
+
+    def test_save_jmx_models_index_writes_shared_store_and_index(self, inventory_manager):
+        version = Version("2.30.0")
+        models = {
+            "jvm": "metrics:\n  - jvm_threads_live\n",
+            "tomcat": "metrics:\n  - tomcat_sessions\n",
+        }
+        manifest = "semantic_conventions: v1.43.0\n"
+
+        indexed_models, manifest_file = inventory_manager.save_jmx_models_index(
+            version=version,
+            models=models,
+            manifest=manifest,
+        )
+
+        assert set(indexed_models.keys()) == {"jvm", "tomcat"}
+        assert manifest_file is not None
+
+        jmx_dir = inventory_manager.get_jmx_store_dir()
+        assert (jmx_dir / indexed_models["jvm"]).exists()
+        assert (jmx_dir / indexed_models["tomcat"]).exists()
+        assert (jmx_dir / manifest_file).exists()
+
+        index_path = inventory_manager.get_version_dir(version) / "jmx-models.yaml"
+        assert index_path.exists()
+
+        index = yaml.safe_load(index_path.read_text(encoding="utf-8"))
+        assert index["models"] == indexed_models
+        assert index["manifest"] == manifest_file
+
+    def test_save_jmx_models_index_is_content_addressed(self, inventory_manager):
+        version_a = Version("2.30.0")
+        version_b = Version("2.31.0")
+        model_content = "metrics:\n  - jvm_threads_live\n"
+
+        first_models, _ = inventory_manager.save_jmx_models_index(
+            version=version_a,
+            models={"jvm": model_content},
+            manifest=None,
+        )
+        second_models, _ = inventory_manager.save_jmx_models_index(
+            version=version_b,
+            models={"jvm": model_content},
+            manifest=None,
+        )
+
+        assert first_models["jvm"] == second_models["jvm"]
+        assert len(list(inventory_manager.get_jmx_store_dir().glob("jvm-*.yaml"))) == 1
+
+    def test_save_jmx_models_index_skips_empty_payload(self, inventory_manager):
+        version = Version("2.29.0")
+        models, manifest = inventory_manager.save_jmx_models_index(version=version, models={}, manifest=None)
+
+        assert models == {}
+        assert manifest is None
+        assert not inventory_manager.jmx_models_index_exists(version)

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_inventory_manager.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_inventory_manager.py
@@ -478,3 +478,4 @@ class TestJmxModels:
         assert models == {}
         assert manifest is None
         assert not inventory_manager.jmx_models_index_exists(version)
+        assert not inventory_manager.get_jmx_store_dir().exists()

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_java_instrumentation_client.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_java_instrumentation_client.py
@@ -198,8 +198,10 @@ def test_fetch_tree_success(mock_session_class):
 
     client = JavaInstrumentationClient()
     tree = client.fetch_tree("abc123")
+    cached_tree = client.fetch_tree("abc123")
 
     assert tree == tree_entries
+    assert cached_tree == tree_entries
     mock_session.get.assert_called_once_with(
         "https://api.github.com/repos/open-telemetry/opentelemetry-java-instrumentation/git/trees/abc123?recursive=1",
         timeout=30,
@@ -216,7 +218,7 @@ def test_fetch_tree_truncated_raises(mock_session_class):
     mock_session.get.return_value = mock_response
 
     client = JavaInstrumentationClient()
-    with pytest.raises(GithubAPIError, match="truncated"):
+    with pytest.raises(GithubAPIError, match=r"Tree at abc123 was truncated$"):
         client.fetch_tree("abc123")
 
 

--- a/ecosystem-automation/java-instrumentation-watcher/tests/test_jmx_model_extractor.py
+++ b/ecosystem-automation/java-instrumentation-watcher/tests/test_jmx_model_extractor.py
@@ -1,0 +1,67 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for JmxModelExtractor."""
+
+from unittest.mock import Mock
+
+import pytest
+from java_instrumentation_watcher.jmx_model_extractor import JmxModelExtractor
+
+
+@pytest.fixture
+def mock_client():
+    return Mock()
+
+
+@pytest.fixture
+def extractor(mock_client):
+    return JmxModelExtractor(mock_client)
+
+
+def test_discover_jmx_model_paths_returns_models_and_manifest(extractor, mock_client):
+    mock_client.fetch_tree.return_value = [
+        {"type": "blob", "path": "instrumentation/jmx-metrics/model/jvm.yaml"},
+        {"type": "blob", "path": "instrumentation/jmx-metrics/model/manifest.yaml"},
+        {"type": "blob", "path": "instrumentation/jmx-metrics/model/tomcat.yaml"},
+        {"type": "blob", "path": "docs/instrumentation-list.yaml"},
+    ]
+
+    models, manifest_path = extractor.discover_jmx_model_paths("abc123")
+
+    assert models == {
+        "jvm": "instrumentation/jmx-metrics/model/jvm.yaml",
+        "tomcat": "instrumentation/jmx-metrics/model/tomcat.yaml",
+    }
+    assert manifest_path == "instrumentation/jmx-metrics/model/manifest.yaml"
+
+
+def test_discover_jmx_model_paths_ignores_nested_paths(extractor, mock_client):
+    mock_client.fetch_tree.return_value = [
+        {"type": "blob", "path": "instrumentation/jmx-metrics/model/nested/jvm.yaml"},
+    ]
+
+    models, manifest_path = extractor.discover_jmx_model_paths("abc123")
+
+    assert models == {}
+    assert manifest_path is None
+
+
+def test_fetch_model_delegates_to_client(extractor, mock_client):
+    mock_client.fetch_raw_file.return_value = "models: []"
+
+    content = extractor.fetch_model("instrumentation/jmx-metrics/model/jvm.yaml", "abc123")
+
+    assert content == "models: []"
+    mock_client.fetch_raw_file.assert_called_once_with("instrumentation/jmx-metrics/model/jvm.yaml", "abc123")


### PR DESCRIPTION
  ## What changed

Scrape JMX weaver model YAML files from Java instrumentation releases and snapshots. Store model content once in a shared content-addressed `jmx/` directory and write a per-version `jmx-models.yaml` index, keeping the manifest separate from target-system models.

  ## Why

  Fixes #975.

  ## How it was tested

  - `uv run pytest ecosystem-automation/java-instrumentation-watcher/` - 102 passed
  - `uv run ruff check ecosystem-automation/`
  - `uv run ruff format --check ecosystem-automation/`
  - Pre-commit hooks passed

  ## Is this a breaking change?

  No.

  ## Special notes for your reviewer

Missing model directories are ignored for older releases. Incomplete GitHub fetches do not write a partial index, allowing later runs to retry.

  PR #960 overlaps with Java watcher inventory handling. This branch may need rebasing if #960 merges first.

  ## Checklist

  - [x] Tests added or updated for new behavior
  - [ ] Screenshots attached for any UI changes (not applicable; no UI changes)
  - [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)