### PR TITLE
fix: filter non-component packages by status class

### DIFF
--- a/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
@@ -89,7 +89,8 @@ class ComponentScanner:
                     components.extend(nested_components)
                 elif self._is_component_directory(item):
                     component_info = self._extract_component_info(item, component_type)
-                    components.append(component_info)
+                    if component_info is not None:
+                        components.append(component_info)
 
         return components
 
@@ -109,7 +110,8 @@ class ComponentScanner:
         for item in sorted(nested_dir.iterdir()):
             if item.is_dir() and self._is_nested_component_directory(item):
                 component_info = self._extract_component_info(item, component_type, subtype=subtype)
-                components.append(component_info)
+                if component_info is not None:
+                    components.append(component_info)
         return components
 
     def _is_valid_component_name(self, path: Path) -> bool:
@@ -191,7 +193,7 @@ class ComponentScanner:
 
     def _extract_component_info(
         self, component_path: Path, component_type: str, subtype: str | None = None
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """
         Extract information about a component.
 
@@ -201,7 +203,10 @@ class ComponentScanner:
             subtype: Optional subtype (e.g., "encoding", "observer", "storage")
 
         Returns:
-            Dictionary with component information
+            Dictionary with component information, or None if the upstream metadata's
+            ``status.class`` identifies this directory as something other than a real
+            component of ``component_type`` (e.g. an internal ``pkg`` interface package)
+            and should be skipped rather than cataloged.
         """
         parser = MetadataParser(component_path)
         has_metadata = parser.has_metadata()
@@ -217,6 +222,8 @@ class ComponentScanner:
         if has_metadata:
             parsed_metadata = parser.parse()
             if parsed_metadata:
+                if not self._matches_component_type(parsed_metadata, component_type):
+                    return None
                 component_info["metadata"] = parsed_metadata
             else:
                 component_info["has_metadata"] = False
@@ -224,3 +231,31 @@ class ComponentScanner:
             component_info["has_metadata"] = False
 
         return component_info
+
+    @staticmethod
+    def _matches_component_type(parsed_metadata: dict[str, Any], component_type: str) -> bool:
+        """
+        Check whether parsed metadata's ``status.class`` is consistent with the directory
+        it was found in, rather than an internal interface package (upstream ``class: pkg``,
+        or ``cmd``/``scraper``/``converter``/``provider``) that happens to live under a
+        component-type directory.
+
+        Nested/subtype components (e.g. ``extension/storage/filestorage``) declare
+        ``status.class`` equal to their *parent* type ("extension"), not their subtype
+        ("storage"), so comparing against ``component_type`` is correct for those too.
+
+        A missing ``status`` or ``status.class`` is treated as a match (fail-open): the
+        upstream schema documents ``class`` as optional for subcomponents, and the scanner
+        must not exclude a real component just because it lacks this field.
+
+        Args:
+            parsed_metadata: The parsed metadata.yaml content.
+            component_type: The directory-derived component type (e.g. "receiver").
+
+        Returns:
+            False only when ``status.class`` is present and differs from ``component_type``.
+        """
+        status_class = (parsed_metadata.get("status") or {}).get("class")
+        if status_class is None:
+            return True
+        return status_class == component_type

--- a/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
+++ b/ecosystem-automation/collector-watcher/src/collector_watcher/component_scanner.py
@@ -255,7 +255,10 @@ class ComponentScanner:
         Returns:
             False only when ``status.class`` is present and differs from ``component_type``.
         """
-        status_class = (parsed_metadata.get("status") or {}).get("class")
+        status = parsed_metadata.get("status")
+        if not isinstance(status, dict):
+            return True
+        status_class = status.get("class")
         if status_class is None:
             return True
         return status_class == component_type

--- a/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
+++ b/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
@@ -14,8 +14,6 @@
 #
 """Tests for component scanner."""
 
-from pathlib import Path
-
 import pytest
 from collector_watcher.component_scanner import ComponentScanner
 

--- a/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
+++ b/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
@@ -268,3 +268,152 @@ def test_scan_empty_component_type_directory(mock_repo):
     scanner = ComponentScanner(str(mock_repo))
     connectors = scanner.scan_component_type("connector")
     assert len(connectors) == 0
+
+
+# ---------------------------------------------------------------------------
+# status.class based filtering (#991)
+#
+# Internal interface packages (e.g. receiver/xreceiver) live under a real
+# component-type directory and pass go.mod/name checks, but declare
+# status.class: pkg upstream rather than the matching component type. These
+# tests exercise the _extract_component_info status.class check that skips
+# such directories instead of cataloging them as real components.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_repo_with_class_metadata():
+    """Mock repo covering status.class match / mismatch / absence for a top-level type."""
+    temp_dir = tempfile.mkdtemp()
+    repo_path = Path(temp_dir)
+
+    # Real component: status.class matches its directory's component_type.
+    real_receiver = repo_path / "receiver" / "otlpreceiver"
+    real_receiver.mkdir(parents=True)
+    (real_receiver / "go.mod").touch()
+    (real_receiver / "metadata.yaml").write_text("type: otlp\nstatus:\n  class: receiver\n")
+
+    # Internal interface package: status.class is "pkg", not "receiver" (the #991 case).
+    pkg_receiver = repo_path / "receiver" / "xreceiver"
+    pkg_receiver.mkdir(parents=True)
+    (pkg_receiver / "go.mod").touch()
+    (pkg_receiver / "metadata.yaml").write_text("type: xreceiver\nstatus:\n  class: pkg\n")
+
+    # metadata.yaml present with a status block but no class field: must fail open.
+    no_class_receiver = repo_path / "receiver" / "noclassreceiver"
+    no_class_receiver.mkdir(parents=True)
+    (no_class_receiver / "go.mod").touch()
+    (no_class_receiver / "metadata.yaml").write_text("type: noclass\nstatus:\n  stability:\n    beta: [traces]\n")
+
+    # metadata.yaml present with no status block at all: must also fail open.
+    no_status_receiver = repo_path / "receiver" / "nostatusreceiver"
+    no_status_receiver.mkdir(parents=True)
+    (no_status_receiver / "go.mod").touch()
+    (no_status_receiver / "metadata.yaml").write_text("type: nostatus\n")
+
+    yield repo_path
+
+    shutil.rmtree(temp_dir)
+
+
+def test_excludes_pkg_class_component(mock_repo_with_class_metadata):
+    """A directory whose upstream status.class is "pkg" (an internal interface package,
+    not a real component) must not be discovered."""
+    scanner = ComponentScanner(str(mock_repo_with_class_metadata))
+    receivers = scanner.scan_component_type("receiver")
+
+    assert not any(r["name"] == "xreceiver" for r in receivers)
+
+
+def test_includes_component_with_matching_class(mock_repo_with_class_metadata):
+    """A real component whose status.class matches its directory's component_type
+    is still discovered."""
+    scanner = ComponentScanner(str(mock_repo_with_class_metadata))
+    receivers = scanner.scan_component_type("receiver")
+
+    assert any(r["name"] == "otlpreceiver" for r in receivers)
+
+
+def test_includes_component_with_missing_status_class(mock_repo_with_class_metadata):
+    """A component with a status block but no class field must fail open (stay
+    included) - class is documented upstream as optional for subcomponents."""
+    scanner = ComponentScanner(str(mock_repo_with_class_metadata))
+    receivers = scanner.scan_component_type("receiver")
+
+    assert any(r["name"] == "noclassreceiver" for r in receivers)
+
+
+def test_includes_component_with_no_status_block(mock_repo_with_class_metadata):
+    """A component with metadata.yaml but no status block at all must fail open."""
+    scanner = ComponentScanner(str(mock_repo_with_class_metadata))
+    receivers = scanner.scan_component_type("receiver")
+
+    assert any(r["name"] == "nostatusreceiver" for r in receivers)
+
+
+@pytest.fixture
+def mock_repo_with_nested_class_metadata():
+    """Mock repo covering status.class match / mismatch for a nested subtype directory."""
+    temp_dir = tempfile.mkdtemp()
+    repo_path = Path(temp_dir)
+
+    storage_dir = repo_path / "extension" / "storage"
+    storage_dir.mkdir(parents=True)
+
+    # Real nested component: status.class equals the *parent* type ("extension"), not
+    # the subtype ("storage") - matches real upstream shape (e.g. filestorage).
+    real_storage_ext = storage_dir / "filestorage"
+    real_storage_ext.mkdir(parents=True)
+    (real_storage_ext / "go.mod").touch()
+    (real_storage_ext / "metadata.yaml").write_text("type: file_storage\nstatus:\n  class: extension\n")
+
+    # Internal interface package nested under a subtype dir: status.class is "pkg".
+    pkg_storage_ext = storage_dir / "xstorage"
+    pkg_storage_ext.mkdir(parents=True)
+    (pkg_storage_ext / "go.mod").touch()
+    (pkg_storage_ext / "metadata.yaml").write_text("type: xstorage\nstatus:\n  class: pkg\n")
+
+    yield repo_path
+
+    shutil.rmtree(temp_dir)
+
+
+def test_nested_component_with_matching_parent_class_included(mock_repo_with_nested_class_metadata):
+    """Nested/subtype components declare status.class equal to their parent
+    component_type (e.g. "extension", not "storage") - this must still match."""
+    scanner = ComponentScanner(str(mock_repo_with_nested_class_metadata))
+    extensions = scanner.scan_component_type("extension")
+
+    assert any(e["name"] == "filestorage" for e in extensions)
+
+
+def test_nested_pkg_class_component_excluded(mock_repo_with_nested_class_metadata):
+    """A pkg-class package nested under a subtype directory must also be excluded."""
+    scanner = ComponentScanner(str(mock_repo_with_nested_class_metadata))
+    extensions = scanner.scan_component_type("extension")
+
+    assert not any(e["name"] == "xstorage" for e in extensions)
+
+
+@pytest.mark.parametrize(
+    ("component_type", "name"),
+    [
+        ("receiver", "xreceiver"),
+        ("exporter", "xexporter"),
+        ("processor", "xprocessor"),
+        ("connector", "xconnector"),
+        ("extension", "xextension"),
+    ],
+)
+def test_excludes_known_pkg_class_interface_packages(tmp_path, component_type, name):
+    """Regression test for #991: the five internal interface packages upstream marks
+    status.class: pkg must not be discovered as real components of any type."""
+    component_dir = tmp_path / component_type / name
+    component_dir.mkdir(parents=True)
+    (component_dir / "go.mod").touch()
+    (component_dir / "metadata.yaml").write_text(f"type: {name}\nstatus:\n  class: pkg\n")
+
+    scanner = ComponentScanner(str(tmp_path))
+    components = scanner.scan_component_type(component_type)
+
+    assert components == []

--- a/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
+++ b/ecosystem-automation/collector-watcher/tests/test_component_scanner.py
@@ -14,8 +14,6 @@
 #
 """Tests for component scanner."""
 
-import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,10 +21,9 @@ from collector_watcher.component_scanner import ComponentScanner
 
 
 @pytest.fixture
-def mock_repo():
+def mock_repo(tmp_path):
     """Create a temporary mock repository structure."""
-    temp_dir = tempfile.mkdtemp()
-    repo_path = Path(temp_dir)
+    repo_path = tmp_path
 
     receiver_with_meta = repo_path / "receiver" / "otlpreceiver"
     receiver_with_meta.mkdir(parents=True)
@@ -63,9 +60,7 @@ def mock_repo():
     hidden_dir.mkdir(parents=True)
     (hidden_dir / "go.mod").touch()
 
-    yield repo_path
-
-    shutil.rmtree(temp_dir)
+    return repo_path
 
 
 def test_scan_receivers(mock_repo):
@@ -127,10 +122,9 @@ def test_scan_all_components(mock_repo):
 
 
 @pytest.fixture
-def mock_repo_with_nested():
+def mock_repo_with_nested(tmp_path):
     """Create a temporary mock repository with nested extension directories."""
-    temp_dir = tempfile.mkdtemp()
-    repo_path = Path(temp_dir)
+    repo_path = tmp_path
 
     # Create a regular extension
     regular_ext = repo_path / "extension" / "healthcheckextension"
@@ -176,10 +170,7 @@ def mock_repo_with_nested():
     internal_dir.mkdir(parents=True)
     (internal_dir / "go.mod").touch()
 
-    yield repo_path
-
-    # Cleanup
-    shutil.rmtree(temp_dir)
+    return repo_path
 
 
 def test_scan_nested_encoding_extensions(mock_repo_with_nested):
@@ -282,10 +273,9 @@ def test_scan_empty_component_type_directory(mock_repo):
 
 
 @pytest.fixture
-def mock_repo_with_class_metadata():
+def mock_repo_with_class_metadata(tmp_path):
     """Mock repo covering status.class match / mismatch / absence for a top-level type."""
-    temp_dir = tempfile.mkdtemp()
-    repo_path = Path(temp_dir)
+    repo_path = tmp_path
 
     # Real component: status.class matches its directory's component_type.
     real_receiver = repo_path / "receiver" / "otlpreceiver"
@@ -311,9 +301,13 @@ def mock_repo_with_class_metadata():
     (no_status_receiver / "go.mod").touch()
     (no_status_receiver / "metadata.yaml").write_text("type: nostatus\n")
 
-    yield repo_path
+    # metadata.yaml present with non-dict status block (e.g. string): must fail open.
+    non_dict_status_receiver = repo_path / "receiver" / "nondictstatusreceiver"
+    non_dict_status_receiver.mkdir(parents=True)
+    (non_dict_status_receiver / "go.mod").touch()
+    (non_dict_status_receiver / "metadata.yaml").write_text("type: nondictstatus\nstatus: invalid_string\n")
 
-    shutil.rmtree(temp_dir)
+    return repo_path
 
 
 def test_excludes_pkg_class_component(mock_repo_with_class_metadata):
@@ -351,11 +345,19 @@ def test_includes_component_with_no_status_block(mock_repo_with_class_metadata):
     assert any(r["name"] == "nostatusreceiver" for r in receivers)
 
 
+def test_includes_component_with_non_dict_status(mock_repo_with_class_metadata):
+    """A component with a non-dict status field (e.g., status: string) must fail open
+    without raising an AttributeError when accessing status.class."""
+    scanner = ComponentScanner(str(mock_repo_with_class_metadata))
+    receivers = scanner.scan_component_type("receiver")
+
+    assert any(r["name"] == "nondictstatusreceiver" for r in receivers)
+
+
 @pytest.fixture
-def mock_repo_with_nested_class_metadata():
+def mock_repo_with_nested_class_metadata(tmp_path):
     """Mock repo covering status.class match / mismatch for a nested subtype directory."""
-    temp_dir = tempfile.mkdtemp()
-    repo_path = Path(temp_dir)
+    repo_path = tmp_path
 
     storage_dir = repo_path / "extension" / "storage"
     storage_dir.mkdir(parents=True)
@@ -373,9 +375,7 @@ def mock_repo_with_nested_class_metadata():
     (pkg_storage_ext / "go.mod").touch()
     (pkg_storage_ext / "metadata.yaml").write_text("type: xstorage\nstatus:\n  class: pkg\n")
 
-    yield repo_path
-
-    shutil.rmtree(temp_dir)
+    return repo_path
 
 
 def test_nested_component_with_matching_parent_class_included(mock_repo_with_nested_class_metadata):


### PR DESCRIPTION
## What changed

Updates `ComponentScanner` to use the upstream `metadata.status.class` when determining whether a scanned package is a valid Collector component...

Packages whose declared `status.class` does not match the component type being scanned are now excluded, while packages with missing metadata or missing `status.class` continue to fail open and retain the existing behavior!

This prevents internal interface packages such as `xreceiver`, `xexporter`, `xprocessor`, `xconnector`, and `xextension` from being cataloged as user-facing Collector components..!

## Why

Closes #991

The scanner previously determined component inclusion before parsing the upstream metadata, so these internal interface packages could pass the directory-based checks and be registered as real components...

This change follows the metadata-driven approach discussed in the issue rather than adding another hardcoded package exclusion list.

## How it was tested

- Added regression coverage for:
  - `status.class` mismatch → excluded
  - matching `status.class` → included
  - missing `status.class` → included
  - missing `status` → included
  - nested components and their parent component types
  - all five affected interface package types
- `pytest ecosystem-automation/collector-watcher/tests/test_component_scanner.py -q`
- Full `ecosystem-automation` Python test suite: **898 passed**
- Ruff lint and format checks pass

## Scope

- `component_scanner.py`
- `test_component_scanner.py`

Registry backfill/generated data is intentionally not included in this PR!