### PR TITLE
fix: respect selected version in source code link

### DIFF
--- a/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx
@@ -459,4 +459,46 @@ describe("CollectorDetailPage", () => {
     expect(screen.getByText("Stability Levels")).toBeInTheDocument();
     expect(screen.queryByText("Distribution Availability")).not.toBeInTheDocument();
   });
+
+  it("View Source Code link points to the main branch when no version is explicitly selected", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithoutTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver");
+
+    const sourceLink = screen.getByRole("link", { name: /source code/i });
+    expect(sourceLink).toHaveAttribute(
+      "href",
+      "https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver"
+    );
+  });
+
+  it("View Source Code link points to the specific v-tagged branch when a version is explicitly selected", () => {
+    vi.mocked(useCollectorVersions).mockReturnValue({
+      data: { versions: [{ version: "0.150.0", is_latest: true }] },
+      loading: false,
+      error: null,
+    });
+    vi.mocked(useCollectorComponent).mockReturnValue({
+      data: mockComponentWithoutTelemetry,
+      loading: false,
+      error: null,
+    });
+
+    renderAtRoute("/collector/components/core/otlpreceiver?version=0.150.0");
+
+    const sourceLink = screen.getByRole("link", { name: /source code/i });
+    expect(sourceLink).toHaveAttribute(
+      "href",
+      "https://github.com/open-telemetry/opentelemetry-collector/tree/v0.150.0/receiver/otlpreceiver"
+    );
+  });
 });

--- a/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
+++ b/ecosystem-explorer/src/features/collector/collector-detail-page.tsx
@@ -367,7 +367,7 @@ export function CollectorDetailPage() {
                         {t("detail.sections.linksResources")}
                       </h2>
                       <a
-                        href={`https://github.com/open-telemetry/${component.repository}/tree/${deprecatedView ? `v${version}` : "main"}/${component.type}/${component.name}`}
+                        href={`https://github.com/open-telemetry/${component.repository}/tree/${deprecatedView || rawVersion ? `v${version}` : "main"}/${component.type}/${component.name}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="border-border/50 hover:bg-muted/50 group flex items-center gap-3 rounded-lg border p-3 transition-colors"


### PR DESCRIPTION
## What changed

Updated the Collector detail page's **View Source Code** link to respect the selected component version!

When a specific version is selected, the link now points to the corresponding version-tagged path instead of always falling back to `main`!

Also added regression coverage for both the default and explicitly versioned cases...!

## Why

Previously, the source code link always pointed to `main` when a historical version was selected, making the link inconsistent with the version currently displayed in the Explorer..

## How it was tested

- Added regression tests for:
  - Default view → source link points to `main`
  - Explicit version (`v0.150.0`) → source link points to the corresponding version tag
- `npm run test -- ecosystem-explorer/src/features/collector/collector-detail-page.test.tsx`
- `npx tsc --noEmit`
- `npm run lint`

All tests passed successfully

## Special notes for reviewers

This is intentionally a minimal fix that preserves the existing `deprecated` behavior while ensuring explicitly selected versions use the correct versioned source link!

Closes #996