### PR TITLE
test(js-watcher): add coverage for main and repository manager

### DIFF
--- a/ecosystem-automation/js-instrumentation-watcher/tests/test_main.py
+++ b/ecosystem-automation/js-instrumentation-watcher/tests/test_main.py
@@ -1,0 +1,147 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the JS instrumentation watcher entry point."""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from js_instrumentation_watcher.main import REGISTRY_DIR, configure_logging, main
+
+
+@pytest.fixture
+def wiring():
+    """Patch the three collaborators main() wires together."""
+    with (
+        patch("js_instrumentation_watcher.main.JsContribRepositoryManager") as repo_manager,
+        patch("js_instrumentation_watcher.main.InventoryManager") as inventory_manager,
+        patch("js_instrumentation_watcher.main.InstrumentationSync") as sync,
+    ):
+        repo_manager.return_value.setup.return_value = Path("/repos/opentelemetry-js-contrib")
+        sync.return_value.sync.return_value = {"new": [], "skipped": [], "failed": []}
+        yield repo_manager, inventory_manager, sync
+
+
+def test_main_returns_none_on_success(wiring, monkeypatch):
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    assert main() is None
+
+
+def test_main_defaults_base_dir_to_tmp_repos(wiring, monkeypatch):
+    repo_manager, _, _ = wiring
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    repo_manager.assert_called_once_with(base_dir="tmp_repos")
+
+
+def test_main_honors_repos_dir_env_var(wiring, monkeypatch):
+    repo_manager, _, _ = wiring
+    monkeypatch.setenv("JS_CONTRIB_REPOS_DIR", "custom_repos")
+
+    main()
+
+    repo_manager.assert_called_once_with(base_dir="custom_repos")
+
+
+def test_main_builds_inventory_manager_with_registry_dir(wiring, monkeypatch):
+    _, inventory_manager, _ = wiring
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    inventory_manager.assert_called_once_with(registry_dir=REGISTRY_DIR)
+
+
+def test_main_passes_resolved_repo_path_and_inventory_to_sync(wiring, monkeypatch):
+    repo_manager, inventory_manager, sync = wiring
+    repo_manager.return_value.setup.return_value = Path("/repos/resolved-js-contrib")
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    sync.assert_called_once_with(
+        repo_path=Path("/repos/resolved-js-contrib"),
+        inventory_manager=inventory_manager.return_value,
+    )
+
+
+def test_main_runs_the_sync(wiring, monkeypatch):
+    _, _, sync = wiring
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    sync.return_value.sync.assert_called_once_with()
+
+
+def test_main_logs_the_sync_summary(wiring, monkeypatch, caplog):
+    _, _, sync = wiring
+    sync.return_value.sync.return_value = {
+        "new": ["instrumentation-express@0.66.0"],
+        "skipped": [],
+        "failed": [],
+    }
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    with caplog.at_level(logging.INFO, logger="js_instrumentation_watcher.main"):
+        main()
+
+    assert "instrumentation-express@0.66.0" in caplog.text
+
+
+def test_main_propagates_repository_setup_failure(wiring, monkeypatch):
+    repo_manager, _, sync = wiring
+    repo_manager.return_value.setup.side_effect = RuntimeError("Failed to clone repository")
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="Failed to clone"):
+        main()
+
+    sync.return_value.sync.assert_not_called()
+
+
+def test_main_propagates_sync_failure(wiring, monkeypatch):
+    _, _, sync = wiring
+    sync.return_value.sync.side_effect = RuntimeError("sync exploded")
+    monkeypatch.delenv("JS_CONTRIB_REPOS_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="sync exploded"):
+        main()
+
+
+def test_registry_dir_points_at_javascript_registry():
+    assert REGISTRY_DIR == "ecosystem-registry/javascript"
+
+
+def test_configure_logging_sets_info_level():
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    original_handlers = root_logger.handlers[:]
+    try:
+        root_logger.handlers.clear()
+        root_logger.setLevel(logging.NOTSET)
+
+        configure_logging()
+
+        assert root_logger.level == logging.INFO
+        assert root_logger.handlers
+    finally:
+        root_logger.handlers[:] = original_handlers
+        root_logger.setLevel(original_level)

--- a/ecosystem-automation/js-instrumentation-watcher/tests/test_repository_manager.py
+++ b/ecosystem-automation/js-instrumentation-watcher/tests/test_repository_manager.py
@@ -1,0 +1,134 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for JsContribRepositoryManager."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from js_instrumentation_watcher.repository_manager import (
+    REPO_ENV_VAR,
+    REPO_NAME,
+    REPO_URL,
+    JsContribRepositoryManager,
+)
+from watcher_common.repository_manager import _GIT
+
+
+def test_init_defaults_to_tmp_repos():
+    manager = JsContribRepositoryManager()
+
+    assert manager.base_dir == Path("tmp_repos")
+
+
+def test_init_honors_custom_base_dir(tmp_path):
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+
+    assert manager.base_dir == tmp_path
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_uses_env_var_path_when_it_exists(mock_run, tmp_path, monkeypatch):
+    existing_repo = tmp_path / "local-js-contrib"
+    existing_repo.mkdir()
+    monkeypatch.setenv(REPO_ENV_VAR, str(existing_repo))
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+
+    assert manager.setup() == existing_repo
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_does_not_touch_git_when_env_var_is_used(mock_run, tmp_path, monkeypatch):
+    existing_repo = tmp_path / "local-js-contrib"
+    existing_repo.mkdir()
+    monkeypatch.setenv(REPO_ENV_VAR, str(existing_repo))
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+    manager.setup()
+
+    mock_run.assert_not_called()
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_falls_back_to_clone_when_env_var_path_is_missing(mock_run, tmp_path, monkeypatch):
+    monkeypatch.setenv(REPO_ENV_VAR, str(tmp_path / "does-not-exist"))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == tmp_path / REPO_NAME
+    assert mock_run.call_args[0][0] == [_GIT, "clone", REPO_URL, str(tmp_path / REPO_NAME)]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_clones_when_repo_not_present(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == tmp_path / REPO_NAME
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0] == [_GIT, "clone", REPO_URL, str(tmp_path / REPO_NAME)]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_pulls_when_repo_already_present(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    repo_path = tmp_path / REPO_NAME
+    repo_path.mkdir()
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == repo_path
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0][0][0] == [_GIT, "checkout", "main"]
+    assert mock_run.call_args_list[1][0][0] == [_GIT, "pull"]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_raises_when_clone_fails(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    mock_run.side_effect = subprocess.CalledProcessError(1, "git clone", stderr="Clone failed")
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="Failed to clone"):
+        manager.setup()
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_raises_when_pull_fails(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    (tmp_path / REPO_NAME).mkdir()
+    mock_run.side_effect = subprocess.CalledProcessError(1, "git pull", stderr="Pull failed")
+
+    manager = JsContribRepositoryManager(base_dir=str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="Failed to pull"):
+        manager.setup()
+
+
+def test_repo_constants_point_at_js_contrib():
+    assert REPO_NAME == "opentelemetry-js-contrib"
+    assert REPO_URL.endswith("opentelemetry-js-contrib.git")
+    assert REPO_ENV_VAR == "JS_CONTRIB_REPO_PATH"


### PR DESCRIPTION
## What changed

I have added two test files for the JavaScript Watcher which are `test_main.py` and `test_repository_manager.py`. These were the last two modules in the watcher which had no test coverage at all (`instrumentation_sync.py` is the third module).

`main.py` tests cover the wiring: that it builds the repository manager, inventory manager and sync with the right args, reads `JS_CONTRIB_REPOS_DIR` and falls back to `tmp_repos`, passes the resolved repo path through to the sync, and logs the summary. Also it covers failure propagation from both setup and sync.

`repository_manager.py` tests cover `setup()`: using `JS_CONTRIB_REPO_PATH` when it points somewhere real, falling back to clone when it doesn't, cloning when the repo isn't there yet, pulling when it is, and raising on clone/pull failure.

## Why

Part of #990 

## How it was tested

I tested it by successfully running the commands mentioned below:

`uv run pytest tests/ --cov=js_instrumentation_watcher --cov-report=term-missing` from `ecosystem-automation/js-instrumentation-watcher`

`main.py` and `repository_manager.py` both went from 0% to 100%. Watcher total went from 57% to 75%.

I also ran `uv run pytest ecosystem-automation -q` for the whole Python suite, 920 passed.

## Is this a breaking change?

No

## Special notes for your reviewer

Two things:

- The dotnet watcher's `test_main.py` asserts `SystemExit` with code 1 when the sync fails. Our `main.py` doesn't catch exceptions or call `sys.exit`, it just lets them propagate, so I tested for propagation instead.

## Checklist

- [x] Tests added or updated for new behavior
- [ ] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
