### PR TITLE
Agent delivery fixes for edge function

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -314,6 +314,12 @@ jobs:
       - name: Run build
         run: bun run build
 
+      # Runs the edge function against the real dist/ output, so the paths it
+      # builds (`${route}.md`, /seo/routes.json, /agent/**) are checked against
+      # what the build emits — not only against mocked rewrites.
+      - name: Run edge tests against the build output
+        run: bun run test:edge
+
   schemas-up-to-date:
     name: Schemas up to date
     runs-on: ubuntu-latest

--- a/docs/seo-and-agent-delivery.md
+++ b/docs/seo-and-agent-delivery.md
@@ -92,14 +92,22 @@ shared `src/lib/seo` helpers, so a JS render and a non-JS fetch of the same URL 
 and is the delivery layer for non-JS clients. It:
 
 - **Negotiates content** — a request with `Accept: text/markdown` is served the route's generated
-  `.md` (falling back to the section index, then `llms.txt`).
+  `.md`. When no such file exists the section index is served instead, but only for paths that are
+  real routes; a fabricated path returns 404 rather than 200 with the index body, so an agent can
+  tell "your URL is wrong" from "here is your answer". The homepage falls back to `llms.txt`.
+- **Redirects the deprecated Java route** — `/java-agent/instrumentation/:version/:name` returns a
+  301 to `/java-agent/instrumentation/:name?version=:version`. The SPA performs the same hop with a
+  React `<Navigate>`, which HTTP-only clients never execute.
 - **Serves documentation assets** with correct content types and strict 404s — `llms.txt`,
   `/agent/**` Markdown, `/schemas` and `/data` JSON, `sitemap.xml`, and `robots.txt`. Passing
   through a conditional revalidation status (304) untouched is important; collapsing it to 404
   breaks data loading.
 - **Rewrites the HTML shell per route** — for page navigations it looks the path up in `routes.json`
   and injects a route-specific title, description, canonical link, Open Graph / Twitter tags, a
-  Markdown `alternate` link, and JSON-LD.
+  Markdown `alternate` link, and JSON-LD. The alternate is advertised in both `<head>` and a
+  `Link: <url>; rel="alternate"; type="text/markdown"` response header (so `HEAD` alone reveals it),
+  and only when the Markdown page actually exists — a route without one advertises no alternate.
+  `HEAD` is handled alongside `GET` for this reason.
 - **Injects real body content** — it renders the route's generated Markdown into the empty `#root`
   (visually hidden and `aria-hidden` so human visitors never see it), so HTTP-only agents receive
   actual page content instead of an empty shell.

--- a/docs/seo-and-agent-delivery.md
+++ b/docs/seo-and-agent-delivery.md
@@ -107,7 +107,8 @@ and is the delivery layer for non-JS clients. It:
   Markdown `alternate` link, and JSON-LD. The alternate is advertised in both `<head>` and a
   `Link: <url>; rel="alternate"; type="text/markdown"` response header (so `HEAD` alone reveals it),
   and only when the Markdown page actually exists — a route without one advertises no alternate.
-  `HEAD` is handled alongside `GET` for this reason.
+  `HEAD` is handled alongside `GET` for this reason, and answers with the same status and headers as
+  the `GET` but no body.
 - **Injects real body content** — it renders the route's generated Markdown into the empty `#root`
   (visually hidden and `aria-hidden` so human visitors never see it), so HTTP-only agents receive
   actual page content instead of an empty shell.

--- a/docs/seo-and-agent-delivery.md
+++ b/docs/seo-and-agent-delivery.md
@@ -115,7 +115,9 @@ and is the delivery layer for non-JS clients. It:
 - **Returns real 404s** for paths absent from the manifest, so crawlers don't index soft 404s.
   Parameterized routes that resolve client-side (versioned lists, instrumentation version routes)
   are allow-listed as known. If the manifest fails to load, every page is treated as known to avoid
-  false 404s.
+  false 404s — which is why the edge reads `routes.json` with an explicit `GET` rather than
+  `context.rewrite()` (that inherits the in-flight method, so a `HEAD` would return a body-less
+  manifest and make every fabricated path look known).
 
 ## Deployment wiring
 

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
@@ -22,8 +22,8 @@
 // and CI builds after the unit tests run.
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createServer, type Server } from "node:http";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { extname, join, resolve, dirname, sep } from "node:path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { extname, join, resolve, dirname, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AddressInfo } from "node:net";
 import handler from "../agent-negotiation";
@@ -49,19 +49,25 @@ describe.skipIf(!hasDist)("agent-negotiation against the built dist/", () => {
   let server: Server;
   let base: string;
 
+  // URL path -> absolute file, indexed once from dist/. The request path is only
+  // ever a lookup key here: nothing derived from it reaches the filesystem, so a
+  // "../" in a URL misses the map and falls through to the catch-all like any
+  // other unknown path.
+  const filesByUrlPath = new Map<string, string>();
+
   beforeAll(async () => {
+    for (const entry of readdirSync(distDir, { recursive: true, withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const absolute = join(entry.parentPath, entry.name);
+      filesByUrlPath.set(`/${relative(distDir, absolute).split(sep).join("/")}`, absolute);
+    }
+    const indexHtml = join(distDir, "index.html");
+
     server = createServer((req, res) => {
-      const path = decodeURIComponent((req.url ?? "/").split("?")[0]);
-      // resolve() collapses any "../" in the request path before the prefix
-      // check, so a traversal attempt reads index.html like any other unknown path.
-      const candidate = resolve(distDir, `.${path}`);
-      const isFile =
-        candidate.startsWith(distDir + sep) &&
-        existsSync(candidate) &&
-        statSync(candidate).isFile();
+      const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
       // SPA catch-all: unknown paths get index.html with status 200, exactly the
       // shape the handler has to distinguish a real file from.
-      const file = isFile ? candidate : join(distDir, "index.html");
+      const file = filesByUrlPath.get(urlPath) ?? indexHtml;
       res.writeHead(200, {
         "content-type": CONTENT_TYPES[extname(file)] ?? "application/octet-stream",
       });

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Runs the edge handler against the real `dist/` produced by `bun run build`,
+// with context.rewrite() backed by an HTTP server that mirrors netlify.toml
+// (existing file wins; everything else falls through to /index.html with 200).
+// The mocked-context suite proves the branching; this proves the paths the
+// branches build (`${route}.md`, /seo/routes.json, /agent/**) match what the
+// build actually emits. Skipped when dist/ is absent, since dist is gitignored
+// and CI builds after the unit tests run.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { extname, join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AddressInfo } from "node:net";
+import handler from "../agent-negotiation";
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../dist");
+const hasDist = existsSync(join(distDir, "index.html"));
+
+// Locally the suite skips when nothing has been built yet; in CI it must not
+// pass vacuously, because the step that runs it comes right after the build.
+if (!hasDist && process.env.CI) {
+  throw new Error("dist/ is missing — run `bun run build` before `bun run test:edge`");
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".json": "application/json",
+  ".txt": "text/plain; charset=utf-8",
+  ".xml": "application/xml",
+};
+
+describe.skipIf(!hasDist)("agent-negotiation against the built dist/", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const path = decodeURIComponent((req.url ?? "/").split("?")[0]);
+      const candidate = join(distDir, path);
+      const isFile =
+        candidate.startsWith(distDir) && existsSync(candidate) && statSync(candidate).isFile();
+      // SPA catch-all: unknown paths get index.html with status 200, exactly the
+      // shape the handler has to distinguish a real file from.
+      const file = isFile ? candidate : join(distDir, "index.html");
+      res.writeHead(200, {
+        "content-type": CONTENT_TYPES[extname(file)] ?? "application/octet-stream",
+      });
+      // node:http drops the body for HEAD on its own, mirroring the origin.
+      res.end(readFileSync(file));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(() => new Promise<void>((r) => server.close(() => r())));
+
+  // Netlify binds rewrite() to the in-flight request, so the method carries
+  // through. The response is re-wrapped because fetch() hands back immutable
+  // headers, while Netlify documents the rewrite/next response as mutable.
+  const contextFor = (request: Request) =>
+    ({
+      rewrite: async (path: string) => {
+        const upstream = await fetch(`${base}${path}`, { method: request.method });
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: new Headers(upstream.headers),
+        });
+      },
+    }) as unknown as Parameters<typeof handler>[1];
+
+  const run = (path: string, init?: RequestInit) => {
+    const request = new Request(`https://explorer.opentelemetry.io${path}`, init);
+    return handler(request, contextFor(request));
+  };
+
+  it("injects the route's real Markdown and advertises the alternate on GET", async () => {
+    const res = await run("/collector");
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("link")).toBe(
+      '<https://explorer.opentelemetry.io/collector.md>; rel="alternate"; type="text/markdown"'
+    );
+    const html = await res!.text();
+    expect(html).not.toContain('<div id="root"></div>');
+    expect(html).toContain(
+      '<link rel="canonical" href="https://explorer.opentelemetry.io/collector" />'
+    );
+  });
+
+  it("answers HEAD for the same route with headers only", async () => {
+    const res = await run("/collector", { method: "HEAD" });
+    expect(res?.status).toBe(200);
+    expect(res?.body).toBeNull();
+    expect(res?.headers.get("link")).toContain('rel="alternate"');
+  });
+
+  it("serves the built Markdown for Accept: text/markdown", async () => {
+    const res = await run("/collector", { headers: { accept: "text/markdown" } });
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-type")).toBe("text/markdown; charset=UTF-8");
+    expect(await res!.text()).toBe(readFileSync(join(distDir, "collector.md"), "utf-8"));
+  });
+
+  it("404s a fabricated route that the SPA catch-all would answer 200 for", async () => {
+    const res = await run("/collector/components/contrib/nope-xyz-does-not-exist");
+    expect(res?.status).toBe(404);
+    expect(res?.headers.get("link")).toBeNull();
+  });
+
+  it("serves the generated /llms.txt", async () => {
+    const res = await run("/llms.txt");
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-type")).toBe("text/plain; charset=UTF-8");
+  });
+
+  it("emits a Markdown page for every route in the SEO manifest", async () => {
+    const routes = JSON.parse(readFileSync(join(distDir, "seo/routes.json"), "utf-8"));
+    const missing = Object.keys(routes).filter(
+      (route) => !existsSync(join(distDir, route === "/" ? "index.md" : `${route}.md`))
+    );
+    expect(missing).toEqual([]);
+    // Guard the agentPathMap targets too.
+    for (const p of [
+      "agent/collector/index.md",
+      "agent/collector/versions.md",
+      "agent/javaagent/index.md",
+      "agent/javaagent/versions.md",
+      "llms-full.txt",
+    ]) {
+      expect(existsSync(join(distDir, p)), p).toBe(true);
+    }
+  });
+});

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.dist.test.ts
@@ -20,10 +20,10 @@
 // branches build (`${route}.md`, /seo/routes.json, /agent/**) match what the
 // build actually emits. Skipped when dist/ is absent, since dist is gitignored
 // and CI builds after the unit tests run.
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createServer, type Server } from "node:http";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { extname, join, resolve, dirname } from "node:path";
+import { extname, join, resolve, dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AddressInfo } from "node:net";
 import handler from "../agent-negotiation";
@@ -52,9 +52,13 @@ describe.skipIf(!hasDist)("agent-negotiation against the built dist/", () => {
   beforeAll(async () => {
     server = createServer((req, res) => {
       const path = decodeURIComponent((req.url ?? "/").split("?")[0]);
-      const candidate = join(distDir, path);
+      // resolve() collapses any "../" in the request path before the prefix
+      // check, so a traversal attempt reads index.html like any other unknown path.
+      const candidate = resolve(distDir, `.${path}`);
       const isFile =
-        candidate.startsWith(distDir) && existsSync(candidate) && statSync(candidate).isFile();
+        candidate.startsWith(distDir + sep) &&
+        existsSync(candidate) &&
+        statSync(candidate).isFile();
       // SPA catch-all: unknown paths get index.html with status 200, exactly the
       // shape the handler has to distinguish a real file from.
       const file = isFile ? candidate : join(distDir, "index.html");
@@ -84,9 +88,22 @@ describe.skipIf(!hasDist)("agent-negotiation against the built dist/", () => {
       },
     }) as unknown as Parameters<typeof handler>[1];
 
+  // Requests carry the test server's own origin so the handler's explicit GET for
+  // /seo/routes.json (rewrite() would inherit HEAD and come back bodyless) resolves
+  // against dist/. Canonical URLs and the Link alternate stay pinned to the
+  // production origin regardless, which the assertions below rely on.
   const run = (path: string, init?: RequestInit) => {
-    const request = new Request(`https://explorer.opentelemetry.io${path}`, init);
+    const request = new Request(`${base}${path}`, init);
     return handler(request, contextFor(request));
+  };
+
+  // The route manifest is cached in module scope; a fresh instance reproduces the
+  // first request an edge isolate sees.
+  const runCold = async (path: string, init?: RequestInit) => {
+    vi.resetModules();
+    const { default: coldHandler } = await import("../agent-negotiation");
+    const request = new Request(`${base}${path}`, init);
+    return coldHandler(request, contextFor(request));
   };
 
   it("injects the route's real Markdown and advertises the alternate on GET", async () => {
@@ -120,6 +137,20 @@ describe.skipIf(!hasDist)("agent-negotiation against the built dist/", () => {
     const res = await run("/collector/components/contrib/nope-xyz-does-not-exist");
     expect(res?.status).toBe(404);
     expect(res?.headers.get("link")).toBeNull();
+  });
+
+  it("404s a fabricated route on a cold HEAD, when nothing has parsed the manifest yet", async () => {
+    const res = await runCold("/nope-xyz-does-not-exist", { method: "HEAD" });
+    expect(res?.status).toBe(404);
+    expect(res?.body).toBeNull();
+  });
+
+  it("404s a fabricated section path on a cold HEAD asking for Markdown", async () => {
+    const res = await runCold("/collector/nope-xyz-does-not-exist", {
+      method: "HEAD",
+      headers: { accept: "text/markdown" },
+    });
+    expect(res?.status).toBe(404);
   });
 
   it("serves the generated /llms.txt", async () => {

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import handler from "../agent-negotiation";
 
 type Rewrite = (path: string) => Promise<Response>;
@@ -80,21 +80,32 @@ function htmlContextWithMd(
 }
 
 // Mirrors a HEAD request reaching origin: context.rewrite() carries the method
-// through, so both the shell and the Markdown probe resolve with headers only.
+// through, so every rewrite — the shell, the Markdown probe, and the manifest —
+// resolves with headers only. The handler therefore fetches /seo/routes.json
+// with an explicit GET, which this stubs; nothing else may go over fetch().
 function headContextWithMd(
   routes: Record<string, { title: string; description: string }>,
   mdPaths: string[]
 ) {
-  return contextWith(async (path) => {
-    if (path === "/seo/routes.json") {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(String(input)).toBe("https://explorer.opentelemetry.io/seo/routes.json");
+      expect(init?.method).toBe("GET");
       return new Response(JSON.stringify(routes), { status: 200 });
-    }
+    })
+  );
+  return contextWith(async (path) => {
     if (mdPaths.includes(path)) {
       return new Response(null, { status: 200, headers: { "content-type": "text/markdown" } });
     }
     return new Response(null, { status: 200, headers: { "content-type": "text/html" } });
   });
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const head = (path: string) =>
   new Request(`https://explorer.opentelemetry.io${path}`, { method: "HEAD" });
@@ -654,20 +665,14 @@ describe("agent-negotiation Markdown alternate advertising", () => {
 
   it("answers a HEAD request with the same header", async () => {
     const handler = await freshHandler();
-    const res = await handler(
-      head("/collector"),
-      htmlContextWithMd(routes, { "/collector.md": "# Collector" })
-    );
+    const res = await handler(head("/collector"), headContextWithMd(routes, ["/collector.md"]));
     expect(res?.status).toBe(200);
     expect(res?.headers.get("link")).toContain('rel="alternate"');
   });
 
   it("answers a HEAD request with headers only, no body", async () => {
     const handler = await freshHandler();
-    const res = await handler(
-      head("/collector"),
-      htmlContextWithMd(routes, { "/collector.md": "# Collector" })
-    );
+    const res = await handler(head("/collector"), headContextWithMd(routes, ["/collector.md"]));
     expect(res?.status).toBe(200);
     expect(res?.body).toBeNull();
     expect(await res!.text()).toBe("");
@@ -694,7 +699,23 @@ describe("agent-negotiation Markdown alternate advertising", () => {
 
   it("returns a bodyless 404 for an unknown route on HEAD", async () => {
     const handler = await freshHandler();
-    const res = await handler(head("/nope-xyz"), headContextWithMd(routes, []));
+    const context = headContextWithMd(routes, []);
+    const res = await handler(head("/nope-xyz"), context);
+    expect(res?.status).toBe(404);
+    expect(res?.body).toBeNull();
+    // The manifest must come from the GET fetch, not from a rewrite that HEAD
+    // would answer bodyless — an unparsed manifest makes every path look known.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(context.rewrite).not.toHaveBeenCalledWith("/seo/routes.json");
+  });
+
+  it("404s a fabricated section path on HEAD with Accept: text/markdown", async () => {
+    const handler = await freshHandler();
+    const request = new Request("https://explorer.opentelemetry.io/collector/nope-xyz", {
+      method: "HEAD",
+      headers: { accept: "text/markdown" },
+    });
+    const res = await handler(request, headContextWithMd(routes, []));
     expect(res?.status).toBe(404);
     expect(res?.body).toBeNull();
   });

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
@@ -79,6 +79,26 @@ function htmlContextWithMd(
   });
 }
 
+// Mirrors a HEAD request reaching origin: context.rewrite() carries the method
+// through, so both the shell and the Markdown probe resolve with headers only.
+function headContextWithMd(
+  routes: Record<string, { title: string; description: string }>,
+  mdPaths: string[]
+) {
+  return contextWith(async (path) => {
+    if (path === "/seo/routes.json") {
+      return new Response(JSON.stringify(routes), { status: 200 });
+    }
+    if (mdPaths.includes(path)) {
+      return new Response(null, { status: 200, headers: { "content-type": "text/markdown" } });
+    }
+    return new Response(null, { status: 200, headers: { "content-type": "text/html" } });
+  });
+}
+
+const head = (path: string) =>
+  new Request(`https://explorer.opentelemetry.io${path}`, { method: "HEAD" });
+
 describe("agent-negotiation edge function", () => {
   it("passes a 304 Not Modified through for /data instead of converting it to 404", async () => {
     const context = contextWith(async () => new Response(null, { status: 304 }));
@@ -109,6 +129,29 @@ describe("agent-negotiation edge function", () => {
     );
     const res = await handler(get("/data/configuration/versions-index.json"), context);
     expect(res?.status).toBe(404);
+  });
+
+  it("keeps the 404 explanation in the body for GET", async () => {
+    const context = contextWith(
+      async () =>
+        new Response("<!doctype html><html></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        })
+    );
+    const res = await handler(get("/agent/nope.md"), context);
+    expect(res?.status).toBe(404);
+    expect(await res!.text()).toBe("Not Found");
+  });
+
+  it("returns a bodyless 404 for HEAD on an asset path", async () => {
+    const context = contextWith(
+      async () => new Response(null, { status: 200, headers: { "content-type": "text/html" } })
+    );
+    const res = await handler(head("/agent/nope.md"), context);
+    expect(res?.status).toBe(404);
+    expect(res?.body).toBeNull();
+    expect(await res!.text()).toBe("");
   });
 
   it("serves markdown for /javaagent with Accept: text/markdown", async () => {
@@ -611,10 +654,49 @@ describe("agent-negotiation Markdown alternate advertising", () => {
 
   it("answers a HEAD request with the same header", async () => {
     const handler = await freshHandler();
-    const req = new Request("https://explorer.opentelemetry.io/collector", { method: "HEAD" });
-    const res = await handler(req, htmlContextWithMd(routes, { "/collector.md": "# Collector" }));
+    const res = await handler(
+      head("/collector"),
+      htmlContextWithMd(routes, { "/collector.md": "# Collector" })
+    );
     expect(res?.status).toBe(200);
     expect(res?.headers.get("link")).toContain('rel="alternate"');
+  });
+
+  it("answers a HEAD request with headers only, no body", async () => {
+    const handler = await freshHandler();
+    const res = await handler(
+      head("/collector"),
+      htmlContextWithMd(routes, { "/collector.md": "# Collector" })
+    );
+    expect(res?.status).toBe(200);
+    expect(res?.body).toBeNull();
+    expect(await res!.text()).toBe("");
+    expect(res?.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(res?.headers.get("content-length")).toBeNull();
+  });
+
+  it("advertises the alternate on HEAD even though the rewrites come back bodyless", async () => {
+    const handler = await freshHandler();
+    const res = await handler(head("/collector"), headContextWithMd(routes, ["/collector.md"]));
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("link")).toBe(
+      '<https://explorer.opentelemetry.io/collector.md>; rel="alternate"; type="text/markdown"'
+    );
+    expect(res?.body).toBeNull();
+  });
+
+  it("advertises no alternate on HEAD for a known route without Markdown", async () => {
+    const handler = await freshHandler();
+    const res = await handler(head("/collector"), headContextWithMd(routes, []));
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("link")).toBeNull();
+  });
+
+  it("returns a bodyless 404 for an unknown route on HEAD", async () => {
+    const handler = await freshHandler();
+    const res = await handler(head("/nope-xyz"), headContextWithMd(routes, []));
+    expect(res?.status).toBe(404);
+    expect(res?.body).toBeNull();
   });
 
   it("advertises no alternate for a known route without a Markdown page", async () => {

--- a/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
+++ b/ecosystem-explorer/netlify/edge-functions/__tests__/agent-negotiation.test.ts
@@ -164,7 +164,10 @@ describe("agent-negotiation HTML metadata injection", () => {
     const handler = await freshHandler();
     const res = await handler(
       get("/collector"),
-      htmlContext({ "/collector": { title: "Collector — X", description: "Browse components." } })
+      htmlContextWithMd(
+        { "/collector": { title: "Collector — X", description: "Browse components." } },
+        { "/collector.md": "# Collector" }
+      )
     );
     expect(res?.status).toBe(200);
     const html = await res!.text();
@@ -468,5 +471,169 @@ describe("agent-negotiation content negotiation", () => {
     expect(res?.status).toBe(200);
     expect(res?.headers.get("content-type")).toBe("text/plain; charset=UTF-8");
     expect(await res!.text()).toContain("# Index");
+  });
+});
+
+describe("agent-negotiation section-index fallback is gated on real routes", () => {
+  const COLLECTOR_INDEX = "# All Collector components";
+
+  // routes.json plus the Collector section index; every other path is the SPA shell.
+  const indexContext = (routes: Record<string, { title: string; description: string }>) =>
+    htmlContextWithMd(routes, { "/agent/collector/index.md": COLLECTOR_INDEX });
+
+  it("returns 404 instead of the section index for a fabricated path", async () => {
+    const handler = await freshHandler();
+    // Not a route in either route table: the Collector detail route is
+    // /collector/components/:distribution/:name, with no version segment.
+    const res = await handler(
+      get("/collector/components/v0.140.0/contrib/kafkareceiver", { accept: "text/markdown" }),
+      indexContext({
+        "/collector/components/contrib/kafkareceiver": { title: "K", description: "d" },
+      })
+    );
+    expect(res?.status).toBe(404);
+    expect(await res!.text()).not.toContain(COLLECTOR_INDEX);
+  });
+
+  it("still serves the section index for a known route with no Markdown page", async () => {
+    const handler = await freshHandler();
+    // Versioned Collector list: a real client-side route, absent from routes.json.
+    const res = await handler(
+      get("/collector/components/0.156.0", { accept: "text/markdown" }),
+      indexContext({ "/collector/components": { title: "C", description: "d" } })
+    );
+    expect(res?.status).toBe(200);
+    expect(await res!.text()).toContain(COLLECTOR_INDEX);
+  });
+
+  it("keeps the /javaagent alias resolving to the Java section index", async () => {
+    const handler = await freshHandler();
+    const res = await handler(
+      get("/javaagent", { accept: "text/markdown" }),
+      htmlContextWithMd(
+        { "/java-agent": { title: "Java Agent", description: "d" } },
+        { "/agent/javaagent/index.md": "# All Java agent instrumentations" }
+      )
+    );
+    expect(res?.status).toBe(200);
+    expect(await res!.text()).toContain("# All Java agent instrumentations");
+  });
+
+  it("404s a fabricated path under the /javaagent alias", async () => {
+    const handler = await freshHandler();
+    const res = await handler(
+      get("/javaagent/not/a/route", { accept: "text/markdown" }),
+      htmlContextWithMd(
+        { "/java-agent": { title: "Java Agent", description: "d" } },
+        { "/agent/javaagent/index.md": "# All Java agent instrumentations" }
+      )
+    );
+    expect(res?.status).toBe(404);
+  });
+
+  it("serves the section index when the routes manifest is unavailable", async () => {
+    const handler = await freshHandler();
+    const context = contextWith(async (path) => {
+      if (path === "/seo/routes.json") return new Response("missing", { status: 404 });
+      if (path === "/agent/collector/index.md") {
+        return new Response(COLLECTOR_INDEX, {
+          status: 200,
+          headers: { "content-type": "text/markdown" },
+        });
+      }
+      return htmlShell();
+    });
+    const res = await handler(
+      get("/collector/components/anything/at/all", { accept: "text/markdown" }),
+      context
+    );
+    expect(res?.status).toBe(200);
+    expect(await res!.text()).toContain(COLLECTOR_INDEX);
+  });
+});
+
+describe("agent-negotiation legacy Java version route", () => {
+  it("issues a real 301 to the query-param shape", async () => {
+    const context = contextWith(async () => htmlShell());
+    const res = await handler(get("/java-agent/instrumentation/2.31.1/apache-dubbo-2.7"), context);
+    expect(res?.status).toBe(301);
+    expect(res?.headers.get("location")).toBe(
+      "/java-agent/instrumentation/apache-dubbo-2.7?version=2.31.1"
+    );
+  });
+
+  it("redirects Markdown requests and the `latest` alias too", async () => {
+    const context = contextWith(async () => htmlShell());
+    const res = await handler(
+      get("/java-agent/instrumentation/latest/apache-dubbo-2.7", { accept: "text/markdown" }),
+      context
+    );
+    expect(res?.status).toBe(301);
+    expect(res?.headers.get("location")).toBe(
+      "/java-agent/instrumentation/apache-dubbo-2.7?version=latest"
+    );
+  });
+
+  it("preserves other query parameters", async () => {
+    const context = contextWith(async () => htmlShell());
+    const res = await handler(
+      get("/java-agent/instrumentation/2.31.1/apache-dubbo-2.7?tab=config"),
+      context
+    );
+    expect(res?.headers.get("location")).toBe(
+      "/java-agent/instrumentation/apache-dubbo-2.7?tab=config&version=2.31.1"
+    );
+  });
+
+  it("does not redirect a two-segment path whose first segment is not a version", async () => {
+    const handler = await freshHandler();
+    const res = await handler(
+      get("/java-agent/instrumentation/not-a-version/apache-dubbo-2.7"),
+      htmlContext({ "/java-agent/instrumentation": { title: "J", description: "d" } })
+    );
+    expect(res?.status).toBe(404);
+  });
+});
+
+describe("agent-negotiation Markdown alternate advertising", () => {
+  const routes = { "/collector": { title: "Collector — X", description: "d" } };
+
+  it("sets a Link: rel=alternate header when the route has Markdown", async () => {
+    const handler = await freshHandler();
+    const res = await handler(
+      get("/collector"),
+      htmlContextWithMd(routes, { "/collector.md": "# Collector" })
+    );
+    expect(res?.headers.get("link")).toBe(
+      '<https://explorer.opentelemetry.io/collector.md>; rel="alternate"; type="text/markdown"'
+    );
+  });
+
+  it("answers a HEAD request with the same header", async () => {
+    const handler = await freshHandler();
+    const req = new Request("https://explorer.opentelemetry.io/collector", { method: "HEAD" });
+    const res = await handler(req, htmlContextWithMd(routes, { "/collector.md": "# Collector" }));
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("link")).toContain('rel="alternate"');
+  });
+
+  it("advertises no alternate for a known route without a Markdown page", async () => {
+    const handler = await freshHandler();
+    const res = await handler(get("/collector"), htmlContext(routes));
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("link")).toBeNull();
+    const html = await res!.text();
+    expect(html).not.toContain('rel="alternate"');
+    // The llms.txt directive still renders, without the dangling Markdown claim.
+    expect(html).toContain('<a href="/llms.txt">/llms.txt</a>');
+    expect(html).not.toContain("A Markdown version of this page");
+  });
+
+  it("advertises no alternate on a 404", async () => {
+    const handler = await freshHandler();
+    const res = await handler(get("/collector/components/contrib/nope-xyz"), htmlContext(routes));
+    expect(res?.status).toBe(404);
+    expect(res?.headers.get("link")).toBeNull();
+    expect(await res!.text()).not.toContain('rel="alternate"');
   });
 });

--- a/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
+++ b/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
@@ -16,7 +16,11 @@
 
 import type { Context } from "@netlify/edge-functions";
 
-const notFound = () => new Response("Not Found", { status: 404 });
+// A HEAD response must not carry a body, so the 404 explanation is omitted for
+// that method. Content-Length is left off rather than set to the length the GET
+// body would have — it is optional here, and a wrong value is worse than none.
+const notFound = (request: Request) =>
+  new Response(request.method === "HEAD" ? null : "Not Found", { status: 404 });
 
 // Rewrites to a static asset and normalizes its Content-Type. Returns null when
 // the rewrite resolves to the SPA HTML shell (the catch-all serves /index.html
@@ -92,7 +96,9 @@ async function loadRoutes(context: Context): Promise<Record<string, RouteMeta>> 
 // Fetches the pre-generated Markdown for a route (served at `${path}.md`).
 // Returns null when the file doesn't exist — the SPA catch-all serves
 // /index.html (200, text/html) for unknown paths, which we detect and treat as
-// "no Markdown for this route".
+// "no Markdown for this route". The text is empty (but non-null) when the
+// rewrite inherits a HEAD request, so callers that only need existence must test
+// for null rather than for truthiness.
 async function fetchMarkdown(context: Context, mdPath: string): Promise<string | null> {
   try {
     const response = await context.rewrite(mdPath);
@@ -378,25 +384,23 @@ function buildJsonLd(title: string, description: string, canonicalUrl: string): 
   return JSON.stringify(data).replace(/</g, "\\u003c");
 }
 
+interface InjectOptions {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  mdUrl: string | null;
+  status: number;
+  // null for HEAD requests, which must answer with headers only: the shell body
+  // is neither read nor rewritten.
+  bodyHtml: string | null;
+}
+
 // Rewrites the SPA shell's <head> with per-route title/description/OG/canonical,
-// a Markdown alternate link, and JSON-LD; injects `bodyHtml` into the empty
-// `#root` so non-JS agents see real content (not a bare SPA shell); then returns
-// it with `status` (200 for known routes, 404 for unknown ones so crawlers don't
-// see soft 404s). `mdUrl` is null when no Markdown page exists for the route, in
-// which case no alternate is advertised in either the <head> or the Link header.
-async function injectHead(
-  shell: Response,
-  opts: {
-    title: string;
-    description: string;
-    canonicalUrl: string;
-    mdUrl: string | null;
-    status: number;
-    bodyHtml: string;
-  }
-): Promise<Response> {
-  const { title, description, canonicalUrl, mdUrl, status, bodyHtml } = opts;
-  let html = await shell.text();
+// a Markdown alternate link, and JSON-LD, and injects `bodyHtml` into the empty
+// `#root` so non-JS agents see real content (not a bare SPA shell).
+function rewriteShell(shellHtml: string, opts: InjectOptions & { bodyHtml: string }): string {
+  const { title, description, canonicalUrl, mdUrl, bodyHtml } = opts;
+  let html = shellHtml;
 
   html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${escapeHtml(title)}</title>`);
   html = setMetaContent(html, 'name="description"', description);
@@ -414,7 +418,25 @@ async function injectHead(
 
   // Populate the SPA root so HTTP-only agents see content. A function replacer
   // avoids `$`-sequence interpretation in bodyHtml (which can contain `$`).
-  html = html.replace(/<div id="root">\s*<\/div>/, () => `<div id="root">${bodyHtml}</div>`);
+  return html.replace(/<div id="root">\s*<\/div>/, () => `<div id="root">${bodyHtml}</div>`);
+}
+
+// Returns the rewritten shell with `status` (200 for known routes, 404 for
+// unknown ones so crawlers don't see soft 404s), or a bodyless response with the
+// same headers when `bodyHtml` is null (HEAD). `mdUrl` is null when no Markdown
+// page exists for the route, in which case no alternate is advertised in either
+// the <head> or the Link header.
+async function injectHead(shell: Response, opts: InjectOptions): Promise<Response> {
+  const { mdUrl, status, bodyHtml } = opts;
+
+  let html: string | null = null;
+  if (bodyHtml === null) {
+    // HEAD: a body would be protocol-incorrect, so drop the shell's instead of
+    // leaving its stream dangling.
+    await shell.body?.cancel();
+  } else {
+    html = rewriteShell(await shell.text(), { ...opts, bodyHtml });
+  }
 
   const headers = new Headers(shell.headers);
   headers.delete("content-length");
@@ -459,7 +481,7 @@ export default async (request: Request, context: Context) => {
   if (pathname === "/llms.txt" || pathname === "/llms-full.txt") {
     return (
       (await serveAsset(context, pathname, "text/plain; charset=UTF-8", { Vary: "Accept" })) ??
-      notFound()
+      notFound(request)
     );
   }
 
@@ -477,7 +499,7 @@ export default async (request: Request, context: Context) => {
     if (lookupPath === "/") {
       return (
         (await serveAsset(context, "/llms.txt", "text/plain; charset=UTF-8", { Vary: "Accept" })) ??
-        notFound()
+        notFound(request)
       );
     }
 
@@ -495,7 +517,7 @@ export default async (request: Request, context: Context) => {
       }
     }
     // Strict 404 for unrecognized Markdown requests (Copilot feedback)
-    return notFound();
+    return notFound(request);
   }
 
   // Explicit agent documentation routes
@@ -518,19 +540,19 @@ export default async (request: Request, context: Context) => {
         return response;
       }
     }
-    return notFound();
+    return notFound(request);
   }
 
   // JSON schemas and metadata
   if (pathname.startsWith("/schemas/") || pathname.startsWith("/data/")) {
     const finalContentType = pathname.endsWith(".json") ? "application/json" : "text/plain";
-    return (await serveAsset(context, pathname, finalContentType)) ?? notFound();
+    return (await serveAsset(context, pathname, finalContentType)) ?? notFound(request);
   }
 
   // Sitemap and Robots
   if (pathname === "/sitemap.xml" || pathname === "/robots.txt") {
     const finalContentType = pathname.endsWith(".xml") ? "application/xml" : "text/plain";
-    return (await serveAsset(context, pathname, finalContentType)) ?? notFound();
+    return (await serveAsset(context, pathname, finalContentType)) ?? notFound(request);
   }
 
   // HTML page navigation. Inject per-route metadata so non-JS social scrapers
@@ -539,7 +561,8 @@ export default async (request: Request, context: Context) => {
   // alternate header below is discoverable without downloading the page; asset
   // requests and other methods pass through untouched so Netlify serves them (or
   // the SPA shell) as before.
-  if ((request.method !== "GET" && request.method !== "HEAD") || ASSET_EXT.test(pathname)) {
+  const isHead = request.method === "HEAD";
+  if ((request.method !== "GET" && !isHead) || ASSET_EXT.test(pathname)) {
     return undefined;
   }
 
@@ -565,13 +588,22 @@ export default async (request: Request, context: Context) => {
   // title/description stub for known routes without a Markdown page and for 404s.
   // The alternate is advertised only when that Markdown actually exists — a
   // dangling alternate is a 404 the agent has to spend a request to discover.
+  // context.rewrite() carries the request method through, so on HEAD this probe
+  // resolves with an empty body: existence is "the rewrite resolved" (non-null),
+  // not "it returned text".
   const md = known ? await fetchMarkdown(context, mdPath) : null;
-  const mdUrl = md ? `${SITE_ORIGIN}${mdPath}` : null;
-  const contentHtml = md
-    ? markdownToHtml(md)
-    : known
-      ? fallbackContent(title, description)
-      : fallbackContent("Page not found", `The page ${lookupPath} could not be found.`);
+  const mdUrl = (isHead ? md !== null : Boolean(md)) ? `${SITE_ORIGIN}${mdPath}` : null;
+
+  // HEAD gets headers only — same status and Link alternate as the GET, no body.
+  let bodyHtml: string | null = null;
+  if (!isHead) {
+    const contentHtml = md
+      ? markdownToHtml(md)
+      : known
+        ? fallbackContent(title, description)
+        : fallbackContent("Page not found", `The page ${lookupPath} could not be found.`);
+    bodyHtml = buildAgentBody(mdUrl, contentHtml);
+  }
 
   return injectHead(shell, {
     title,
@@ -579,6 +611,6 @@ export default async (request: Request, context: Context) => {
     canonicalUrl,
     mdUrl,
     status: known ? 200 : 404,
-    bodyHtml: buildAgentBody(mdUrl, contentHtml),
+    bodyHtml,
   });
 };

--- a/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
+++ b/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
@@ -106,14 +106,61 @@ async function fetchMarkdown(context: Context, mdPath: string): Promise<string |
 
 // Parameterized routes that are valid but not enumerated in routes.json (they
 // resolve client-side): versioned Collector lists and the Java instrumentation
-// version/redirect routes. Anything else not in the manifest is a real 404.
+// version list. Anything else not in the manifest is a real 404.
 function isDynamicKnownRoute(pathname: string): boolean {
   if (/^\/collector\/components\/[^/]+$/.test(pathname)) return true;
   if (/^\/java-agent\/instrumentation\/(latest|\d[\w.+-]*)$/.test(pathname)) return true;
-  if (/^\/java-agent\/instrumentation\/[^/]+\/[^/]+$/.test(pathname)) return true;
   if (pathname === "/_dev/components") return true;
   return false;
 }
+
+interface RouteStatus {
+  meta?: RouteMeta;
+  known: boolean;
+}
+
+// Resolves a path against the build-time manifest plus the dynamic route
+// patterns. If the manifest failed to load, don't risk false 404s: treat every
+// page as known.
+async function routeStatus(context: Context, lookupPath: string): Promise<RouteStatus> {
+  const routes = await loadRoutes(context);
+  const manifestLoaded = Object.keys(routes).length > 0;
+  const meta = routes[lookupPath];
+  return { meta, known: !manifestLoaded || Boolean(meta) || isDynamicKnownRoute(lookupPath) };
+}
+
+// Normalizes /index.html and trailing slashes to the canonical route key so those
+// variants resolve against the manifest instead of falling to a 404.
+function normalizeLookupPath(pathname: string): string {
+  if (pathname === "/index.html") return "/";
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+// `/javaagent` is not an app route — it is the spelling agents commonly guess for
+// the Java agent section. Map it onto the real prefix so the known-route check
+// resolves the alias instead of 404ing it.
+const canonicalizeAlias = (pathname: string): string =>
+  pathname === "/javaagent"
+    ? "/java-agent"
+    : pathname.startsWith("/javaagent/")
+      ? `/java-agent${pathname.slice("/javaagent".length)}`
+      : pathname;
+
+// The generated section index for a path, or null when the path is outside both
+// documented sections.
+function sectionIndexFor(pathname: string): string | null {
+  const p = canonicalizeAlias(pathname);
+  if (p === "/java-agent" || p.startsWith("/java-agent/")) return "/agent/javaagent/index.md";
+  if (p === "/collector" || p.startsWith("/collector/")) return "/agent/collector/index.md";
+  return null;
+}
+
+// Deprecated Java route: `/java-agent/instrumentation/:version/:name` moved to
+// `/java-agent/instrumentation/:name?version=:version`. The SPA performs that hop
+// with a React <Navigate>, which HTTP-only clients never execute — they get a 200
+// and a generic shell with no Location header. Issue the redirect at the edge so
+// it is visible over plain HTTP.
+const LEGACY_JAVA_VERSION_ROUTE = /^\/java-agent\/instrumentation\/(latest|\d[\w.+-]*)\/([^/]+)$/;
 
 const escapeHtml = (value: string): string =>
   value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -264,12 +311,15 @@ function markdownToHtml(md: string): string {
 // Kept in the page content area (a <p>, not <nav>/<script>/<style>) so it
 // satisfies the afdocs llms-txt-directive-html check, which scans the <body> for
 // a directive that survives HTML-to-Markdown conversion.
-function llmsDirective(mdUrl: string): string {
-  return (
-    `<p>This documentation has an index for AI agents at ` +
-    `<a href="/llms.txt">/llms.txt</a>. A Markdown version of this page is available at ` +
-    `<a href="${escapeAttr(mdUrl)}">${escapeHtml(mdUrl)}</a>.</p>`
-  );
+// `mdUrl` is null when the route has no generated Markdown page (versioned lists,
+// 404s); the index sentence still renders so the afdocs check keeps passing.
+function llmsDirective(mdUrl: string | null): string {
+  const index = `This documentation has an index for AI agents at <a href="/llms.txt">/llms.txt</a>.`;
+  const alternate = mdUrl
+    ? ` A Markdown version of this page is available at ` +
+      `<a href="${escapeAttr(mdUrl)}">${escapeHtml(mdUrl)}</a>.`
+    : "";
+  return `<p>${index}${alternate}</p>`;
 }
 
 // Wraps the agent-facing body injected into `#root`. It's rendered for HTTP-only
@@ -287,7 +337,7 @@ const SR_ONLY_STYLE =
   "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
   "clip:rect(0,0,0,0);white-space:nowrap;border:0";
 
-function buildAgentBody(mdUrl: string, contentHtml: string): string {
+function buildAgentBody(mdUrl: string | null, contentHtml: string): string {
   return (
     `<div inert aria-hidden="true" style="${SR_ONLY_STYLE}">` +
     llmsDirective(mdUrl) +
@@ -332,14 +382,15 @@ function buildJsonLd(title: string, description: string, canonicalUrl: string): 
 // a Markdown alternate link, and JSON-LD; injects `bodyHtml` into the empty
 // `#root` so non-JS agents see real content (not a bare SPA shell); then returns
 // it with `status` (200 for known routes, 404 for unknown ones so crawlers don't
-// see soft 404s).
+// see soft 404s). `mdUrl` is null when no Markdown page exists for the route, in
+// which case no alternate is advertised in either the <head> or the Link header.
 async function injectHead(
   shell: Response,
   opts: {
     title: string;
     description: string;
     canonicalUrl: string;
-    mdUrl: string;
+    mdUrl: string | null;
     status: number;
     bodyHtml: string;
   }
@@ -357,7 +408,7 @@ async function injectHead(
 
   const extraHead =
     `<link rel="canonical" href="${escapeAttr(canonicalUrl)}" />` +
-    `<link rel="alternate" type="text/markdown" href="${escapeAttr(mdUrl)}" />` +
+    (mdUrl ? `<link rel="alternate" type="text/markdown" href="${escapeAttr(mdUrl)}" />` : "") +
     `<script type="application/ld+json">${buildJsonLd(title, description, canonicalUrl)}</script>`;
   html = html.replace(/<\/head>/i, `${extraHead}</head>`);
 
@@ -369,6 +420,12 @@ async function injectHead(
   headers.delete("content-length");
   headers.delete("content-encoding");
   headers.set("content-type", "text/html; charset=utf-8");
+  // Announce the Markdown alternate as a response header as well as in <head>, so
+  // an agent can discover it with a HEAD request instead of fetching and parsing
+  // the HTML.
+  if (mdUrl) {
+    headers.set("link", `<${mdUrl}>; rel="alternate"; type="text/markdown"`);
+  }
   // Merge "Accept" into any existing Vary (the shell may already vary on e.g.
   // Accept-Encoding) rather than clobbering it, to keep caching correct.
   const vary = headers.get("vary");
@@ -385,6 +442,18 @@ export default async (request: Request, context: Context) => {
   const { pathname } = url;
   const acceptHeader = request.headers.get("accept") || "";
   const isMarkdownRequested = acceptHeader.includes("text/markdown");
+  const lookupPath = normalizeLookupPath(pathname);
+
+  const legacyJavaRoute = LEGACY_JAVA_VERSION_ROUTE.exec(lookupPath);
+  if (legacyJavaRoute) {
+    const [, version, name] = legacyJavaRoute;
+    const params = new URLSearchParams(url.search);
+    params.set("version", version);
+    return new Response(null, {
+      status: 301,
+      headers: { Location: `/java-agent/instrumentation/${name}?${params}` },
+    });
+  }
 
   // Documentation root files
   if (pathname === "/llms.txt" || pathname === "/llms-full.txt") {
@@ -397,28 +466,30 @@ export default async (request: Request, context: Context) => {
   // Content negotiation for AI agents: prefer the page's own Markdown (generated
   // at the app-route path), falling back to the section index, then the docs root.
   if (isMarkdownRequested) {
-    const candidates: string[] = [];
-    if (pathname === "/" || pathname === "/index.html") {
-      candidates.push("/index.md", "/llms.txt");
-    } else {
-      candidates.push(`${pathname}.md`);
-      if (
-        pathname === "/java-agent" ||
-        pathname.startsWith("/java-agent/") ||
-        pathname === "/javaagent" ||
-        pathname.startsWith("/javaagent/")
-      ) {
-        candidates.push("/agent/javaagent/index.md");
-      } else if (pathname === "/collector" || pathname.startsWith("/collector/")) {
-        candidates.push("/agent/collector/index.md");
-      }
+    const ownMd = lookupPath === "/" ? "/index.md" : `${lookupPath}.md`;
+    const own = await serveAsset(context, ownMd, "text/markdown; charset=UTF-8", {
+      Vary: "Accept",
+    });
+    if (own) {
+      return own;
     }
 
-    for (const mdPath of candidates) {
-      const finalContentType = mdPath.endsWith(".md")
-        ? "text/markdown; charset=UTF-8"
-        : "text/plain; charset=UTF-8";
-      const response = await serveAsset(context, mdPath, finalContentType, { Vary: "Accept" });
+    if (lookupPath === "/") {
+      return (
+        (await serveAsset(context, "/llms.txt", "text/plain; charset=UTF-8", { Vary: "Accept" })) ??
+        notFound()
+      );
+    }
+
+    // Section-index fallback, but only for paths that are real routes. Serving the
+    // index for a fabricated path returned 200 with a 71 KB body, so an agent
+    // could not tell "your URL is wrong" from "here is your answer" and had no
+    // signal to retry with a corrected path.
+    const sectionIndex = sectionIndexFor(lookupPath);
+    if (sectionIndex && (await routeStatus(context, canonicalizeAlias(lookupPath))).known) {
+      const response = await serveAsset(context, sectionIndex, "text/markdown; charset=UTF-8", {
+        Vary: "Accept",
+      });
       if (response) {
         return response;
       }
@@ -464,9 +535,11 @@ export default async (request: Request, context: Context) => {
 
   // HTML page navigation. Inject per-route metadata so non-JS social scrapers
   // and crawlers get page-specific title/description/OG/canonical, and return a
-  // real 404 for unknown routes. Asset requests and non-GET methods pass through
-  // untouched so Netlify serves them (or the SPA shell) as before.
-  if (request.method !== "GET" || ASSET_EXT.test(pathname)) {
+  // real 404 for unknown routes. HEAD is handled alongside GET so the Link
+  // alternate header below is discoverable without downloading the page; asset
+  // requests and other methods pass through untouched so Netlify serves them (or
+  // the SPA shell) as before.
+  if ((request.method !== "GET" && request.method !== "HEAD") || ASSET_EXT.test(pathname)) {
     return undefined;
   }
 
@@ -477,40 +550,28 @@ export default async (request: Request, context: Context) => {
     return shell.status === 200 ? undefined : shell;
   }
 
-  // Normalize /index.html and trailing slashes to the canonical route key so
-  // those variants resolve against the manifest instead of falling to a 404.
-  const lookupPath =
-    pathname === "/index.html"
-      ? "/"
-      : pathname.length > 1 && pathname.endsWith("/")
-        ? pathname.replace(/\/+$/, "")
-        : pathname;
-
-  const routes = await loadRoutes(context);
-  const manifestLoaded = Object.keys(routes).length > 0;
-  const meta = routes[lookupPath];
-  // If the manifest failed to load, don't risk false 404s: treat every page as known.
-  const known = !manifestLoaded || Boolean(meta) || isDynamicKnownRoute(lookupPath);
+  const { meta, known } = await routeStatus(context, lookupPath);
 
   const title = meta?.title ?? (known ? DEFAULT_TITLE : `Page not found — ${DEFAULT_TITLE}`);
   const description = meta?.description ?? DEFAULT_DESCRIPTION;
   const canonicalUrl = `${SITE_ORIGIN}${lookupPath}`;
   // The homepage's Markdown is /index.md (the route's own generated page), not
   // /llms.txt. Keep mdPath (fetched + injected), mdUrl (advertised alternate +
-  // directive), and the Accept negotiation below all pointing at the same file.
+  // directive), and the Accept negotiation above all pointing at the same file.
   const mdPath = lookupPath === "/" ? "/index.md" : `${lookupPath}.md`;
-  const mdUrl = `${SITE_ORIGIN}${mdPath}`;
 
   // Body injected into #root so HTTP-only agents get real content instead of an
   // empty shell. Prefer the route's pre-generated Markdown; fall back to a
   // title/description stub for known routes without a Markdown page and for 404s.
-  let contentHtml: string;
-  if (!known) {
-    contentHtml = fallbackContent("Page not found", `The page ${lookupPath} could not be found.`);
-  } else {
-    const md = await fetchMarkdown(context, mdPath);
-    contentHtml = md ? markdownToHtml(md) : fallbackContent(title, description);
-  }
+  // The alternate is advertised only when that Markdown actually exists — a
+  // dangling alternate is a 404 the agent has to spend a request to discover.
+  const md = known ? await fetchMarkdown(context, mdPath) : null;
+  const mdUrl = md ? `${SITE_ORIGIN}${mdPath}` : null;
+  const contentHtml = md
+    ? markdownToHtml(md)
+    : known
+      ? fallbackContent(title, description)
+      : fallbackContent("Page not found", `The page ${lookupPath} could not be found.`);
 
   return injectHead(shell, {
     title,

--- a/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
+++ b/ecosystem-explorer/netlify/edge-functions/agent-negotiation.ts
@@ -71,15 +71,25 @@ interface RouteMeta {
 
 // Per-route SEO metadata generated at build time (dist/seo/routes.json), cached
 // across invocations within an edge isolate.
+const MANIFEST_PATH = "/seo/routes.json";
 let routesCache: Record<string, RouteMeta> | null = null;
 let routesLoaded = false;
 
-async function loadRoutes(context: Context): Promise<Record<string, RouteMeta>> {
+// The manifest is a build artifact — the same file for every request — so it is
+// fetched with an explicit GET instead of context.rewrite(), which inherits the
+// in-flight method. On a HEAD request the rewrite resolves with no body, json()
+// throws, and the empty manifest would make every fabricated path look known
+// (200 instead of 404). The rewrite is still used for GET: it stays inside the
+// CDN instead of taking a network hop back to the origin.
+async function loadRoutes(request: Request, context: Context): Promise<Record<string, RouteMeta>> {
   if (routesLoaded) {
     return routesCache ?? {};
   }
   try {
-    const response = await context.rewrite("/seo/routes.json");
+    const response =
+      request.method === "GET"
+        ? await context.rewrite(MANIFEST_PATH)
+        : await fetch(new URL(MANIFEST_PATH, request.url), { method: "GET" });
     if (response.status === 200) {
       routesCache = (await response.json()) as Record<string, RouteMeta>;
       // Only latch the cache on success; a transient failure (bad status,
@@ -128,8 +138,12 @@ interface RouteStatus {
 // Resolves a path against the build-time manifest plus the dynamic route
 // patterns. If the manifest failed to load, don't risk false 404s: treat every
 // page as known.
-async function routeStatus(context: Context, lookupPath: string): Promise<RouteStatus> {
-  const routes = await loadRoutes(context);
+async function routeStatus(
+  request: Request,
+  context: Context,
+  lookupPath: string
+): Promise<RouteStatus> {
+  const routes = await loadRoutes(request, context);
   const manifestLoaded = Object.keys(routes).length > 0;
   const meta = routes[lookupPath];
   return { meta, known: !manifestLoaded || Boolean(meta) || isDynamicKnownRoute(lookupPath) };
@@ -508,7 +522,10 @@ export default async (request: Request, context: Context) => {
     // could not tell "your URL is wrong" from "here is your answer" and had no
     // signal to retry with a corrected path.
     const sectionIndex = sectionIndexFor(lookupPath);
-    if (sectionIndex && (await routeStatus(context, canonicalizeAlias(lookupPath))).known) {
+    if (
+      sectionIndex &&
+      (await routeStatus(request, context, canonicalizeAlias(lookupPath))).known
+    ) {
       const response = await serveAsset(context, sectionIndex, "text/markdown; charset=UTF-8", {
         Vary: "Accept",
       });
@@ -573,7 +590,7 @@ export default async (request: Request, context: Context) => {
     return shell.status === 200 ? undefined : shell;
   }
 
-  const { meta, known } = await routeStatus(context, lookupPath);
+  const { meta, known } = await routeStatus(request, context, lookupPath);
 
   const title = meta?.title ?? (known ? DEFAULT_TITLE : `Page not found — ${DEFAULT_TITLE}`);
   const description = meta?.description ?? DEFAULT_DESCRIPTION;

--- a/ecosystem-explorer/package.json
+++ b/ecosystem-explorer/package.json
@@ -23,6 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:edge": "vitest run --config vitest.dist.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "screenshots:capture": "bun scripts/take-screenshots.mjs",
     "screenshots:diff": "bun scripts/diff-screenshots.mjs"

--- a/ecosystem-explorer/vitest.dist.config.ts
+++ b/ecosystem-explorer/vitest.dist.config.ts
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react-swc";
-import path from "path";
 
+// Tests that exercise build output in `dist/` rather than source. They run after
+// `bun run build` (see the "Run edge tests" step in .github/workflows/build-and-test.yml)
+// and are excluded from the default unit run, where dist/ does not exist yet.
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
   test: {
     globals: true,
-    environment: "jsdom",
-    setupFiles: "./src/test/setup.ts",
-    exclude: ["**/node_modules/**", "**/*.integration.test.{ts,tsx}", "**/*.dist.test.ts"],
+    environment: "node",
+    include: ["**/*.dist.test.ts"],
+    exclude: ["**/node_modules/**"],
   },
 });


### PR DESCRIPTION
some agent-delivery fixes in the Netlify edge function:                                                                                                                                               

- The Java `/java-agent/instrumentation/:version/:name` redirect only existed as a React <Navigate>, so HTTP-only clients got a 200 and a generic shell with no Location. It now issues a real 301 at the edge. 
- Fabricated paths under /collector/ and /java-agent/ returned 200 with the full section index, so an agent couldn't distinguish a wrong URL from an answer. The index fallback is now gated on the path being a real route; anything else 404s.                                                                                                                              
- The Markdown alternate is now advertised in a Link: response header as well as <head>, discoverable via HEAD, and only when the Markdown page actually exists.
- Added additional test coverage to catch a bunch of these issues                                                                                                                                                                                                                                                                                                                                                                                                                   

Related to #636.