### PR TITLE
Add latest alias for more efficient agent searching

### DIFF
--- a/docs/AGENT_READINESS.md
+++ b/docs/AGENT_READINESS.md
@@ -23,6 +23,20 @@ hashed to ensure consistency.
 - **Collector Components**: `/data/collector/components/{id}/{id}-{hash}.json`
 - **Java Agent Instrumentations**: `/data/javaagent/instrumentations/{id}/{id}-{hash}.json`
 
+### Stable `latest.json` alias
+
+The hashed URL above is immutable but unguessable: reaching one costs three requests
+(`versions-index.json` → the version manifest → the hashed file), and it changes on every rebuild.
+Each component directory therefore also carries a `latest.json` copy of its current-release file:
+
+- **Collector Components**: `/data/collector/components/{id}/latest.json`
+- **Java Agent Instrumentations**: `/data/javaagent/instrumentations/{id}/latest.json`
+
+An agent that knows only the component id reads it in one request. The alias is written into `dist`
+by `generate-agent-docs.mjs` — not into `public/data`, which is the committed content-addressed
+store owned by `explorer-db-builder`. Use the hashed URL when a response must be pinned to a
+specific build.
+
 ### JSON Schemas
 
 All structured metadata follows strict JSON schemas:
@@ -62,7 +76,8 @@ Agents are instructed via `llms.txt` to follow these patterns:
 
 - Use `/agent/collector/index.md` as the primary index for collector components.
 - Use `/agent/javaagent/index.md` as the primary index for javaagent instrumentations.
-- Navigate to specific component metadata using the versioned JSON URLs found in these indices.
+- Navigate to specific component metadata using the versioned JSON URLs found in these indices, or
+  construct `/data/{ecosystem}/{content-dir}/{id}/latest.json` directly from a component id.
 
 ### Per-page Markdown and content negotiation
 

--- a/ecosystem-explorer/scripts/generate-agent-docs.mjs
+++ b/ecosystem-explorer/scripts/generate-agent-docs.mjs
@@ -589,9 +589,8 @@ export async function writeLatestJsonAliases(publicPath, outDir = distDir) {
         await fs.copyFile(source, target);
         written += 1;
       } catch (e) {
-        console.warn(
-          `[WARN] Could not write latest.json alias for ${ecosystem}/${id}: ${e.message}`
-        );
+        const message = e instanceof Error ? e.message : String(e);
+        console.warn(`[WARN] Could not write latest.json alias for ${ecosystem}/${id}: ${message}`);
       }
     }
     console.log(` - Wrote ${written} ${ecosystem} latest.json aliases (${latest.latestVersion})`);

--- a/ecosystem-explorer/scripts/generate-agent-docs.mjs
+++ b/ecosystem-explorer/scripts/generate-agent-docs.mjs
@@ -49,7 +49,7 @@ async function buildCollectorIndex(components, publicPath) {
     componentHashes = manifest.components || {};
   }
 
-  let md = `> For the complete documentation index, see [llms.txt](/llms.txt)\n\n# Collector Components\n\n<!-- llms-txt-link: /llms.txt -->\n\nThis is an index of all OpenTelemetry Collector components.\nFor full configuration details, please refer to the raw JSON data.\n\n**JSON Schema**: [collector-component.schema.json](/schemas/collector-component.schema.json)\n\n## Components\n\n| Display Name | ID | Stability | JSON Data URL |\n| --- | --- | --- | --- |\n`;
+  let md = `> For the complete documentation index, see [llms.txt](/llms.txt)\n\n# Collector Components\n\n<!-- llms-txt-link: /llms.txt -->\n\nThis is an index of all OpenTelemetry Collector components.\nFor full configuration details, please refer to the raw JSON data.\n\n**JSON Schema**: [collector-component.schema.json](/schemas/collector-component.schema.json)\n\nThe JSON Data URLs below are content-addressed and change whenever a component changes. Every component also answers at the stable alias \`/data/collector/components/{id}/latest.json\`, which always serves the current release.\n\n## Components\n\n| Display Name | ID | Stability | JSON Data URL |\n| --- | --- | --- | --- |\n`;
 
   for (const comp of components) {
     const displayName = comp.display_name || comp.name || "Unknown";
@@ -86,7 +86,7 @@ function buildCollectorVersions(versions) {
  */
 async function buildJavaAgentIndex(versions, publicPath) {
   const latestVersion = versions.find((v) => v.is_latest)?.version;
-  let md = `> For the complete documentation index, see [llms.txt](/llms.txt)\n\n# Java Agent Instrumentations\n\n<!-- llms-txt-link: /llms.txt -->\n\nThis is an index of all OpenTelemetry Java Agent instrumentations.\nFor full configuration details, please refer to the raw JSON data.\n\n**JSON Schema**: [javaagent-instrumentation.schema.json](/schemas/javaagent-instrumentation.schema.json)\n\n## Components\n\n| Display Name | ID | JSON Data URL |\n| --- | --- | --- |\n`;
+  let md = `> For the complete documentation index, see [llms.txt](/llms.txt)\n\n# Java Agent Instrumentations\n\n<!-- llms-txt-link: /llms.txt -->\n\nThis is an index of all OpenTelemetry Java Agent instrumentations.\nFor full configuration details, please refer to the raw JSON data.\n\n**JSON Schema**: [javaagent-instrumentation.schema.json](/schemas/javaagent-instrumentation.schema.json)\n\nThe JSON Data URLs below are content-addressed and change whenever an instrumentation changes. Every instrumentation also answers at the stable alias \`/data/javaagent/instrumentations/{id}/latest.json\`, which always serves the current release.\n\n## Components\n\n| Display Name | ID | JSON Data URL |\n| --- | --- | --- |\n`;
 
   if (latestVersion) {
     const manifestRaw = await fs.readFile(
@@ -176,6 +176,11 @@ To help agents parse our JSON data, we provide the following JSON Schemas:
 ## Navigation Patterns
 
 Agents can fetch specific component data using the following URL patterns:
+
+- **Collector Components**: \`/data/collector/components/{id}/latest.json\`
+- **Java Agent Instrumentations**: \`/data/javaagent/instrumentations/{id}/latest.json\`
+
+\`latest.json\` always serves the current release, so \`{id}\` is the only thing you need to know. To pin a specific build instead, use the content-addressed sibling, which never changes once published:
 
 - **Collector Components**: \`/data/collector/components/{id}/{id}-{hash}.json\`
 - **Java Agent Instrumentations**: \`/data/javaagent/instrumentations/{id}/{id}-{hash}.json\`
@@ -292,7 +297,7 @@ function collectorMetricsTable(heading, metrics, attributeDefs) {
  * real, parseable content (name, stability, attributes) at a stable URL instead
  * of the client-rendered SPA shell.
  */
-export function buildCollectorComponentPage(component, jsonUrl) {
+export function buildCollectorComponentPage(component, jsonUrl, latestJsonUrl) {
   const label = component.display_name || component.name || component.id;
   const pageUrl = `/collector/components/${component.distribution}/${component.name}`;
   const lines = [
@@ -346,10 +351,15 @@ export function buildCollectorComponentPage(component, jsonUrl) {
     lines.push("");
   }
 
+  lines.push("## Data", "");
+  if (latestJsonUrl) {
+    // Stable alias for the current release. Constructible from the component name
+    // alone, so an agent does not have to walk versions-index -> version manifest
+    // to resolve the content hash.
+    lines.push(`- **JSON (latest)**: [${latestJsonUrl}](${latestJsonUrl})`);
+  }
   lines.push(
-    "## Data",
-    "",
-    `- **JSON**: [${jsonUrl}](${jsonUrl})`,
+    `- **JSON (pinned)**: [${jsonUrl}](${jsonUrl})`,
     `- **Explore**: [${pageUrl}](${pageUrl})`,
     ""
   );
@@ -359,7 +369,7 @@ export function buildCollectorComponentPage(component, jsonUrl) {
 /**
  * Builds a per-instrumentation Markdown page for a Java agent instrumentation.
  */
-export function buildJavaInstrumentationPage(instr, jsonUrl) {
+export function buildJavaInstrumentationPage(instr, jsonUrl, latestJsonUrl) {
   const label = instr.display_name || instr.name;
   const pageUrl = `/java-agent/instrumentation/${instr.name}`;
   const lines = [
@@ -465,10 +475,15 @@ export function buildJavaInstrumentationPage(instr, jsonUrl) {
     lines.push("");
   }
 
+  lines.push("## Data", "");
+  if (latestJsonUrl) {
+    // Stable alias for the current release. Constructible from the component name
+    // alone, so an agent does not have to walk versions-index -> version manifest
+    // to resolve the content hash.
+    lines.push(`- **JSON (latest)**: [${latestJsonUrl}](${latestJsonUrl})`);
+  }
   lines.push(
-    "## Data",
-    "",
-    `- **JSON**: [${jsonUrl}](${jsonUrl})`,
+    `- **JSON (pinned)**: [${jsonUrl}](${jsonUrl})`,
     `- **Explore**: [${pageUrl}](${pageUrl})`,
     ""
   );
@@ -493,6 +508,94 @@ ${description}
 - [All Java agent instrumentations](/agent/javaagent/index.md)
 - [Full documentation index](/llms.txt)
 `;
+}
+
+/**
+ * The content-addressed stores under `/data` (`{id}/{id}-{hash}.json`) have no
+ * URL an agent can construct from a component name: reaching one file costs a
+ * versions index, then a version manifest, then the hashed file, and the URL
+ * changes on every rebuild. These two entries describe the stores so the alias
+ * below can be emitted for both.
+ */
+const DATA_STORES = [
+  {
+    ecosystem: "collector",
+    contentDir: "components",
+    manifestSections: ["components"],
+  },
+  {
+    ecosystem: "javaagent",
+    contentDir: "instrumentations",
+    manifestSections: ["instrumentations", "custom_instrumentations"],
+  },
+];
+
+/** Stable alias URL for a component's latest-release JSON. */
+function latestJsonUrl(ecosystem, contentDir, id) {
+  return `/data/${ecosystem}/${contentDir}/${id}/latest.json`;
+}
+
+/**
+ * Reads a store's latest release version and its `{id: hash}` manifest.
+ * Returns `null` (with a warning) when no version is flagged latest.
+ */
+async function readLatestManifest(publicPath, { ecosystem, manifestSections }) {
+  const { versions } = JSON.parse(
+    await fs.readFile(path.join(publicPath, `data/${ecosystem}/versions-index.json`), "utf-8")
+  );
+  const latestVersion = versions.find((v) => v.is_latest)?.version;
+  if (!latestVersion) {
+    console.warn(`[WARN] No latest ${ecosystem} version; skipping latest.json aliases.`);
+    return null;
+  }
+
+  const manifest = JSON.parse(
+    await fs.readFile(
+      path.join(publicPath, `data/${ecosystem}/versions/${latestVersion}-index.json`),
+      "utf-8"
+    )
+  );
+  const hashes = Object.assign({}, ...manifestSections.map((section) => manifest[section] || {}));
+  return { latestVersion, hashes };
+}
+
+/**
+ * Copies every latest-release component JSON to `latest.json` beside its hashed
+ * sibling, giving each component one stable, guessable URL. A copy rather than a
+ * redirect so the read stays a single request; the hashed files remain for
+ * callers that want an immutable, pinned URL.
+ *
+ * Written into the build output only — `public/data` is the committed
+ * content-addressed store that the Python `explorer-db-builder` owns and
+ * garbage-collects.
+ *
+ * Exported for tests; `outDir` defaults to `dist`.
+ */
+export async function writeLatestJsonAliases(publicPath, outDir = distDir) {
+  for (const store of DATA_STORES) {
+    const latest = await readLatestManifest(publicPath, store);
+    if (!latest) continue;
+
+    const { ecosystem, contentDir } = store;
+    let written = 0;
+    for (const [id, hash] of Object.entries(latest.hashes)) {
+      const source = path.join(
+        publicPath,
+        `data/${ecosystem}/${contentDir}/${id}/${id}-${hash}.json`
+      );
+      const target = path.join(outDir, `data/${ecosystem}/${contentDir}/${id}/latest.json`);
+      try {
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.copyFile(source, target);
+        written += 1;
+      } catch (e) {
+        console.warn(
+          `[WARN] Could not write latest.json alias for ${ecosystem}/${id}: ${e.message}`
+        );
+      }
+    }
+    console.log(` - Wrote ${written} ${ecosystem} latest.json aliases (${latest.latestVersion})`);
+  }
 }
 
 /** Maps a route pathname to its Markdown file path in dist (\`/\` -> index.md). */
@@ -553,7 +656,11 @@ async function generateCollectorPages(publicPath) {
       await fs.mkdir(outDir, { recursive: true });
       await fs.writeFile(
         path.join(outDir, `${component.name}.md`),
-        buildCollectorComponentPage(component, jsonUrl)
+        buildCollectorComponentPage(
+          component,
+          jsonUrl,
+          latestJsonUrl("collector", "components", id)
+        )
       );
       pages.push({
         label: component.display_name || component.name,
@@ -603,7 +710,11 @@ async function generateJavaPages(publicPath) {
       const jsonUrl = `/data/javaagent/instrumentations/${name}/${name}-${hash}.json`;
       await fs.writeFile(
         path.join(outDir, `${name}.md`),
-        buildJavaInstrumentationPage(instr, jsonUrl)
+        buildJavaInstrumentationPage(
+          instr,
+          jsonUrl,
+          latestJsonUrl("javaagent", "instrumentations", name)
+        )
       );
       pages.push({
         label: instr.display_name || instr.name,
@@ -646,6 +757,7 @@ async function generateDocs() {
   console.log(` - Generated ${collectorPages.length} Collector component pages`);
   const javaPages = await generateJavaPages(publicDir);
   console.log(` - Generated ${javaPages.length} Java agent instrumentation pages`);
+  await writeLatestJsonAliases(publicDir);
 
   const llmsTxt = buildLlmsTxt(staticPages, collectorPages, javaPages);
 

--- a/ecosystem-explorer/scripts/generate-agent-docs.test.ts
+++ b/ecosystem-explorer/scripts/generate-agent-docs.test.ts
@@ -14,18 +14,26 @@
  * limitations under the License.
  */
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 // @ts-expect-error -- untyped build script, imported for its pure page builders.
 import {
   buildJavaInstrumentationPage,
   buildCollectorComponentPage,
+  writeLatestJsonAliases,
 } from "./generate-agent-docs.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const dataDir = resolve(__dirname, "../public/data");
+const publicDir = resolve(__dirname, "../public");
+const dataDir = resolve(publicDir, "data");
 const readJson = (p: string) => JSON.parse(readFileSync(p, "utf-8"));
+
+const latestVersion = (ecosystem: string): string => {
+  const { versions } = readJson(resolve(dataDir, ecosystem, "versions-index.json"));
+  return versions.find((v: { is_latest: boolean }) => v.is_latest).version;
+};
 
 describe("agent docs: Java telemetry rendering", () => {
   // Mirrors Apache Dubbo: two `when` groups whose metrics are mutually
@@ -165,11 +173,6 @@ describe("agent docs: Collector metric rendering", () => {
  * metrics at build time.
  */
 describe("agent docs: fidelity against the registry corpus", () => {
-  const latestVersion = (ecosystem: string): string => {
-    const { versions } = readJson(resolve(dataDir, ecosystem, "versions-index.json"));
-    return versions.find((v: { is_latest: boolean }) => v.is_latest).version;
-  };
-
   it("preserves every Java metric name, span kind, and `when` condition", () => {
     const version = latestVersion("javaagent");
     const manifest = readJson(resolve(dataDir, `javaagent/versions/${version}-index.json`));
@@ -213,5 +216,77 @@ describe("agent docs: fidelity against the registry corpus", () => {
       }
     }
     expect(missing).toEqual([]);
+  });
+});
+
+describe("agent docs: stable JSON alias", () => {
+  it("links the latest.json alias alongside the pinned hashed URL (Collector)", () => {
+    const md = buildCollectorComponentPage(
+      { id: "kafkareceiver", name: "kafkareceiver", distribution: "contrib" },
+      "/data/collector/components/kafkareceiver/kafkareceiver-abc123def456.json",
+      "/data/collector/components/kafkareceiver/latest.json"
+    );
+    expect(md).toContain(
+      "- **JSON (latest)**: [/data/collector/components/kafkareceiver/latest.json]"
+    );
+    expect(md).toContain(
+      "- **JSON (pinned)**: [/data/collector/components/kafkareceiver/kafkareceiver-abc123def456.json]"
+    );
+  });
+
+  it("links the latest.json alias alongside the pinned hashed URL (Java agent)", () => {
+    const md = buildJavaInstrumentationPage(
+      { name: "apache-dubbo-2.7" },
+      "/data/javaagent/instrumentations/apache-dubbo-2.7/apache-dubbo-2.7-abc123def456.json",
+      "/data/javaagent/instrumentations/apache-dubbo-2.7/latest.json"
+    );
+    expect(md).toContain(
+      "- **JSON (latest)**: [/data/javaagent/instrumentations/apache-dubbo-2.7/latest.json]"
+    );
+    expect(md).toContain(
+      "- **JSON (pinned)**: [/data/javaagent/instrumentations/apache-dubbo-2.7/"
+    );
+  });
+
+  it("omits the alias line when no alias is supplied", () => {
+    const md = buildCollectorComponentPage({ name: "x", distribution: "core" }, "/data/x.json");
+    expect(md).not.toContain("**JSON (latest)**");
+    expect(md).toContain("- **JSON (pinned)**: [/data/x.json](/data/x.json)");
+  });
+
+  // The alias is what makes a component readable in one request; if the copy
+  // silently produced nothing, only a manual `curl` against a deploy would notice.
+  it("writes a latest.json copy of every latest-release component", async () => {
+    const outDir = mkdtempSync(resolve(tmpdir(), "agent-docs-aliases-"));
+    try {
+      await writeLatestJsonAliases(publicDir, outDir);
+
+      for (const [ecosystem, contentDir, sections] of [
+        ["collector", "components", ["components"]],
+        ["javaagent", "instrumentations", ["instrumentations", "custom_instrumentations"]],
+      ] as const) {
+        const version = latestVersion(ecosystem);
+        const manifest = readJson(resolve(dataDir, `${ecosystem}/versions/${version}-index.json`));
+        const hashes: Record<string, string> = Object.assign(
+          {},
+          ...sections.map((section) => manifest[section] ?? {})
+        );
+        expect(Object.keys(hashes).length).toBeGreaterThan(0);
+
+        for (const [id, hash] of Object.entries(hashes)) {
+          const alias = readFileSync(
+            resolve(outDir, `data/${ecosystem}/${contentDir}/${id}/latest.json`),
+            "utf-8"
+          );
+          const pinned = readFileSync(
+            resolve(dataDir, `${ecosystem}/${contentDir}/${id}/${id}-${hash}.json`),
+            "utf-8"
+          );
+          expect(alias).toBe(pinned);
+        }
+      }
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   });
 });

--- a/ecosystem-explorer/src/lib/search/search-index.test.ts
+++ b/ecosystem-explorer/src/lib/search/search-index.test.ts
@@ -75,14 +75,14 @@ describe("search (orchestration)", () => {
     const javaAgentResults = await search("kafka");
     expect(javaAgentResults[0]).toMatchObject({
       title: "Kafka Client",
-      path: "/java-agent/instrumentation/1.2.3/kafka-client",
+      path: "/java-agent/instrumentation/kafka-client?version=1.2.3",
       type: "item",
       ecosystem: "java-agent",
       version: "1.2.3",
     });
 
     // The instrumentation path itself is searchable via its keywords.
-    const pathQuery = "/java-agent/instrumentation/1.2.3/kafka-client";
+    const pathQuery = "/java-agent/instrumentation/kafka-client?version=1.2.3";
     const pathResults = await search(pathQuery);
     expect(pathResults[0]).toMatchObject({ title: "Kafka Client", path: pathQuery, type: "item" });
 

--- a/ecosystem-explorer/src/lib/search/sources/java-agent.test.ts
+++ b/ecosystem-explorer/src/lib/search/sources/java-agent.test.ts
@@ -37,13 +37,13 @@ describe("toJavaAgentResult", () => {
     expect(result).toMatchObject({
       title: "Kafka Client",
       description: "Messaging instrumentation for Kafka",
-      path: "/java-agent/instrumentation/1.2.3/kafka-client",
+      path: "/java-agent/instrumentation/kafka-client?version=1.2.3",
       type: "item",
       ecosystem: "java-agent",
       version: "1.2.3",
     });
     // The full instrumentation path is indexed as a keyword so path queries match.
-    expect(result.keywords).toContain("/java-agent/instrumentation/1.2.3/kafka-client");
+    expect(result.keywords).toContain("/java-agent/instrumentation/kafka-client?version=1.2.3");
   });
 
   it("omits stability and surfaces no facet for agent-only instrumentations", () => {
@@ -92,7 +92,7 @@ describe("getInstrumentationSearchTerms via toJavaAgentResult", () => {
       "kafka-client",
       "Kafka Client",
       "Messaging instrumentation for Kafka",
-      "/java-agent/instrumentation/1.2.3/kafka-client",
+      "/java-agent/instrumentation/kafka-client?version=1.2.3",
     ]);
   });
 });

--- a/ecosystem-explorer/src/lib/search/sources/java-agent.ts
+++ b/ecosystem-explorer/src/lib/search/sources/java-agent.ts
@@ -48,7 +48,7 @@ export function toJavaAgentResult(
   version: string,
   resultType: SearchResult["type"] = "item"
 ): SearchResult {
-  // `/instrumentation/{version}/{name}` is a deprecated route whose redirect to
+  // `/java-agent/instrumentation/{version}/{name}` is a deprecated route whose redirect to
   // this shape lives in a React <Navigate>, so it only resolves for clients that
   // run JavaScript. Emit the canonical target directly, as the Collector source does.
   const path = `/java-agent/instrumentation/${entry.name}?version=${version}`;

--- a/ecosystem-explorer/src/lib/search/sources/java-agent.ts
+++ b/ecosystem-explorer/src/lib/search/sources/java-agent.ts
@@ -48,7 +48,10 @@ export function toJavaAgentResult(
   version: string,
   resultType: SearchResult["type"] = "item"
 ): SearchResult {
-  const path = `/java-agent/instrumentation/${version}/${entry.name}`;
+  // `/instrumentation/{version}/{name}` is a deprecated route whose redirect to
+  // this shape lives in a React <Navigate>, so it only resolves for clients that
+  // run JavaScript. Emit the canonical target directly, as the Collector source does.
+  const path = `/java-agent/instrumentation/${entry.name}?version=${version}`;
   return {
     title: entry.display_name ?? entry.name,
     description: entry.description ?? "OpenTelemetry Java Agent instrumentation",


### PR DESCRIPTION
Adds a latest.json alias beside each component's content-addressed JSON so an agent that knows only a component id can read it in one request instead of walking the versions index and version manifest to resolve a hash.

Also fixes in-site search, which pointed every Java Agent result at the deprecated `/javaagent/instrumentation/{version}/{name}` route whose redirect only runs in JavaScript.

Part of #636 