### PR TITLE
test(js-watcher): cover remaining package_parser branches

### DIFF
--- a/ecosystem-automation/js-instrumentation-watcher/tests/test_package_parser.py
+++ b/ecosystem-automation/js-instrumentation-watcher/tests/test_package_parser.py
@@ -249,3 +249,256 @@ def test_not_in_bundle_when_absent(tmp_package):
 
     assert result is not None
     assert result["in_auto_instrumentations_node"] is False
+
+
+def test_supported_versions_empty_when_readme_has_no_section(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    # A README with no "Supported Versions" heading at all - 39/47 packages
+    # in the May audit were prose-only like this.
+    (tmp_package / "README.md").write_text("# Express Instrumentation\n\nSome prose.\n")
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["supported_versions"] == []
+
+
+def test_supported_versions_empty_when_readme_unreadable(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    # A directory named README.md passes exists() but raises IsADirectoryError
+    # (an OSError) on read. The package must still parse rather than be dropped.
+    (tmp_package / "README.md").mkdir()
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["supported_versions"] == []
+
+
+def test_tav_entry_includes_exclude(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-aws-sdk",
+            "version": "0.77.0",
+            "description": "test",
+        },
+    )
+    tav = textwrap.dedent("""
+        "@aws-sdk/client-s3":
+          - versions:
+              include: "^3.6.1"
+              exclude: "3.529.0 || >=3.363.0 <=3.377.0"
+              mode: max-7
+            commands: npm test
+    """)
+    (tmp_package / ".tav.yml").write_text(tav)
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["tested_versions"][0]["exclude"] == "3.529.0 || >=3.363.0 <=3.377.0"
+    assert result["tested_versions"][0]["mode"] == "max-7"
+
+
+def test_tav_jobs_key_inside_list_entry(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-aws-sdk",
+            "version": "0.77.0",
+            "description": "test",
+        },
+    )
+    # Structure 2 nested in a list: the entry has no `versions` of its own,
+    # the ranges live under `jobs`.
+    tav = textwrap.dedent("""
+        "@aws-sdk/client-sqs":
+          - jobs:
+              - versions:
+                  include: "^3.24.0"
+                  mode: max-7
+                commands: npm test
+    """)
+    (tmp_package / ".tav.yml").write_text(tav)
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert len(result["tested_versions"]) == 1
+    assert result["tested_versions"][0]["package"] == "@aws-sdk/client-sqs"
+    assert result["tested_versions"][0]["range"] == "^3.24.0"
+    assert result["tested_versions"][0]["mode"] == "max-7"
+
+
+def test_tav_top_level_jobs_key(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-aws-sdk",
+            "version": "0.77.0",
+            "description": "test",
+        },
+    )
+    # Structure 2 as documented for aws-sdk: the package maps to a dict whose
+    # `jobs` list carries the version ranges. This is the shape behind the
+    # exclude/mode data already in the registry for aws-sdk and 6 other packages.
+    tav = textwrap.dedent("""
+        "@aws-sdk/client-bedrock-runtime":
+          jobs:
+            - versions:
+                include: "^3.587.0"
+                exclude: ">=3.363.0 <=3.377.0"
+                mode: max-7
+              commands: npm test
+            - versions:
+                include: "^3.600.0"
+                mode: latest-minors
+              commands: npm test
+    """)
+    (tmp_package / ".tav.yml").write_text(tav)
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert len(result["tested_versions"]) == 2
+    ranges = [entry["range"] for entry in result["tested_versions"]]
+    assert ranges == sorted(ranges)
+    assert result["tested_versions"][0]["exclude"] == ">=3.363.0 <=3.377.0"
+
+
+def test_tav_flat_versions_on_dict_config(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    # A dict config with no `jobs` - the versions hang directly off the mapping.
+    tav = textwrap.dedent("""
+        express:
+          versions:
+            include: ">=4.16.2 <6"
+            mode: latest-minors
+          commands: npm test
+    """)
+    (tmp_package / ".tav.yml").write_text(tav)
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert len(result["tested_versions"]) == 1
+    assert result["tested_versions"][0]["range"] == ">=4.16.2 <6"
+
+
+def test_tav_empty_when_yaml_is_malformed(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    (tmp_package / ".tav.yml").write_text("express:\n  - versions:\n   include: [unclosed\n")
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["tested_versions"] == []
+
+
+def test_tav_empty_when_unreadable(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    # Same OSError path as the README case above.
+    (tmp_package / ".tav.yml").mkdir()
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["tested_versions"] == []
+
+
+def test_tav_empty_when_yaml_is_not_a_mapping(tmp_package):
+    write_package_json(
+        tmp_package,
+        {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.66.0",
+            "description": "test",
+        },
+    )
+    (tmp_package / ".tav.yml").write_text("- express\n- mongoose\n")
+
+    parser = PackageParser(
+        package_path=tmp_package,
+        bundle_membership=set(),
+        component_owners={},
+    )
+    result = parser.parse()
+
+    assert result is not None
+    assert result["tested_versions"] == []


### PR DESCRIPTION
## What changed

I have added 9 tests to the existing ```test_package_parser.py```. ```package_parser.py``` already had tests but it still had 23 uncovered statements.

Most of it is the ```.tav.yml``` parsing. The main gap was "Structure 2", where a package maps to a dict with a jobs key instead of a list. That branch runs every night and had nothing on it, it's what produces the exclude and mode fields that are already in the registry for aws-sdk, ioredis, knex, mongodb, mysql2, redis and tedious. The exclude field wasn't covered either. The rest are the failure paths, malformed ```.tav.yml```, unreadable files, yaml that isn't a mapping, and READMEs with no Supported Versions section.

## Why

Part of #990 

I said in #1066 that was the last one for watcher coverage. I meant the three untested modules and those are done, but ```package_parser.py``` was still sitting at 76% so the watcher wasn't actually finished. This takes ```package_parser.py``` from 76% to 100% and the watcher from 89% to 98%.

## How it was tested

I ran `uv run pytest tests/ --cov=js_instrumentation_watcher --cov-report=term-missing` from ecosystem-automation/js-instrumentation-watcher

<img width="1858" height="1041" alt="Screenshot from 2026-09-11 17-18-40" src="https://github.com/user-attachments/assets/3e7c65ec-c863-4d61-afba-4a48523f5a9d" />

I also ran `uv run pytest ecosystem-automation -q` for the whole Python suite too...

## Is this a breaking change?

No

## Special notes for your reviewer

NA

## Checklist

- [x] Tests added or updated for new behavior
- [x] Screenshots attached for any UI changes
- [x] I wrote this PR description myself (AI tools must not check this box on behalf of the author)
