### PR TITLE
feat(python): add instrumentation watcher

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -193,6 +193,28 @@ jobs:
           cd ecosystem-automation/js-instrumentation-watcher
           uv run pytest tests/ --cov=js_instrumentation_watcher --cov-report=term-missing --cov-report=json
 
+  test-automation-python-instrumentation-watcher:
+    name: Test python-instrumentation-watcher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: ".python-version"
+      - name: Install dependencies
+        run: uv sync --locked --all-extras --dev
+      - name: Run python-instrumentation-watcher tests
+        run: |
+          cd ecosystem-automation/python-instrumentation-watcher
+          uv run pytest tests/ --cov=python_instrumentation_watcher --cov-report=term-missing --cov-report=json
+
   test-automation-explorer-db-builder:
     name: Test explorer-db-builder
     runs-on: ubuntu-latest

--- a/ecosystem-automation/AGENTS.md
+++ b/ecosystem-automation/AGENTS.md
@@ -7,6 +7,7 @@ Python pipelines that watch upstream OpenTelemetry projects and write versioned 
 - `java-instrumentation-watcher/` — Java agent instrumentations
 - `dotnet-instrumentation-watcher/` — .NET automatic instrumentation components
 - `js-instrumentation-watcher/` — JavaScript (js-contrib) instrumentations
+- `python-instrumentation-watcher/` — Python (python-contrib) instrumentations
 - `configuration-watcher/` — Declarative configuration schema
 - `explorer-db-builder/` — Builds the content-addressed database the frontend reads
 - `v1-registry-sync/` — Compares the collector registry against the upstream v1 registry
@@ -27,8 +28,8 @@ Run from the repository root:
 - `uv run ruff format ecosystem-automation/` — Format
 - `uv run collector-watcher` / `uv run java-instrumentation-watcher` /
   `uv run dotnet-instrumentation-watcher` / `uv run js-instrumentation-watcher` /
-  `uv run configuration-watcher` / `uv run explorer-db-builder` / `uv run v1-registry-sync` — Run a
-  watcher or tool
+  `uv run python-instrumentation-watcher` / `uv run configuration-watcher` /
+  `uv run explorer-db-builder` / `uv run v1-registry-sync` — Run a watcher or tool
 
 Nightly CI invokes the watchers directly via these console scripts. The `collector-watcher` and
 `configuration-watcher` also expose a `backfill` mode (`--backfill`) for re-extracting existing
@@ -46,9 +47,11 @@ non-negotiable rules:
   `SNAPSHOT` prerelease tag for nightly builds. The `{distribution}` segment applies only where an
   ecosystem ships multiple distributions: collector (`collector/{core,contrib}/v…`) and Java
   (`java/javaagent/v…`). Configuration (`configuration/v…`) and .NET (`dotnet/v…`) have no
-  distribution segment. JavaScript is the exception to the per-version-directory rule: js-contrib
-  packages version independently, so they are written per package as a single file —
-  `javascript/{package-name}/v{version}.yaml` — rather than an aggregated per-version directory.
+  distribution segment. JavaScript and Python are exceptions to the per-version-directory rule:
+  js-contrib and python-contrib packages version independently (Python via a hybrid
+  lockstep/independent model — see `projects/135-python-instrumentation/02-schema-design.md`), so
+  they are written per package as a single file — `javascript/{package-name}/v{version}.yaml` /
+  `python/{package-name}/v{version}.yaml` — rather than an aggregated per-version directory.
 
 ## Schema discipline
 

--- a/ecosystem-automation/python-instrumentation-watcher/README.md
+++ b/ecosystem-automation/python-instrumentation-watcher/README.md
@@ -1,0 +1,117 @@
+# Python Instrumentation Watcher
+
+Automation tool for synchronizing OpenTelemetry Python instrumentation metadata to the ecosystem
+registry.
+
+The metadata source is the contrib repository:
+<https://github.com/open-telemetry/opentelemetry-python-contrib>
+
+Background and design rationale for this watcher live in
+[`projects/135-python-instrumentation/`](../../projects/135-python-instrumentation/), specifically
+the [metadata audit](../../projects/135-python-instrumentation/01-metadata-audit.md) and the
+[registry schema design](../../projects/135-python-instrumentation/02-schema-design.md).
+
+## Methodology
+
+On a scheduled basis, the tool clones (or pulls) `opentelemetry-python-contrib`, discovers every
+instrumentation package under `instrumentation/`, and records per-package metadata snapshots in the
+registry.
+
+Process:
+
+- Clone or pull `opentelemetry-python-contrib` (override the checkout with the
+  `PYTHON_CONTRIB_REPO_PATH` env var; the clone target dir is configurable with
+  `PYTHON_CONTRIB_REPOS_DIR`, default `tmp_repos`).
+- Discover packages under `instrumentation/opentelemetry-instrumentation-*` that ship a
+  `pyproject.toml`. The separate `instrumentation-genai/` area is explicitly out of scope (tracked
+  instead by [#154](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/issues/154)).
+- For each package, parse `pyproject.toml` (authoritative) and `package.py` (cross-check only):
+  - `pyproject.toml`'s `[project]` table for name, description, `requires-python`, `urls.Homepage`.
+  - `pyproject.toml`'s `[project.optional-dependencies]` `instruments` / `instruments-any` keys for
+    instrumented library/version-range pairs (source key preserved per entry).
+  - `pyproject.toml`'s `[project.entry-points.opentelemetry_instrumentor]` for auto-instrumentation
+    entry points.
+  - The package's own version: read directly from `[project].version` if static, otherwise resolved
+    from the file named by `[tool.hatch.version].path` (reading `__version__`) when the version is
+    `dynamic`.
+  - `package.py`'s `_instruments`, `_supports_metrics`, and `_semconv_status`, parsed with
+    `ast.literal_eval` rather than executed (`package.py` is untrusted upstream code).
+- Compare `package.py`'s `_instruments` against `pyproject.toml`'s `instruments`/`instruments-any`;
+  log and report (but do not block on) any disagreement. `pyproject.toml` remains authoritative for
+  the `instruments` field written to the registry.
+- For each package, skip it if its current version is already tracked; otherwise write a versioned
+  YAML snapshot.
+
+Like the JS watcher — and unlike the Java agent, which has a single release version covering all
+instrumentations — Python packages are resolved and stored at their own, independent version. This
+also holds for packages that happen to release in lockstep with others; see schema design §6 for why
+no "release group" field is recorded.
+
+## Registry layout
+
+The watcher maintains a per-package, per-version inventory under `ecosystem-registry/python/`:
+
+```text
+python/
+└── {package-name}/                 # e.g. opentelemetry-instrumentation-flask
+    └── v{version}.yaml             # e.g. v0.48b0.yaml
+```
+
+### File format
+
+**Example**: `python/opentelemetry-instrumentation-example/v0.48b0.yaml`
+
+```yaml
+description: OpenTelemetry instrumentation for the Example framework
+entry_points:
+  - name: example
+    value: opentelemetry.instrumentation.example:ExampleInstrumentor
+homepage: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-example
+instruments:
+  - library: example
+    source_key: instruments
+    version_range: ">=1.0,<3.0"
+name: opentelemetry-instrumentation-example
+repository: open-telemetry/opentelemetry-python-contrib
+requires_python: ">=3.9"
+semantic_convention_status: null
+source_path: instrumentation/opentelemetry-instrumentation-example
+supports_metrics: null
+version: 0.48b0
+```
+
+Output is deterministic: keys are sorted and the `instruments` / `entry_points` arrays are sorted by
+a stable key so upstream reordering does not churn the registry. `version_range` preserves the raw
+specifier text from `pyproject.toml`, not a renormalized round-trip.
+
+## Usage
+
+From the repository root:
+
+```bash
+uv run python-instrumentation-watcher
+```
+
+## Development
+
+From the repository root:
+
+```bash
+# Install dependencies
+uv sync
+
+# Run tests
+uv run pytest ecosystem-automation/python-instrumentation-watcher/tests
+
+# Run tests with coverage
+uv run pytest ecosystem-automation/python-instrumentation-watcher/tests --cov=python_instrumentation_watcher
+
+# Run the module
+uv run python -m python_instrumentation_watcher
+```
+
+## Adding Dependencies
+
+```bash
+uv add --package python-instrumentation-watcher <package-name>
+```

--- a/ecosystem-automation/python-instrumentation-watcher/pyproject.toml
+++ b/ecosystem-automation/python-instrumentation-watcher/pyproject.toml
@@ -1,0 +1,42 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[project]
+name = "python-instrumentation-watcher"
+version = "0.1.0"
+description = "Automation tool for watching and collecting OpenTelemetry Python instrumentation metadata"
+requires-python = ">=3.11"
+dependencies = [
+    "PyYAML>=6.0.1",
+    "watcher-common",
+]
+
+[project.scripts]
+python-instrumentation-watcher = "python_instrumentation_watcher.main:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+watcher-common = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/python_instrumentation_watcher"]

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/__init__.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/__init__.py
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""OpenTelemetry Python instrumentation metadata automation."""
+
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("python-instrumentation-watcher")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/__main__.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/__main__.py
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Allow running python_instrumentation_watcher as a module with python -m python_instrumentation_watcher."""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/instrumentation_sync.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/instrumentation_sync.py
@@ -1,0 +1,129 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Synchronization orchestration for Python instrumentation metadata."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from .inventory_manager import InventoryManager
+from .package_parser import PackageParser
+from .package_scanner import PackageScanner
+
+logger = logging.getLogger(__name__)
+
+
+class InstrumentationSync:
+    """
+    Orchestrates synchronization of Python instrumentation metadata.
+
+    Walks the python-contrib repository, parses each instrumentation package,
+    and writes per-package versioned YAML to the registry.
+
+    Like the JS watcher (and unlike Java's single release version), Python
+    packages are resolved and stored at their own, independent version:
+        ecosystem-registry/python/{package}/v{version}.yaml
+    This is deliberate for Python's hybrid lockstep/independent release model —
+    see projects/135-python-instrumentation/02-schema-design.md §6.
+    """
+
+    def __init__(
+        self,
+        repo_path: Path,
+        inventory_manager: InventoryManager,
+    ):
+        """
+        Args:
+            repo_path: Path to the cloned opentelemetry-python-contrib repository
+            inventory_manager: Inventory manager for writing registry files
+        """
+        self.repo_path = repo_path
+        self.inventory_manager = inventory_manager
+        self.scanner = PackageScanner(repo_path)
+
+    def sync(self) -> dict[str, Any]:
+        """
+        Synchronize all Python instrumentation packages to the registry.
+
+        For each package:
+        - If the current version already exists in the registry, skip it
+        - Otherwise parse and write the metadata
+        - Separately, report (but do not block on) a pyproject.toml/package.py
+          `instruments` disagreement, per schema design §7 open decision #2
+
+        Returns:
+            Summary dict with counts of new, skipped, failed, and
+            metadata-disagreeing packages
+        """
+        summary: dict[str, Any] = {
+            "new": [],
+            "skipped": [],
+            "failed": [],
+            "disagreements": [],
+        }
+
+        packages = self.scanner.discover_packages()
+
+        for package_path in packages:
+            name = package_path.name
+            parser = PackageParser(package_path=package_path, repo_path=self.repo_path)
+
+            try:
+                data = parser.parse()
+            except Exception:
+                logger.exception("Failed to parse %s", name)
+                summary["failed"].append(name)
+                continue
+
+            if data is None:
+                logger.warning("No data parsed for %s — skipping", name)
+                summary["failed"].append(name)
+                continue
+
+            version = data.get("version", "")
+            if not version:
+                logger.warning("No version found for %s — skipping", name)
+                summary["failed"].append(name)
+                continue
+
+            package_id = f"{name}@{version}"
+
+            if parser.has_metadata_disagreement():
+                logger.warning(
+                    "pyproject.toml and package.py disagree on instruments for %s; "
+                    "using pyproject.toml (authoritative)",
+                    package_id,
+                )
+                summary["disagreements"].append(package_id)
+
+            if self.inventory_manager.version_exists(name, version):
+                logger.debug("Already tracked: %s", package_id)
+                summary["skipped"].append(package_id)
+                continue
+
+            self.inventory_manager.save(name, version, data)
+            logger.info("Saved: %s", package_id)
+            summary["new"].append(package_id)
+
+        logger.info(
+            "Sync complete — new: %d, skipped: %d, failed: %d, disagreements: %d",
+            len(summary["new"]),
+            len(summary["skipped"]),
+            len(summary["failed"]),
+            len(summary["disagreements"]),
+        )
+
+        return summary

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/inventory_manager.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/inventory_manager.py
@@ -1,0 +1,89 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Inventory manager for Python instrumentation registry storage."""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class InventoryManager:
+    """
+    Manages storage of Python instrumentation metadata in the registry.
+
+    Registry layout (per-package-version, like JavaScript's — see
+    projects/135-python-instrumentation/02-schema-design.md §3):
+        ecosystem-registry/python/{package-name}/v{version}.yaml
+    """
+
+    def __init__(self, registry_dir: str):
+        """
+        Args:
+            registry_dir: Base registry directory, e.g. 'ecosystem-registry/python'
+        """
+        self.registry_dir = Path(registry_dir)
+
+    def version_exists(self, package_name: str, version: str) -> bool:
+        """
+        Check if a specific package version already exists in the registry.
+
+        Args:
+            package_name: Package directory name, e.g. 'opentelemetry-instrumentation-flask'
+            version: Version string, e.g. '0.48b0'
+
+        Returns:
+            True if the version file exists
+        """
+        return self._version_path(package_name, version).exists()
+
+    def save(self, package_name: str, version: str, data: dict) -> None:
+        """
+        Save a package version to the registry.
+
+        Args:
+            package_name: Package directory name
+            version: Version string
+            data: Metadata dict to serialize as YAML
+        """
+        path = self._version_path(package_name, version)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with path.open("w") as f:
+            yaml.dump(
+                data,
+                f,
+                default_flow_style=False,
+                sort_keys=True,
+                allow_unicode=True,
+            )
+
+        logger.debug("Saved %s v%s to %s", package_name, version, path)
+
+    def _version_path(self, package_name: str, version: str) -> Path:
+        """
+        Build the path for a package version file.
+
+        Args:
+            package_name: Package directory name
+            version: Version string
+
+        Returns:
+            Path to the version YAML file
+        """
+        return self.registry_dir / package_name / f"v{version}.yaml"

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/main.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/main.py
@@ -1,0 +1,58 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Entry point for the Python instrumentation watcher."""
+
+import logging
+import os
+
+from .instrumentation_sync import InstrumentationSync
+from .inventory_manager import InventoryManager
+from .repository_manager import PythonContribRepositoryManager
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_DIR = "ecosystem-registry/python"
+
+
+def configure_logging() -> None:
+    """Configure root logging for the watcher."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+def main() -> None:
+    """Main entry point for the Python instrumentation watcher."""
+    configure_logging()
+
+    base_dir = os.environ.get("PYTHON_CONTRIB_REPOS_DIR", "tmp_repos")
+
+    logger.info("Starting Python instrumentation watcher...")
+
+    repo_manager = PythonContribRepositoryManager(base_dir=base_dir)
+    repo_path = repo_manager.setup()
+
+    inventory_manager = InventoryManager(registry_dir=REGISTRY_DIR)
+
+    sync = InstrumentationSync(
+        repo_path=repo_path,
+        inventory_manager=inventory_manager,
+    )
+
+    summary = sync.sync()
+
+    logger.info("Sync complete: %s", summary)

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_parser.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_parser.py
@@ -1,0 +1,360 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Parser for Python instrumentation package metadata.
+
+Reads pyproject.toml (authoritative) and package.py (cross-check only), per
+projects/135-python-instrumentation/02-schema-design.md §5. package.py is
+parsed with `ast.literal_eval` rather than executed, since it is untrusted
+upstream code.
+"""
+
+import ast
+import logging
+import re
+import tomllib
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPOSITORY = "open-telemetry/opentelemetry-python-contrib"
+
+# instrumentation-genai packages are explicitly out of scope; see package_scanner.py.
+INSTRUMENTS_SOURCE_KEYS = ("instruments", "instruments-any")
+
+# Matches a PEP 508-ish requirement string's leading distribution name (and an
+# optional extras marker), capturing the remainder verbatim so version_range is
+# stored as the raw specifier text rather than a renormalized round-trip
+# (projects/135-python-instrumentation/02-schema-design.md §4: "not renormalized").
+_REQUIREMENT_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[[^\]]*\])?\s*(.*)$")
+
+_PACKAGE_PY_FIELDS = {
+    "_instruments": "instruments",
+    "_supports_metrics": "supports_metrics",
+    "_semconv_status": "semantic_convention_status",
+}
+
+
+def _split_requirement(spec: str) -> tuple[str, str] | None:
+    """Split a requirement string into (library, raw version range).
+
+    Returns None if `spec` isn't a parseable requirement string.
+    """
+    if not isinstance(spec, str):
+        return None
+    match = _REQUIREMENT_RE.match(spec)
+    if not match:
+        return None
+    name = match.group(1)
+    # Drop an environment marker (e.g. `; python_version >= "3.9"`) rather than
+    # folding it into version_range — instrumentation optional-deps don't use
+    # markers in practice, but this keeps the field's meaning unambiguous if one
+    # ever appears.
+    version_range = match.group(2).split(";", 1)[0].strip()
+    return name, version_range
+
+
+def _normalize_for_comparison(library: str, version_range: str) -> tuple[str, str]:
+    """Normalize a (library, version_range) pair for disagreement comparison only.
+
+    Whitespace differences between pyproject.toml and package.py (e.g.
+    "flask >= 1.0" vs "flask>=1.0") describe the same requirement and must not
+    be reported as a disagreement; the raw text is still preserved verbatim in
+    the parsed output.
+    """
+    return library.strip().lower(), re.sub(r"\s+", "", version_range)
+
+
+class PackageParser:
+    """
+    Parses metadata from a single Python instrumentation package directory.
+
+    Reads pyproject.toml and package.py. Does not scrape README.md — the audit
+    (projects/135-python-instrumentation/01-metadata-audit.md) found individual
+    package READMEs add no metadata beyond the structured sources.
+    """
+
+    def __init__(self, package_path: Path, repo_path: Path):
+        """
+        Args:
+            package_path: Path to the instrumentation package directory
+            repo_path: Path to the cloned opentelemetry-python-contrib repository
+        """
+        self.package_path = package_path
+        self.repo_path = repo_path
+        self._package_py_instruments: list[str] | None = None
+        self._pyproject_instruments: list[tuple[str, str]] = []
+
+    def parse(self) -> dict | None:
+        """
+        Parse all available metadata for this package.
+
+        Returns:
+            Dict of metadata fields matching the python registry schema
+            (projects/135-python-instrumentation/02-schema-design.md §4), or
+            None if pyproject.toml is missing/invalid or has no package name.
+        """
+        pyproject_data = self._parse_pyproject_toml()
+        if pyproject_data is None:
+            return None
+
+        project = pyproject_data.get("project", {})
+        if not isinstance(project, dict):
+            logger.warning("pyproject.toml for %s has no [project] table", self.package_path.name)
+            return None
+
+        name = project.get("name", "")
+        if not name:
+            logger.warning("pyproject.toml for %s has no project name", self.package_path.name)
+            return None
+
+        version = self._resolve_version(pyproject_data)
+
+        optional_deps = project.get("optional-dependencies", {})
+        instruments = self._parse_instruments(optional_deps)
+        self._pyproject_instruments = [(e["library"], e["version_range"]) for e in instruments]
+
+        entry_points = self._parse_entry_points(project)
+
+        urls = project.get("urls", {})
+        homepage = self._extract_homepage(urls)
+
+        package_py_info = self._find_and_parse_package_py()
+        self._package_py_instruments = package_py_info["instruments"]
+
+        source_path = str(self.package_path.relative_to(self.repo_path))
+
+        return {
+            "name": name,
+            "version": version,
+            "description": project.get("description", ""),
+            "requires_python": project.get("requires-python", ""),
+            "repository": REPOSITORY,
+            "source_path": source_path,
+            "homepage": homepage,
+            "instruments": instruments,
+            "entry_points": entry_points,
+            "semantic_convention_status": package_py_info["semantic_convention_status"],
+            "supports_metrics": package_py_info["supports_metrics"],
+        }
+
+    def has_metadata_disagreement(self) -> bool:
+        """
+        Check whether package.py's `_instruments` disagrees with pyproject.toml's
+        `instruments`/`instruments-any`. Must be called after parse().
+
+        pyproject.toml is authoritative (schema design §5); this is a reporting-only
+        cross-check, not a source of registry data. Returns False if package.py
+        doesn't define `_instruments` at all — there's nothing to disagree with.
+
+        Returns:
+            True if the two sources describe different sets of instrumented
+            libraries/ranges.
+        """
+        if self._package_py_instruments is None:
+            return False
+
+        package_py_set = set()
+        for spec in self._package_py_instruments:
+            parsed = _split_requirement(spec)
+            if parsed is not None:
+                package_py_set.add(_normalize_for_comparison(*parsed))
+
+        pyproject_set = {_normalize_for_comparison(library, rng) for library, rng in self._pyproject_instruments}
+
+        return package_py_set != pyproject_set
+
+    def _parse_pyproject_toml(self) -> dict | None:
+        """Read and parse pyproject.toml."""
+        path = self.package_path / "pyproject.toml"
+        try:
+            with path.open("rb") as f:
+                return tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError) as e:
+            logger.warning("Failed to parse pyproject.toml for %s: %s", self.package_path.name, e)
+            return None
+
+    def _resolve_version(self, pyproject_data: dict) -> str:
+        """
+        Resolve the package's own version.
+
+        A static `[project].version` is used directly. A `dynamic = ["version"]`
+        declaration (the common case — see schema design §5) is resolved via
+        `[tool.hatch.version].path`, reading `__version__` from that file rather
+        than the string literally declared in pyproject.toml.
+        """
+        project = pyproject_data.get("project", {})
+        static_version = project.get("version")
+        if isinstance(static_version, str) and static_version:
+            return static_version
+
+        dynamic = project.get("dynamic", [])
+        if not isinstance(dynamic, list) or "version" not in dynamic:
+            return ""
+
+        version_path = pyproject_data.get("tool", {}).get("hatch", {}).get("version", {}).get("path")
+        if not isinstance(version_path, str) or not version_path:
+            logger.warning("No [tool.hatch.version].path for dynamic version in %s", self.package_path.name)
+            return ""
+
+        version_file = self.package_path / version_path
+        if not version_file.exists():
+            logger.warning("Version file %s not found for %s", version_path, self.package_path.name)
+            return ""
+
+        return self._read_dunder_version(version_file)
+
+    def _read_dunder_version(self, version_file: Path) -> str:
+        """Safely extract `__version__ = "..."` from a version file via ast, without executing it."""
+        try:
+            tree = ast.parse(version_file.read_text())
+        except (OSError, SyntaxError) as e:
+            logger.warning("Failed to parse version file %s: %s", version_file, e)
+            return ""
+
+        for node in ast.iter_child_nodes(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__version__":
+                    try:
+                        value = ast.literal_eval(node.value)
+                    except (ValueError, SyntaxError):
+                        logger.warning("Could not evaluate __version__ in %s", version_file)
+                        return ""
+                    return value if isinstance(value, str) else ""
+        return ""
+
+    def _parse_instruments(self, optional_deps: object) -> list[dict]:
+        """
+        Parse `instruments` / `instruments-any` from [project.optional-dependencies].
+
+        `source_key` is preserved per entry rather than collapsed — the audit
+        didn't establish the precise semantic difference between the two keys
+        (schema design §4).
+
+        Returns:
+            List of {library, version_range, source_key} dicts, sorted by
+            (source_key, library, version_range) for deterministic output.
+        """
+        if not isinstance(optional_deps, dict):
+            return []
+
+        results = []
+        for source_key in INSTRUMENTS_SOURCE_KEYS:
+            specs = optional_deps.get(source_key, [])
+            if not isinstance(specs, list):
+                continue
+            for spec in specs:
+                parsed = _split_requirement(spec)
+                if parsed is None:
+                    logger.warning(
+                        "Could not parse requirement %r (%s) for %s", spec, source_key, self.package_path.name
+                    )
+                    continue
+                library, version_range = parsed
+                results.append({"library": library, "version_range": version_range, "source_key": source_key})
+
+        return sorted(results, key=lambda e: (e["source_key"], e["library"], e["version_range"]))
+
+    def _parse_entry_points(self, project: dict) -> list[dict]:
+        """
+        Parse [project.entry-points.opentelemetry_instrumentor] entries.
+
+        Returns:
+            List of {name, value} dicts, sorted by name for deterministic output.
+        """
+        entry_points_table = project.get("entry-points", {})
+        if not isinstance(entry_points_table, dict):
+            return []
+
+        instrumentor_entries = entry_points_table.get("opentelemetry_instrumentor", {})
+        if not isinstance(instrumentor_entries, dict):
+            return []
+
+        return sorted(
+            ({"name": name, "value": value} for name, value in instrumentor_entries.items() if isinstance(value, str)),
+            key=lambda e: e["name"],
+        )
+
+    def _extract_homepage(self, urls: object) -> str | None:
+        """Best-effort homepage URL from [project.urls], case-insensitive key match."""
+        if not isinstance(urls, dict):
+            return None
+        for key, value in urls.items():
+            if isinstance(key, str) and key.lower() == "homepage" and isinstance(value, str):
+                return value
+        return None
+
+    def _find_and_parse_package_py(self) -> dict:
+        """
+        Locate and parse this package's package.py.
+
+        package.py's location varies with the instrumented module's dotted path
+        (e.g. src/opentelemetry/instrumentation/aws_lambda/package.py), so it is
+        discovered by searching rather than assumed from the directory name.
+
+        Returns:
+            Dict with 'instruments' (list[str] | None), 'semantic_convention_status'
+            (str | None), and 'supports_metrics' (bool | None). All None if no
+            package.py was found.
+        """
+        candidates = sorted(
+            p for p in self.package_path.rglob("package.py") if "tests" not in p.parts and "test" not in p.parts
+        )
+        if not candidates:
+            return {"instruments": None, "semantic_convention_status": None, "supports_metrics": None}
+
+        if len(candidates) > 1:
+            logger.warning(
+                "Multiple package.py files found for %s; using %s",
+                self.package_path.name,
+                candidates[0],
+            )
+
+        return self._parse_package_py(candidates[0])
+
+    def _parse_package_py(self, path: Path) -> dict:
+        """
+        Safely extract `_instruments`, `_supports_metrics`, and `_semconv_status`
+        from a package.py file via `ast.literal_eval`. The file is never executed.
+        """
+        result: dict = {"instruments": None, "semantic_convention_status": None, "supports_metrics": None}
+
+        try:
+            tree = ast.parse(path.read_text())
+        except (OSError, SyntaxError) as e:
+            logger.warning("Failed to parse %s: %s", path, e)
+            return result
+
+        for node in ast.iter_child_nodes(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not (isinstance(target, ast.Name) and target.id in _PACKAGE_PY_FIELDS):
+                    continue
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, SyntaxError):
+                    logger.warning("Could not evaluate %s in %s", target.id, path)
+                    continue
+
+                field = _PACKAGE_PY_FIELDS[target.id]
+                if field == "instruments" and isinstance(value, (list, tuple)):
+                    result[field] = list(value)
+                elif field != "instruments":
+                    result[field] = value
+
+        return result

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_parser.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_parser.py
@@ -40,10 +40,31 @@ INSTRUMENTS_SOURCE_KEYS = ("instruments", "instruments-any")
 # (projects/135-python-instrumentation/02-schema-design.md §4: "not renormalized").
 _REQUIREMENT_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[[^\]]*\])?\s*(.*)$")
 
-_PACKAGE_PY_FIELDS = {
+# Maps package.py's instrument-list attribute names to the pyproject.toml
+# optional-dependencies key each one is expected to mirror. package.py may define
+# either, both, or neither — `_instruments` alone is not a complete mirror of
+# pyproject.toml when a package also declares `instruments-any` (see
+# has_metadata_disagreement).
+_PACKAGE_PY_INSTRUMENT_FIELDS = {
     "_instruments": "instruments",
+    "_instruments_any": "instruments-any",
+}
+
+_PACKAGE_PY_SCALAR_FIELDS = {
     "_supports_metrics": "supports_metrics",
     "_semconv_status": "semantic_convention_status",
+}
+
+# Upstream package.py sometimes spells an empty instruments list as a zero-arg
+# constructor call (e.g. `_instruments: tuple[str, ...] = tuple()`) rather than a
+# literal `()`. `ast.literal_eval` can't evaluate a Call node, so this is handled
+# as a narrow, explicit allowlist — never general call execution.
+_EMPTY_CONTAINER_CALLS: dict[str, type] = {
+    "tuple": tuple,
+    "list": list,
+    "dict": dict,
+    "set": set,
+    "frozenset": frozenset,
 }
 
 
@@ -77,6 +98,48 @@ def _normalize_for_comparison(library: str, version_range: str) -> tuple[str, st
     return library.strip().lower(), re.sub(r"\s+", "", version_range)
 
 
+def _safe_eval_container(node: ast.AST) -> object:
+    """Evaluate a literal, or a recognized zero-arg empty-container call, from an ast node.
+
+    Supports everything `ast.literal_eval` does, plus the narrow additional case of a
+    bare `tuple()` / `list()` / `dict()` / `set()` / `frozenset()` call with no
+    arguments — a valid, observed upstream spelling of an empty instruments list that
+    `ast.literal_eval` alone rejects (it only accepts literal nodes, not calls). The
+    call is recognized structurally by name and never invoked or otherwise executed.
+
+    Raises ValueError or SyntaxError if `node` is neither form.
+    """
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, SyntaxError):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _EMPTY_CONTAINER_CALLS
+            and not node.args
+            and not node.keywords
+        ):
+            return _EMPTY_CONTAINER_CALLS[node.func.id]()
+        raise
+
+
+def _iter_field_assignments(tree: ast.Module):
+    """Yield (name, value_node) for each top-level `Assign`/`AnnAssign` in `tree`.
+
+    Covers both `_instruments = (...)` and the annotated form
+    `_instruments: tuple[str, ...] = (...)` observed in current upstream package.py
+    files — visiting only `ast.Assign` misses the latter and silently leaves the
+    field unset.
+    """
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    yield target.id, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None and isinstance(node.target, ast.Name):
+            yield node.target.id, node.value
+
+
 class PackageParser:
     """
     Parses metadata from a single Python instrumentation package directory.
@@ -94,8 +157,10 @@ class PackageParser:
         """
         self.package_path = package_path
         self.repo_path = repo_path
-        self._package_py_instruments: list[str] | None = None
-        self._pyproject_instruments: list[tuple[str, str]] = []
+        # Both keyed by pyproject.toml's source_key ("instruments" / "instruments-any"),
+        # populated by parse(). See has_metadata_disagreement().
+        self._package_py_instruments: dict[str, list[str] | None] = dict.fromkeys(INSTRUMENTS_SOURCE_KEYS)
+        self._pyproject_instruments_by_key: dict[str, list[tuple[str, str]]] = {}
 
     def parse(self) -> dict | None:
         """
@@ -124,7 +189,11 @@ class PackageParser:
 
         optional_deps = project.get("optional-dependencies", {})
         instruments = self._parse_instruments(optional_deps)
-        self._pyproject_instruments = [(e["library"], e["version_range"]) for e in instruments]
+        self._pyproject_instruments_by_key = {}
+        for entry in instruments:
+            self._pyproject_instruments_by_key.setdefault(entry["source_key"], []).append(
+                (entry["library"], entry["version_range"])
+            )
 
         entry_points = self._parse_entry_points(project)
 
@@ -152,29 +221,48 @@ class PackageParser:
 
     def has_metadata_disagreement(self) -> bool:
         """
-        Check whether package.py's `_instruments` disagrees with pyproject.toml's
-        `instruments`/`instruments-any`. Must be called after parse().
+        Check whether package.py's `_instruments`/`_instruments_any` disagree with
+        pyproject.toml's `instruments`/`instruments-any`. Must be called after parse().
 
         pyproject.toml is authoritative (schema design §5); this is a reporting-only
-        cross-check, not a source of registry data. Returns False if package.py
-        doesn't define `_instruments` at all — there's nothing to disagree with.
+        cross-check, not a source of registry data. `_instruments` alone is not
+        assumed to be a complete mirror of pyproject.toml: each package.py field is
+        compared only against its own matching pyproject.toml key
+        (`_instruments` <-> `instruments`, `_instruments_any` <-> `instruments-any`),
+        never against the combined set. A package.py field that isn't defined at all
+        contributes nothing to the comparison — that's a genuinely incomplete/
+        unavailable source, not a value to compare against pyproject.toml as if it
+        were an intentional empty list. Returns False if package.py defines neither
+        field — there's nothing to disagree with.
 
         Returns:
-            True if the two sources describe different sets of instrumented
-            libraries/ranges.
+            True if, for some key, the two sources describe different sets of
+            instrumented libraries/ranges.
         """
-        if self._package_py_instruments is None:
+        if all(specs is None for specs in self._package_py_instruments.values()):
             return False
 
-        package_py_set = set()
-        for spec in self._package_py_instruments:
-            parsed = _split_requirement(spec)
-            if parsed is not None:
-                package_py_set.add(_normalize_for_comparison(*parsed))
+        for source_key, specs in self._package_py_instruments.items():
+            if specs is None:
+                # package.py doesn't define this field at all — nothing to compare it
+                # against, so it must not be silently folded into another key's set.
+                continue
 
-        pyproject_set = {_normalize_for_comparison(library, rng) for library, rng in self._pyproject_instruments}
+            package_py_set = set()
+            for spec in specs:
+                parsed = _split_requirement(spec)
+                if parsed is not None:
+                    package_py_set.add(_normalize_for_comparison(*parsed))
 
-        return package_py_set != pyproject_set
+            pyproject_set = {
+                _normalize_for_comparison(library, rng)
+                for library, rng in self._pyproject_instruments_by_key.get(source_key, [])
+            }
+
+            if package_py_set != pyproject_set:
+                return True
+
+        return False
 
     def _parse_pyproject_toml(self) -> dict | None:
         """Read and parse pyproject.toml."""
@@ -307,15 +395,15 @@ class PackageParser:
         discovered by searching rather than assumed from the directory name.
 
         Returns:
-            Dict with 'instruments' (list[str] | None), 'semantic_convention_status'
-            (str | None), and 'supports_metrics' (bool | None). All None if no
-            package.py was found.
+            Dict with 'instruments' (dict mapping each of INSTRUMENTS_SOURCE_KEYS to
+            list[str] | None), 'semantic_convention_status' (str | None), and
+            'supports_metrics' (bool | None). All None if no package.py was found.
         """
         candidates = sorted(
             p for p in self.package_path.rglob("package.py") if "tests" not in p.parts and "test" not in p.parts
         )
         if not candidates:
-            return {"instruments": None, "semantic_convention_status": None, "supports_metrics": None}
+            return self._empty_package_py_result()
 
         if len(candidates) > 1:
             logger.warning(
@@ -326,12 +414,21 @@ class PackageParser:
 
         return self._parse_package_py(candidates[0])
 
+    def _empty_package_py_result(self) -> dict:
+        return {
+            "instruments": dict.fromkeys(INSTRUMENTS_SOURCE_KEYS),
+            "semantic_convention_status": None,
+            "supports_metrics": None,
+        }
+
     def _parse_package_py(self, path: Path) -> dict:
         """
-        Safely extract `_instruments`, `_supports_metrics`, and `_semconv_status`
-        from a package.py file via `ast.literal_eval`. The file is never executed.
+        Safely extract `_instruments`, `_instruments_any`, `_supports_metrics`, and
+        `_semconv_status` from a package.py file via `ast.literal_eval` (plus the
+        narrow empty-container-call allowlist in `_safe_eval_container`). The file is
+        never executed. Handles both plain and annotated assignments.
         """
-        result: dict = {"instruments": None, "semantic_convention_status": None, "supports_metrics": None}
+        result = self._empty_package_py_result()
 
         try:
             tree = ast.parse(path.read_text())
@@ -339,22 +436,22 @@ class PackageParser:
             logger.warning("Failed to parse %s: %s", path, e)
             return result
 
-        for node in ast.iter_child_nodes(tree):
-            if not isinstance(node, ast.Assign):
-                continue
-            for target in node.targets:
-                if not (isinstance(target, ast.Name) and target.id in _PACKAGE_PY_FIELDS):
-                    continue
+        for name, value_node in _iter_field_assignments(tree):
+            if name in _PACKAGE_PY_INSTRUMENT_FIELDS:
+                source_key = _PACKAGE_PY_INSTRUMENT_FIELDS[name]
                 try:
-                    value = ast.literal_eval(node.value)
+                    value = _safe_eval_container(value_node)
                 except (ValueError, SyntaxError):
-                    logger.warning("Could not evaluate %s in %s", target.id, path)
+                    logger.warning("Could not evaluate %s in %s", name, path)
                     continue
-
-                field = _PACKAGE_PY_FIELDS[target.id]
-                if field == "instruments" and isinstance(value, (list, tuple)):
-                    result[field] = list(value)
-                elif field != "instruments":
-                    result[field] = value
+                if isinstance(value, (list, tuple)):
+                    result["instruments"][source_key] = list(value)
+            elif name in _PACKAGE_PY_SCALAR_FIELDS:
+                try:
+                    value = ast.literal_eval(value_node)
+                except (ValueError, SyntaxError):
+                    logger.warning("Could not evaluate %s in %s", name, path)
+                    continue
+                result[_PACKAGE_PY_SCALAR_FIELDS[name]] = value
 
         return result

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_scanner.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/package_scanner.py
@@ -1,0 +1,69 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Scanner for Python instrumentation packages in the python-contrib repository."""
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+INSTRUMENTATION_DIR = "instrumentation"
+PACKAGE_PREFIX = "opentelemetry-instrumentation-"
+
+
+class PackageScanner:
+    """
+    Scans the python-contrib repository for instrumentation packages.
+
+    Discovers all instrumentation/opentelemetry-instrumentation-* directories.
+    Deliberately scans only `instrumentation/`, not `instrumentation-genai/` —
+    the GenAI instrumentation area is a separate ecosystem effort (see
+    projects/135-python-instrumentation/01-metadata-audit.md, "Boundary Note").
+    """
+
+    def __init__(self, repo_path: Path):
+        """
+        Args:
+            repo_path: Path to the cloned opentelemetry-python-contrib repository
+        """
+        self.repo_path = repo_path
+
+    def discover_packages(self) -> list[Path]:
+        """
+        Discover all instrumentation package directories.
+
+        Returns:
+            Sorted list of paths to instrumentation package directories
+            that have a pyproject.toml
+        """
+        instrumentation_dir = self.repo_path / INSTRUMENTATION_DIR
+        if not instrumentation_dir.exists():
+            logger.warning("instrumentation/ directory not found at %s", instrumentation_dir)
+            return []
+
+        found = []
+        for item in sorted(instrumentation_dir.iterdir()):
+            if not item.is_dir():
+                continue
+            if not item.name.startswith(PACKAGE_PREFIX):
+                continue
+            if not (item / "pyproject.toml").exists():
+                logger.debug("Skipping %s — no pyproject.toml", item.name)
+                continue
+            found.append(item)
+
+        logger.info("Found %d instrumentation packages", len(found))
+        return found

--- a/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/repository_manager.py
+++ b/ecosystem-automation/python-instrumentation-watcher/src/python_instrumentation_watcher/repository_manager.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Repository manager for opentelemetry-python-contrib."""
+
+import logging
+from pathlib import Path
+
+from watcher_common.repository_manager import BaseRepositoryManager
+
+logger = logging.getLogger(__name__)
+
+REPO_URL = "https://github.com/open-telemetry/opentelemetry-python-contrib.git"
+REPO_ENV_VAR = "PYTHON_CONTRIB_REPO_PATH"
+REPO_NAME = "opentelemetry-python-contrib"
+
+
+class PythonContribRepositoryManager(BaseRepositoryManager):
+    """Manages the opentelemetry-python-contrib repository."""
+
+    def setup(self) -> Path:
+        """
+        Set up the python-contrib repository — clone if not present, pull if it is.
+
+        Checks PYTHON_CONTRIB_REPO_PATH env var first, then falls back to
+        cloning into tmp_repos/opentelemetry-python-contrib.
+
+        Returns:
+            Path to the repository root
+        """
+        existing = self._get_repository_path(REPO_ENV_VAR)
+        if existing:
+            return existing
+
+        repo_path = self.base_dir / REPO_NAME
+
+        if repo_path.exists():
+            logger.info("Pulling latest changes for python-contrib...")
+            self._pull_latest(repo_path)
+        else:
+            logger.info("Cloning opentelemetry-python-contrib...")
+            self._clone_repository(REPO_URL, repo_path)
+
+        return repo_path

--- a/ecosystem-automation/python-instrumentation-watcher/tests/__init__.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_instrumentation_sync.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_instrumentation_sync.py
@@ -1,0 +1,251 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for InstrumentationSync."""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from python_instrumentation_watcher.instrumentation_sync import InstrumentationSync
+
+REPO_PATH = Path("/repos/opentelemetry-python-contrib")
+
+
+def package(name):
+    return REPO_PATH / "instrumentation" / name
+
+
+@pytest.fixture
+def inventory():
+    manager = MagicMock()
+    manager.version_exists.return_value = False
+    return manager
+
+
+@pytest.fixture
+def collaborators():
+    """Patch the scanner and parser that InstrumentationSync builds internally."""
+    with (
+        patch("python_instrumentation_watcher.instrumentation_sync.PackageScanner") as scanner_cls,
+        patch("python_instrumentation_watcher.instrumentation_sync.PackageParser") as parser_cls,
+    ):
+        scanner = scanner_cls.return_value
+        scanner.discover_packages.return_value = []
+        parser_cls.return_value.has_metadata_disagreement.return_value = False
+        yield scanner_cls, scanner, parser_cls
+
+
+def test_scanner_is_built_with_the_repo_path(collaborators, inventory):
+    scanner_cls, _, _ = collaborators
+
+    InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory)
+
+    scanner_cls.assert_called_once_with(REPO_PATH)
+
+
+def test_sync_returns_empty_summary_when_no_packages_found(collaborators, inventory):
+    sync = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory)
+
+    assert sync.sync() == {"new": [], "skipped": [], "failed": [], "disagreements": []}
+
+
+def test_sync_saves_a_package_that_is_not_yet_tracked(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-flask")]
+    data = {"name": "opentelemetry-instrumentation-flask", "version": "0.48b0"}
+    parser_cls.return_value.parse.return_value = data
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.save.assert_called_once_with("opentelemetry-instrumentation-flask", "0.48b0", data)
+    assert summary["new"] == ["opentelemetry-instrumentation-flask@0.48b0"]
+    assert summary["skipped"] == []
+    assert summary["failed"] == []
+
+
+def test_sync_builds_parser_with_package_and_repo_path(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    pkg_path = package("opentelemetry-instrumentation-flask")
+    scanner.discover_packages.return_value = [pkg_path]
+    parser_cls.return_value.parse.return_value = {"version": "0.48b0"}
+
+    InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    parser_cls.assert_called_once_with(package_path=pkg_path, repo_path=REPO_PATH)
+
+
+def test_sync_checks_the_registry_with_the_package_name_and_version(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-kafka")]
+    parser_cls.return_value.parse.return_value = {"version": "0.30.0"}
+
+    InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.version_exists.assert_called_once_with("opentelemetry-instrumentation-kafka", "0.30.0")
+
+
+def test_sync_skips_a_package_already_in_the_registry(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-pg")]
+    parser_cls.return_value.parse.return_value = {"version": "0.60.0"}
+    inventory.version_exists.return_value = True
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.save.assert_not_called()
+    assert summary["skipped"] == ["opentelemetry-instrumentation-pg@0.60.0"]
+    assert summary["new"] == []
+
+
+def test_sync_records_a_failure_when_the_parser_raises(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-broken")]
+    parser_cls.return_value.parse.side_effect = ValueError("malformed pyproject.toml")
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.save.assert_not_called()
+    assert summary["failed"] == ["opentelemetry-instrumentation-broken"]
+
+
+def test_sync_records_a_failure_when_the_parser_returns_none(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-empty")]
+    parser_cls.return_value.parse.return_value = None
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.save.assert_not_called()
+    assert summary["failed"] == ["opentelemetry-instrumentation-empty"]
+
+
+def test_sync_records_a_failure_when_the_version_key_is_absent(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-noversion")]
+    parser_cls.return_value.parse.return_value = {"name": "opentelemetry-instrumentation-noversion"}
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.version_exists.assert_not_called()
+    inventory.save.assert_not_called()
+    assert summary["failed"] == ["opentelemetry-instrumentation-noversion"]
+
+
+def test_sync_records_a_failure_when_the_version_is_empty(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-blankversion")]
+    parser_cls.return_value.parse.return_value = {"version": ""}
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    inventory.save.assert_not_called()
+    assert summary["failed"] == ["opentelemetry-instrumentation-blankversion"]
+
+
+def test_sync_keeps_going_after_one_package_raises(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [
+        package("opentelemetry-instrumentation-broken"),
+        package("opentelemetry-instrumentation-fine"),
+    ]
+    parser_cls.return_value.parse.side_effect = [
+        RuntimeError("boom"),
+        {"version": "0.40.0"},
+    ]
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    assert summary["failed"] == ["opentelemetry-instrumentation-broken"]
+    assert summary["new"] == ["opentelemetry-instrumentation-fine@0.40.0"]
+    inventory.save.assert_called_once_with("opentelemetry-instrumentation-fine", "0.40.0", {"version": "0.40.0"})
+
+
+def test_sync_handles_a_mix_of_new_skipped_and_failed(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [
+        package("opentelemetry-instrumentation-new"),
+        package("opentelemetry-instrumentation-existing"),
+        package("opentelemetry-instrumentation-broken"),
+    ]
+    parser_cls.return_value.parse.side_effect = [
+        {"version": "1.0.0"},
+        {"version": "2.0.0"},
+        None,
+    ]
+    inventory.version_exists.side_effect = [False, True]
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    assert summary["new"] == ["opentelemetry-instrumentation-new@1.0.0"]
+    assert summary["skipped"] == ["opentelemetry-instrumentation-existing@2.0.0"]
+    assert summary["failed"] == ["opentelemetry-instrumentation-broken"]
+
+
+def test_sync_records_a_metadata_disagreement_without_blocking_the_save(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-flask")]
+    parser_cls.return_value.parse.return_value = {"version": "0.48b0"}
+    parser_cls.return_value.has_metadata_disagreement.return_value = True
+
+    summary = InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    assert summary["disagreements"] == ["opentelemetry-instrumentation-flask@0.48b0"]
+    assert summary["new"] == ["opentelemetry-instrumentation-flask@0.48b0"]
+    inventory.save.assert_called_once()
+
+
+def test_sync_does_not_check_disagreement_when_parse_fails(collaborators, inventory):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-broken")]
+    parser_cls.return_value.parse.return_value = None
+
+    InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    parser_cls.return_value.has_metadata_disagreement.assert_not_called()
+
+
+def test_sync_logs_the_summary_counts(collaborators, inventory, caplog):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [
+        package("opentelemetry-instrumentation-new"),
+        package("opentelemetry-instrumentation-existing"),
+        package("opentelemetry-instrumentation-broken"),
+    ]
+    parser_cls.return_value.parse.side_effect = [
+        {"version": "1.0.0"},
+        {"version": "2.0.0"},
+        None,
+    ]
+    inventory.version_exists.side_effect = [False, True]
+
+    logger_name = "python_instrumentation_watcher.instrumentation_sync"
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    assert "new: 1, skipped: 1, failed: 1, disagreements: 0" in caplog.text
+
+
+def test_sync_logs_the_parse_failure_with_the_package_name(collaborators, inventory, caplog):
+    _, scanner, parser_cls = collaborators
+    scanner.discover_packages.return_value = [package("opentelemetry-instrumentation-broken")]
+    parser_cls.return_value.parse.side_effect = ValueError("malformed pyproject.toml")
+
+    logger_name = "python_instrumentation_watcher.instrumentation_sync"
+    with caplog.at_level(logging.ERROR, logger=logger_name):
+        InstrumentationSync(repo_path=REPO_PATH, inventory_manager=inventory).sync()
+
+    assert "opentelemetry-instrumentation-broken" in caplog.text

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_inventory_manager.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_inventory_manager.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for InventoryManager."""
+
+import yaml
+from python_instrumentation_watcher.inventory_manager import InventoryManager
+
+
+def test_save_and_version_exists(tmp_path):
+    manager = InventoryManager(registry_dir=str(tmp_path))
+    data = {"name": "opentelemetry-instrumentation-flask", "version": "0.48b0"}
+
+    assert not manager.version_exists("opentelemetry-instrumentation-flask", "0.48b0")
+
+    manager.save("opentelemetry-instrumentation-flask", "0.48b0", data)
+
+    assert manager.version_exists("opentelemetry-instrumentation-flask", "0.48b0")
+
+
+def test_save_writes_valid_yaml(tmp_path):
+    manager = InventoryManager(registry_dir=str(tmp_path))
+    data = {
+        "name": "opentelemetry-instrumentation-flask",
+        "version": "0.48b0",
+        "instruments": [{"library": "flask", "version_range": ">=1.0", "source_key": "instruments"}],
+    }
+
+    manager.save("opentelemetry-instrumentation-flask", "0.48b0", data)
+
+    path = tmp_path / "opentelemetry-instrumentation-flask" / "v0.48b0.yaml"
+    assert path.exists()
+
+    loaded = yaml.safe_load(path.read_text())
+    assert loaded["name"] == "opentelemetry-instrumentation-flask"
+    assert loaded["instruments"][0]["library"] == "flask"
+
+
+def test_version_path_format(tmp_path):
+    manager = InventoryManager(registry_dir=str(tmp_path))
+    manager.save("opentelemetry-instrumentation-requests", "0.48b0", {"name": "test"})
+
+    expected = tmp_path / "opentelemetry-instrumentation-requests" / "v0.48b0.yaml"
+    assert expected.exists()

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_main.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_main.py
@@ -1,0 +1,148 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the Python instrumentation watcher entry point."""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from python_instrumentation_watcher.main import REGISTRY_DIR, configure_logging, main
+
+
+@pytest.fixture
+def wiring():
+    """Patch the three collaborators main() wires together."""
+    with (
+        patch("python_instrumentation_watcher.main.PythonContribRepositoryManager") as repo_manager,
+        patch("python_instrumentation_watcher.main.InventoryManager") as inventory_manager,
+        patch("python_instrumentation_watcher.main.InstrumentationSync") as sync,
+    ):
+        repo_manager.return_value.setup.return_value = Path("/repos/opentelemetry-python-contrib")
+        sync.return_value.sync.return_value = {"new": [], "skipped": [], "failed": [], "disagreements": []}
+        yield repo_manager, inventory_manager, sync
+
+
+def test_main_returns_none_on_success(wiring, monkeypatch):
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    assert main() is None
+
+
+def test_main_defaults_base_dir_to_tmp_repos(wiring, monkeypatch):
+    repo_manager, _, _ = wiring
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    repo_manager.assert_called_once_with(base_dir="tmp_repos")
+
+
+def test_main_honors_repos_dir_env_var(wiring, monkeypatch):
+    repo_manager, _, _ = wiring
+    monkeypatch.setenv("PYTHON_CONTRIB_REPOS_DIR", "custom_repos")
+
+    main()
+
+    repo_manager.assert_called_once_with(base_dir="custom_repos")
+
+
+def test_main_builds_inventory_manager_with_registry_dir(wiring, monkeypatch):
+    _, inventory_manager, _ = wiring
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    inventory_manager.assert_called_once_with(registry_dir=REGISTRY_DIR)
+
+
+def test_main_passes_resolved_repo_path_and_inventory_to_sync(wiring, monkeypatch):
+    repo_manager, inventory_manager, sync = wiring
+    repo_manager.return_value.setup.return_value = Path("/repos/resolved-python-contrib")
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    sync.assert_called_once_with(
+        repo_path=Path("/repos/resolved-python-contrib"),
+        inventory_manager=inventory_manager.return_value,
+    )
+
+
+def test_main_runs_the_sync(wiring, monkeypatch):
+    _, _, sync = wiring
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    main()
+
+    sync.return_value.sync.assert_called_once_with()
+
+
+def test_main_logs_the_sync_summary(wiring, monkeypatch, caplog):
+    _, _, sync = wiring
+    sync.return_value.sync.return_value = {
+        "new": ["opentelemetry-instrumentation-flask@0.48b0"],
+        "skipped": [],
+        "failed": [],
+        "disagreements": [],
+    }
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    with caplog.at_level(logging.INFO, logger="python_instrumentation_watcher.main"):
+        main()
+
+    assert "opentelemetry-instrumentation-flask@0.48b0" in caplog.text
+
+
+def test_main_propagates_repository_setup_failure(wiring, monkeypatch):
+    repo_manager, _, sync = wiring
+    repo_manager.return_value.setup.side_effect = RuntimeError("Failed to clone repository")
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="Failed to clone"):
+        main()
+
+    sync.return_value.sync.assert_not_called()
+
+
+def test_main_propagates_sync_failure(wiring, monkeypatch):
+    _, _, sync = wiring
+    sync.return_value.sync.side_effect = RuntimeError("sync exploded")
+    monkeypatch.delenv("PYTHON_CONTRIB_REPOS_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="sync exploded"):
+        main()
+
+
+def test_registry_dir_points_at_python_registry():
+    assert REGISTRY_DIR == "ecosystem-registry/python"
+
+
+def test_configure_logging_sets_info_level():
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    original_handlers = root_logger.handlers[:]
+    try:
+        root_logger.handlers.clear()
+        root_logger.setLevel(logging.NOTSET)
+
+        configure_logging()
+
+        assert root_logger.level == logging.INFO
+        assert root_logger.handlers
+    finally:
+        root_logger.handlers[:] = original_handlers
+        root_logger.setLevel(original_level)

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_package_parser.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_package_parser.py
@@ -472,6 +472,38 @@ def test_has_metadata_disagreement_true_when_version_ranges_differ(repo, pkg_dir
     assert parser.has_metadata_disagreement() is True
 
 
+def test_has_metadata_disagreement_false_for_httpx_botocore_style_empty_instruments(repo, pkg_dir):
+    """Exact scenario from the PR #1099 review: real upstream packages like httpx and
+    botocore define `_instruments = ()` and put their actual requirements in
+    `_instruments_any`. Before the fix, comparing only `_instruments` against the
+    combined pyproject set compared an empty set against a populated one and always
+    falsely reported a disagreement for these packages.
+    """
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-httpx"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments-any = ["httpx >= 0.18.0"]
+        """,
+    )
+    write_package_py(
+        pkg_dir,
+        """\
+        _instruments = ()
+        _instruments_any = ("httpx >= 0.18.0",)
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
 def test_has_metadata_disagreement_true_when_library_sets_differ(repo, pkg_dir):
     write_pyproject(pkg_dir, BASIC_PYPROJECT)
     write_package_py(pkg_dir, '_instruments = ("flask >= 1.0", "werkzeug >= 1.0")\n')
@@ -480,6 +512,197 @@ def test_has_metadata_disagreement_true_when_library_sets_differ(repo, pkg_dir):
     parser.parse()
 
     assert parser.has_metadata_disagreement() is True
+
+
+def test_has_metadata_disagreement_false_when_package_py_only_mirrors_instruments_key(repo, pkg_dir):
+    """Regression test: package.py legitimately doesn't have to mirror `instruments-any`.
+
+    pyproject.toml declares both `instruments` and `instruments-any`; package.py only
+    defines `_instruments` (matching `instruments`). Before the fix, `_instruments` was
+    compared against the *combined* pyproject set, so this agreeing-but-partial package.py
+    was always falsely flagged as disagreeing.
+    """
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-botocore"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["botocore >= 1.0"]
+        instruments-any = ["boto3 >= 1.0", "aiobotocore >= 1.0"]
+        """,
+    )
+    write_package_py(pkg_dir, '_instruments = ("botocore >= 1.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_true_when_instruments_any_field_disagrees(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-botocore"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["botocore >= 1.0"]
+        instruments-any = ["boto3 >= 1.0"]
+        """,
+    )
+    write_package_py(
+        pkg_dir,
+        """\
+        _instruments = ("botocore >= 1.0",)
+        _instruments_any = ("boto3 >= 2.0",)
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_has_metadata_disagreement_false_when_instruments_and_instruments_any_both_agree(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-botocore"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["botocore >= 1.0"]
+        instruments-any = ["boto3 >= 1.0"]
+        """,
+    )
+    write_package_py(
+        pkg_dir,
+        """\
+        _instruments = ("botocore >= 1.0",)
+        _instruments_any = ("boto3 >= 1.0",)
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_true_when_package_py_declares_instruments_pyproject_lacks(repo, pkg_dir):
+    """package.py explicitly declaring instruments that pyproject.toml doesn't have at all
+    (under that specific key) is a real, reportable disagreement — not silent."""
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-botocore"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["botocore >= 1.0"]
+        """,
+    )
+    write_package_py(pkg_dir, '_instruments_any = ("boto3 >= 1.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_parse_package_py_handles_annotated_instruments_assignment(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments: tuple[str, ...] = ("flask >= 1.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    # Would stay a false negative if AnnAssign weren't handled: the field would read as
+    # "not defined" and no disagreement would ever be reported for this package.py.
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_true_with_annotated_assignment_mismatch(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments: tuple[str, ...] = ("flask >= 9.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_parse_package_py_handles_empty_tuple_call_annotated_assignment(repo, pkg_dir):
+    """`tuple()` is a Call node, not a literal — ast.literal_eval alone can't read it."""
+    write_pyproject(pkg_dir, '[project]\nname = "opentelemetry-instrumentation-flask"\nversion = "1.0.0"\n')
+    write_package_py(pkg_dir, "_instruments: tuple[str, ...] = tuple()\n")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    # package.py explicitly declares zero instruments, and pyproject.toml agrees (none
+    # declared either) — not a disagreement.
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_true_when_package_py_empty_tuple_call_but_pyproject_has_entries(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, "_instruments: tuple[str, ...] = tuple()\n")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_parse_package_py_handles_annotated_scalar_assignment(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(
+        pkg_dir,
+        """\
+        _semconv_status: str = "stable"
+        _supports_metrics: bool = True
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["semantic_convention_status"] == "stable"
+    assert result["supports_metrics"] is True
+
+
+def test_parse_package_py_annotation_only_statement_without_value_is_ignored(repo, pkg_dir):
+    """`_instruments: tuple[str, ...]` with no assigned value must not be evaluated as None."""
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, "_instruments: tuple[str, ...]\n")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    # No value was ever assigned, so this is indistinguishable from "not defined".
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_parse_package_py_unrecognized_call_is_not_evaluated(repo, pkg_dir):
+    """Only the explicit empty-container allowlist is accepted; other calls are skipped, not executed."""
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, "_instruments = some_function_call()\n")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    # some_function_call() is neither a literal nor a recognized empty-container call, so
+    # the field is left unset (as if not defined) rather than raising or being invoked.
+    assert parser.has_metadata_disagreement() is False
 
 
 def test_parse_uses_first_package_py_when_multiple_found(repo, pkg_dir):

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_package_parser.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_package_parser.py
@@ -1,0 +1,494 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for PackageParser."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from python_instrumentation_watcher.package_parser import PackageParser
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "instrumentation").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def pkg_dir(repo):
+    pkg = repo / "instrumentation" / "opentelemetry-instrumentation-flask"
+    pkg.mkdir()
+    return pkg
+
+
+def write_pyproject(pkg_dir: Path, content: str) -> None:
+    (pkg_dir / "pyproject.toml").write_text(textwrap.dedent(content))
+
+
+def write_package_py(
+    pkg_dir: Path,
+    content: str,
+    rel_path: str = "src/opentelemetry/instrumentation/flask/package.py",
+) -> None:
+    path = pkg_dir / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content))
+
+
+BASIC_PYPROJECT = """\
+    [project]
+    name = "opentelemetry-instrumentation-flask"
+    version = "0.48b0"
+    description = "OpenTelemetry Flask instrumentation"
+    requires-python = ">=3.9"
+
+    [project.urls]
+    Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask"
+
+    [project.optional-dependencies]
+    instruments = ["flask >= 1.0"]
+
+    [project.entry-points.opentelemetry_instrumentor]
+    flask = "opentelemetry.instrumentation.flask:FlaskInstrumentor"
+    """
+
+
+def test_parse_basic_fields(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["name"] == "opentelemetry-instrumentation-flask"
+    assert result["version"] == "0.48b0"
+    assert result["description"] == "OpenTelemetry Flask instrumentation"
+    assert result["requires_python"] == ">=3.9"
+    assert result["repository"] == "open-telemetry/opentelemetry-python-contrib"
+    assert result["source_path"] == "instrumentation/opentelemetry-instrumentation-flask"
+    assert result["homepage"] == (
+        "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/"
+        "instrumentation/opentelemetry-instrumentation-flask"
+    )
+    assert result["instruments"] == [{"library": "flask", "version_range": ">= 1.0", "source_key": "instruments"}]
+    assert result["entry_points"] == [
+        {"name": "flask", "value": "opentelemetry.instrumentation.flask:FlaskInstrumentor"}
+    ]
+    assert result["semantic_convention_status"] is None
+    assert result["supports_metrics"] is None
+
+
+def test_parse_returns_none_on_missing_pyproject_toml(repo, pkg_dir):
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    assert parser.parse() is None
+
+
+def test_parse_returns_none_on_malformed_toml(repo, pkg_dir):
+    (pkg_dir / "pyproject.toml").write_text("this is not [valid toml")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    assert parser.parse() is None
+
+
+def test_parse_returns_none_when_project_table_missing(repo, pkg_dir):
+    write_pyproject(pkg_dir, '[build-system]\nrequires = ["hatchling"]\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    assert parser.parse() is None
+
+
+def test_parse_returns_none_when_name_missing(repo, pkg_dir):
+    write_pyproject(pkg_dir, '[project]\ndescription = "no name"\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    assert parser.parse() is None
+
+
+def test_parse_defaults_missing_optional_fields(repo, pkg_dir):
+    write_pyproject(pkg_dir, '[project]\nname = "opentelemetry-instrumentation-flask"\nversion = "1.0.0"\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["description"] == ""
+    assert result["requires_python"] == ""
+    assert result["homepage"] is None
+    assert result["instruments"] == []
+    assert result["entry_points"] == []
+
+
+def test_parse_resolves_dynamic_version_from_hatch_path(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        dynamic = ["version"]
+
+        [tool.hatch.version]
+        path = "src/opentelemetry/instrumentation/flask/version.py"
+        """,
+    )
+    version_file = pkg_dir / "src/opentelemetry/instrumentation/flask/version.py"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "0.58b0.dev"\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["version"] == "0.58b0.dev"
+
+
+def test_parse_dynamic_version_missing_hatch_path_yields_empty_version(repo, pkg_dir):
+    write_pyproject(pkg_dir, '[project]\nname = "opentelemetry-instrumentation-flask"\ndynamic = ["version"]\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["version"] == ""
+
+
+def test_parse_dynamic_version_missing_file_yields_empty_version(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        dynamic = ["version"]
+
+        [tool.hatch.version]
+        path = "src/opentelemetry/instrumentation/flask/version.py"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["version"] == ""
+
+
+def test_parse_static_version_takes_priority_over_dynamic(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "2.0.0"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["version"] == "2.0.0"
+
+
+def test_parse_instruments_any_preserves_source_key(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-botocore"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments-any = ["boto3 >= 1.0", "botocore >= 1.0"]
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["instruments"] == [
+        {"library": "boto3", "version_range": ">= 1.0", "source_key": "instruments-any"},
+        {"library": "botocore", "version_range": ">= 1.0", "source_key": "instruments-any"},
+    ]
+
+
+def test_parse_instruments_sorted_deterministically(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-multi"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["zeta >= 1.0", "alpha >= 1.0"]
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    libraries = [e["library"] for e in result["instruments"]]
+    assert libraries == sorted(libraries)
+
+
+def test_parse_instruments_preserves_raw_version_range_text(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["flask>=1.0,<3.0"]
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    # Not renormalized: the exact spacing/format from the source is preserved.
+    assert result["instruments"] == [{"library": "flask", "version_range": ">=1.0,<3.0", "source_key": "instruments"}]
+
+
+def test_parse_instruments_handles_no_version_constraint(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["flask"]
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["instruments"] == [{"library": "flask", "version_range": "", "source_key": "instruments"}]
+
+
+def test_parse_instruments_skips_unparseable_entry(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "1.0.0"
+
+        [project.optional-dependencies]
+        instruments = ["", "flask >= 1.0"]
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert len(result["instruments"]) == 1
+    assert result["instruments"][0]["library"] == "flask"
+
+
+def test_parse_handles_non_list_optional_dependencies(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "1.0.0"
+        optional-dependencies = "not-a-table"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["instruments"] == []
+
+
+def test_parse_entry_points_sorted_by_name(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-multi"
+        version = "1.0.0"
+
+        [project.entry-points.opentelemetry_instrumentor]
+        zeta = "pkg.zeta:ZetaInstrumentor"
+        alpha = "pkg.alpha:AlphaInstrumentor"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    names = [e["name"] for e in result["entry_points"]]
+    assert names == ["alpha", "zeta"]
+
+
+def test_parse_homepage_case_insensitive_key(repo, pkg_dir):
+    write_pyproject(
+        pkg_dir,
+        """\
+        [project]
+        name = "opentelemetry-instrumentation-flask"
+        version = "1.0.0"
+
+        [project.urls]
+        homepage = "https://example.com/flask"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["homepage"] == "https://example.com/flask"
+
+
+def test_parse_package_py_fields(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(
+        pkg_dir,
+        """\
+        _instruments = ("flask >= 1.0",)
+        _supports_metrics = True
+        _semconv_status = "stable"
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["semantic_convention_status"] == "stable"
+    assert result["supports_metrics"] is True
+
+
+def test_parse_package_py_missing_yields_none_fields(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["semantic_convention_status"] is None
+    assert result["supports_metrics"] is None
+
+
+def test_parse_package_py_skips_test_directories(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(
+        pkg_dir,
+        '_semconv_status = "should-not-be-used"\n',
+        rel_path="tests/package.py",
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result["semantic_convention_status"] is None
+
+
+def test_parse_package_py_ignores_non_literal_assignment(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(
+        pkg_dir,
+        """\
+        _semconv_status = some_function_call()
+        _supports_metrics = True
+        """,
+    )
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    # Unevaluatable expression is skipped rather than raising or executing code.
+    assert result["semantic_convention_status"] is None
+    assert result["supports_metrics"] is True
+
+
+def test_parse_package_py_malformed_syntax_does_not_raise(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, "def broken(:\n")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    assert result is not None
+    assert result["semantic_convention_status"] is None
+
+
+def test_has_metadata_disagreement_false_when_package_py_absent(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_false_when_sources_agree(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments = ("flask >= 1.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_ignores_whitespace_only_differences(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments = ("flask>=1.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is False
+
+
+def test_has_metadata_disagreement_true_when_version_ranges_differ(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments = ("flask >= 2.0",)\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_has_metadata_disagreement_true_when_library_sets_differ(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_instruments = ("flask >= 1.0", "werkzeug >= 1.0")\n')
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    parser.parse()
+
+    assert parser.has_metadata_disagreement() is True
+
+
+def test_parse_uses_first_package_py_when_multiple_found(repo, pkg_dir):
+    write_pyproject(pkg_dir, BASIC_PYPROJECT)
+    write_package_py(pkg_dir, '_semconv_status = "stable"\n', rel_path="src/a/package.py")
+    write_package_py(pkg_dir, '_semconv_status = "experimental"\n', rel_path="src/b/package.py")
+
+    parser = PackageParser(package_path=pkg_dir, repo_path=repo)
+    result = parser.parse()
+
+    # Deterministic: sorted candidate paths, first one wins.
+    assert result["semantic_convention_status"] == "stable"

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_package_scanner.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_package_scanner.py
@@ -1,0 +1,100 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for PackageScanner."""
+
+from pathlib import Path
+
+import pytest
+from python_instrumentation_watcher.package_scanner import PackageScanner
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Create a minimal python-contrib-like repo structure."""
+    (tmp_path / "instrumentation").mkdir()
+    return tmp_path
+
+
+def make_package(repo: Path, name: str, under: str = "instrumentation", has_pyproject: bool = True) -> Path:
+    pkg_dir = repo / under / name
+    pkg_dir.mkdir(parents=True)
+    if has_pyproject:
+        (pkg_dir / "pyproject.toml").write_text('[project]\nname = "%s"\n' % name)
+    return pkg_dir
+
+
+def test_discover_packages_finds_instrumentation_dirs(repo):
+    make_package(repo, "opentelemetry-instrumentation-flask")
+    make_package(repo, "opentelemetry-instrumentation-requests")
+
+    scanner = PackageScanner(repo)
+    found = scanner.discover_packages()
+
+    names = [p.name for p in found]
+    assert "opentelemetry-instrumentation-flask" in names
+    assert "opentelemetry-instrumentation-requests" in names
+
+
+def test_discover_packages_skips_non_prefixed_dirs(repo):
+    make_package(repo, "opentelemetry-instrumentation-flask")
+    make_package(repo, "some-other-tool")
+
+    scanner = PackageScanner(repo)
+    found = scanner.discover_packages()
+
+    names = [p.name for p in found]
+    assert "some-other-tool" not in names
+    assert "opentelemetry-instrumentation-flask" in names
+
+
+def test_discover_packages_skips_dirs_without_pyproject_toml(repo):
+    make_package(repo, "opentelemetry-instrumentation-broken", has_pyproject=False)
+    make_package(repo, "opentelemetry-instrumentation-flask")
+
+    scanner = PackageScanner(repo)
+    found = scanner.discover_packages()
+
+    names = [p.name for p in found]
+    assert "opentelemetry-instrumentation-broken" not in names
+    assert "opentelemetry-instrumentation-flask" in names
+
+
+def test_discover_packages_ignores_instrumentation_genai(repo):
+    (repo / "instrumentation-genai").mkdir()
+    make_package(repo, "opentelemetry-instrumentation-genai-openai", under="instrumentation-genai")
+    make_package(repo, "opentelemetry-instrumentation-flask")
+
+    scanner = PackageScanner(repo)
+    found = scanner.discover_packages()
+
+    names = [p.name for p in found]
+    assert "opentelemetry-instrumentation-genai-openai" not in names
+    assert "opentelemetry-instrumentation-flask" in names
+
+
+def test_discover_packages_returns_empty_when_instrumentation_dir_missing(tmp_path):
+    scanner = PackageScanner(tmp_path)
+    assert scanner.discover_packages() == []
+
+
+def test_discover_packages_ignores_non_directories(repo):
+    (repo / "instrumentation" / "README.md").write_text("not a package")
+    make_package(repo, "opentelemetry-instrumentation-flask")
+
+    scanner = PackageScanner(repo)
+    found = scanner.discover_packages()
+
+    assert [p.name for p in found] == ["opentelemetry-instrumentation-flask"]

--- a/ecosystem-automation/python-instrumentation-watcher/tests/test_repository_manager.py
+++ b/ecosystem-automation/python-instrumentation-watcher/tests/test_repository_manager.py
@@ -1,0 +1,134 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for PythonContribRepositoryManager."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from python_instrumentation_watcher.repository_manager import (
+    REPO_ENV_VAR,
+    REPO_NAME,
+    REPO_URL,
+    PythonContribRepositoryManager,
+)
+from watcher_common.repository_manager import _GIT
+
+
+def test_init_defaults_to_tmp_repos():
+    manager = PythonContribRepositoryManager()
+
+    assert manager.base_dir == Path("tmp_repos")
+
+
+def test_init_honors_custom_base_dir(tmp_path):
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+
+    assert manager.base_dir == tmp_path
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_uses_env_var_path_when_it_exists(mock_run, tmp_path, monkeypatch):
+    existing_repo = tmp_path / "local-python-contrib"
+    existing_repo.mkdir()
+    monkeypatch.setenv(REPO_ENV_VAR, str(existing_repo))
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+
+    assert manager.setup() == existing_repo
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_does_not_touch_git_when_env_var_is_used(mock_run, tmp_path, monkeypatch):
+    existing_repo = tmp_path / "local-python-contrib"
+    existing_repo.mkdir()
+    monkeypatch.setenv(REPO_ENV_VAR, str(existing_repo))
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+    manager.setup()
+
+    mock_run.assert_not_called()
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_falls_back_to_clone_when_env_var_path_is_missing(mock_run, tmp_path, monkeypatch):
+    monkeypatch.setenv(REPO_ENV_VAR, str(tmp_path / "does-not-exist"))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == tmp_path / REPO_NAME
+    assert mock_run.call_args[0][0] == [_GIT, "clone", REPO_URL, str(tmp_path / REPO_NAME)]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_clones_when_repo_not_present(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == tmp_path / REPO_NAME
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0] == [_GIT, "clone", REPO_URL, str(tmp_path / REPO_NAME)]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_pulls_when_repo_already_present(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    repo_path = tmp_path / REPO_NAME
+    repo_path.mkdir()
+    mock_run.return_value = MagicMock(returncode=0)
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+    path = manager.setup()
+
+    assert path == repo_path
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0][0][0] == [_GIT, "checkout", "main"]
+    assert mock_run.call_args_list[1][0][0] == [_GIT, "pull"]
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_raises_when_clone_fails(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    mock_run.side_effect = subprocess.CalledProcessError(1, "git clone", stderr="Clone failed")
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="Failed to clone"):
+        manager.setup()
+
+
+@patch("watcher_common.repository_manager.subprocess.run")
+def test_setup_raises_when_pull_fails(mock_run, tmp_path, monkeypatch):
+    monkeypatch.delenv(REPO_ENV_VAR, raising=False)
+    (tmp_path / REPO_NAME).mkdir()
+    mock_run.side_effect = subprocess.CalledProcessError(1, "git pull", stderr="Pull failed")
+
+    manager = PythonContribRepositoryManager(base_dir=str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="Failed to pull"):
+        manager.setup()
+
+
+def test_repo_constants_point_at_python_contrib():
+    assert REPO_NAME == "opentelemetry-python-contrib"
+    assert REPO_URL.endswith("opentelemetry-python-contrib.git")
+    assert REPO_ENV_VAR == "PYTHON_CONTRIB_REPO_PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "explorer-db-builder",
     "v1-registry-sync",
     "js-instrumentation-watcher",
+    "python-instrumentation-watcher",
 ]
 
 [tool.uv.workspace]
@@ -31,6 +32,7 @@ dotnet-instrumentation-watcher = { workspace = true }
 explorer-db-builder = { workspace = true }
 v1-registry-sync = { workspace = true }
 js-instrumentation-watcher = { workspace = true }
+python-instrumentation-watcher = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ members = [
     "java-instrumentation-watcher",
     "js-instrumentation-watcher",
     "opentelemetry-ecosystem-explorer",
+    "python-instrumentation-watcher",
     "v1-registry-sync",
     "watcher-common",
 ]
@@ -533,6 +534,7 @@ dependencies = [
     { name = "explorer-db-builder" },
     { name = "java-instrumentation-watcher" },
     { name = "js-instrumentation-watcher" },
+    { name = "python-instrumentation-watcher" },
     { name = "v1-registry-sync" },
 ]
 
@@ -552,6 +554,7 @@ requires-dist = [
     { name = "explorer-db-builder", editable = "ecosystem-automation/explorer-db-builder" },
     { name = "java-instrumentation-watcher", editable = "ecosystem-automation/java-instrumentation-watcher" },
     { name = "js-instrumentation-watcher", editable = "ecosystem-automation/js-instrumentation-watcher" },
+    { name = "python-instrumentation-watcher", editable = "ecosystem-automation/python-instrumentation-watcher" },
     { name = "v1-registry-sync", editable = "ecosystem-automation/v1-registry-sync" },
 ]
 
@@ -656,6 +659,30 @@ sdist = { url = "https://files.pythonhosted.org/packages/91/96/0f93e27c9f60a6508
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/5e/21abf578182fb15006a57faf3711a1e659e29d600d19b6e557eae908c81d/python_discovery-1.6.0-py3-none-any.whl", hash = "sha256:d4e244cf17b8b29819ed78003d55fbacf86eda23425b075454fff9271b79377a", size = 38451, upload-time = "2026-08-28T17:30:01.236Z" },
 ]
+
+[[package]]
+name = "python-instrumentation-watcher"
+version = "0.1.0"
+source = { editable = "ecosystem-automation/python-instrumentation-watcher" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "watcher-common" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "watcher-common", editable = "ecosystem-automation/watcher-common" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "pyyaml"


### PR DESCRIPTION
## What changed

Implements the first part of #1088 by adding the Python instrumentation watcher and initial registry generation for the Ecosystem Explorer!

This establishes an automated path from `opentelemetry-python-contrib` to the Python instrumentation registry, following the existing watcher architecture used by other ecosystems!

### Changes

- Add a Python instrumentation watcher under `ecosystem-automation`
- Add repository management and package discovery for `opentelemetry-python-contrib`
- Parse instrumentation metadata from `pyproject.toml` and `package.py`
- Resolve package and release versions using the hybrid versioning model defined in #1064
- Generate per-package-version registry entries under `ecosystem-registry/python/`
- Preserve the relevant upstream metadata required by the Python registry schema
- Detect and report metadata-source disagreements where applicable
- Integrate with the repository's existing watcher and workspace infrastructure
- Add unit/fixture tests covering package discovery, metadata parsing, version resolution, registry generation, disagreement handling, and sync behavior

## Why

This is the implementation phase of #1088, following the metadata audit in #1041 and registry schema design in #1064! The watcher provides the automated path needed to keep Python instrumentation metadata synchronized with the Ecosystem Explorer registry...!

## How it was tested

- Full repository test suite passes
- Ruff and formatting checks pass
- Watcher-specific tests pass
- End-to-end smoke testing was performed against a synthetic `opentelemetry-python-contrib` repository

## Is this a breaking change?

No

## Special notes for your reviewer

This PR intentionally covers only the watcher and initial registry integration. CI/nightly automation, DB builder integration, and related documentation updates are left for the subsequent parts of #1088